### PR TITLE
Fix duplicate action registration

### DIFF
--- a/src/composables/useSoundRoomActions.js
+++ b/src/composables/useSoundRoomActions.js
@@ -2,7 +2,29 @@ import downloadAudio from '@/utils/downloadAudio'
 import { useRoomStore } from '@/stores/useRoomStore'
 import { storeToRefs } from 'pinia'
 
-export function registerCanvasActions() {
+let actionsRegistered = false
+
+export function registerSoundRoomActions() {
+  if (actionsRegistered) return
+  registerCanvasActions()
+  registerDraggableActions()
+  actionsRegistered = true
+}
+
+export function unregisterSoundRoomActions() {
+  if (!actionsRegistered) return
+  const { actionManager } = storeToRefs(useRoomStore())
+  actionManager.value.unregisterActionHandlers([
+    'add_canvas_sound_source',
+    'delete_canvas_sound_source',
+    'move_canvas_sound_source',
+    'delete_draggable_sound_source',
+    'add_draggable_sound_source'
+  ])
+  actionsRegistered = false
+}
+
+function registerCanvasActions() {
   const { audioEngine,  actionManager, listener, soundLibrarySources} = storeToRefs(useRoomStore())
   const moveSoundSource = (src, coords) => {
     src.instance.state.x = coords.x
@@ -48,7 +70,7 @@ const maxLibSourcesReached = function(soundLibrarySources){
   }
   return false
 }
-export function registerDraggableActions() {
+function registerDraggableActions() {
   const { audioEngine, actionManager, soundLibrarySources } = storeToRefs(useRoomStore())
 
   const deleteDraggableSoundSource = (payload) => {
@@ -119,3 +141,4 @@ export function registerDraggableActions() {
     payload => deleteDraggableSoundSource(payload),
   )
 }
+

--- a/src/lib/ActionManager.js
+++ b/src/lib/ActionManager.js
@@ -23,6 +23,13 @@ export default class ActionManager {
     this._actionMap[actionName] = { doAction, undoAction }
   }
 
+  unregisterActionHandlers(actionNames) {
+    if (!Array.isArray(actionNames)) actionNames = [actionNames]
+    for (const name of actionNames) {
+      delete this._actionMap[name]
+    }
+  }
+
   async doAction(actionName, payload = null) {
     const action = this._actionMap[actionName]
     if (!action) {

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -92,7 +92,7 @@ import { useKeyboardControls } from '@/composables/useKeyboardControls'
 import { useDragDropAudio } from '@/composables/useDragDropAudio'
 import { useSelectedSource } from '@/composables/useSelectedSource'
 import { useContextMenuLogic } from '@/composables/useContextMenuLogic'
-import { registerCanvasActions, registerDraggableActions, setMaxLibSources } from '@/composables/useSoundRoomActions'
+import { registerSoundRoomActions, unregisterSoundRoomActions, setMaxLibSources } from '@/composables/useSoundRoomActions'
 import { useSaveAndLoadRoom } from '@/composables/useSaveAndLoadRoom';
 import { storeToRefs } from 'pinia'
 
@@ -137,12 +137,11 @@ const { onKeyDown, onKeyUp } = useKeyboardControls({selectedIndex, selectedSourc
 
 const { saveRoom, isLoadingRoom, isSavingRoom, loadRoomLocal } = useSaveAndLoadRoom()
 
-registerCanvasActions()
-registerDraggableActions()
 setMaxLibSources(MAX_LIB_SOURCES)
 
 const showWelcomeOverlay = ref(false)
 onBeforeMount(() => {
+  registerSoundRoomActions()
   store.clearSoundLibrarySources() // Clear any previous sound library sources
   if (sessionStorage.getItem('justLoggedIn') === 'true') {
     sessionStorage.removeItem('justLoggedIn')
@@ -159,6 +158,7 @@ onBeforeMount(() => {
 })
 
 onUnmounted(() => {
+  unregisterSoundRoomActions()
   audioEngine.value.dispose()
 })
 </script>


### PR DESCRIPTION
## Summary
- avoid duplicate action handler registration by tracking a flag
- expose unregister function for sound-room actions
- call register/unregister in `SoundRoom.vue`
- add unregister support in `ActionManager`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686381d85fb0832fb74a93cbdb925928