### PR TITLE
Integrate AudioCacheManager

### DIFF
--- a/src/components/SoundRoom/SidebarLeft/LibrarySource.vue
+++ b/src/components/SoundRoom/SidebarLeft/LibrarySource.vue
@@ -7,13 +7,15 @@
   </li>
 </template>
 <script setup>
-import { onUnmounted } from 'vue';
+import { onUnmounted } from 'vue'
+import { useRoomStore } from '@/stores/useRoomStore'
 
 const props = defineProps({
   librarySource: Object
 })
 
 onUnmounted(() => {
-  URL.revokeObjectURL(props.librarySource.audioPath)
+  const store = useRoomStore()
+  store.audioCacheManager.remove(props.librarySource.libraryId)
 })
 </script>

--- a/src/components/ui/modals/SoundLibrary/SoundPreviewCircle.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundPreviewCircle.vue
@@ -41,6 +41,7 @@
 <script setup>
 import { ref, onUnmounted, computed, watch, onMounted, nextTick } from 'vue'
 import downloadAudio from '@/utils/downloadAudio'
+import { useRoomStore } from '@/stores/useRoomStore'
 
 
 // Cache the downloaded preview locally to avoid redundant network calls
@@ -74,7 +75,13 @@ async function emitAudio() {
   if (cachedPreview) {
     blobUrl = cachedPreview.blobUrl
   } else {
-    ({ blobUrl } = await downloadAudio(props.soundData.bucket, props.soundData.path, false))
+    ;({ blobUrl } = await downloadAudio(
+      props.soundData.bucket,
+      props.soundData.path,
+      false,
+      null,
+      props.soundData.id
+    ))
     cachedPreview = { blobUrl, audio: null }
   }
   hasBeenPromoted.value = true
@@ -148,7 +155,13 @@ async function togglePlay() {
         cachedPreview.audio = audio
       }
     } else {
-      ({ blobUrl, audio } = await downloadAudio(props.soundData.bucket, props.soundData.path, true, stopPlayback))
+      ;({ blobUrl, audio } = await downloadAudio(
+        props.soundData.bucket,
+        props.soundData.path,
+        true,
+        stopPlayback,
+        props.soundData.id
+      ))
       cachedPreview = { blobUrl, audio }
     }
     audio.currentTime = 0
@@ -191,7 +204,8 @@ function stopPlayback() {
 onUnmounted(() => {
   stopPlayback()
   if (!hasBeenPromoted.value && cachedPreview) {
-    URL.revokeObjectURL(cachedPreview.blobUrl)
+    const store = useRoomStore()
+    store.audioCacheManager.remove(props.soundData.id)
     cachedPreview = null
   }
 })

--- a/src/composables/useSoundRoomActions.js
+++ b/src/composables/useSoundRoomActions.js
@@ -106,14 +106,21 @@ function registerDraggableActions() {
       }
 
 
-      URL.revokeObjectURL(originalSrc.audioPath)
+      const store = useRoomStore()
+      store.audioCacheManager.remove(originalSrc.libraryId)
     }
 
   
   const addDraggableSoundSource = async (payload) => {
     if (maxLibSourcesReached(soundLibrarySources)) return;
     // download blob and re-instate draggable source
-    const { blobUrl } = await downloadAudio(payload.src.bucket, payload.src.path, false)
+    const { blobUrl } = await downloadAudio(
+      payload.src.bucket,
+      payload.src.path,
+      false,
+      null,
+      payload.src.libraryId
+    )
     payload.src.audioPath = blobUrl
     const exists = soundLibrarySources.value.find(s => s.libraryId === payload.src.libraryId)
     if (!exists) {

--- a/src/stores/useRoomStore.js
+++ b/src/stores/useRoomStore.js
@@ -39,6 +39,9 @@ export const useRoomStore = defineStore('room', () => {
   }
 
   function clearSoundLibrarySources() {
+    soundLibrarySources.value.forEach(src => {
+      audioCacheManager.remove(src.libraryId)
+    })
     soundLibrarySources.value = []
   }
 

--- a/src/utils/downloadAudio.js
+++ b/src/utils/downloadAudio.js
@@ -1,39 +1,64 @@
 import { supabase } from '@/utils/supabase'
+import { useRoomStore } from '@/stores/useRoomStore'
 
-export default async function downloadAudio(bucket, path, populateAudio=true, stopPlayback=null) {
-  const { data: fileData, error: fileError } = await supabase
-    .storage
-    .from(bucket)
-    .download(path)
+export default async function downloadAudio(
+  bucket,
+  path,
+  populateAudio = true,
+  stopPlayback = null,
+  libraryId = null
+) {
+  const store = useRoomStore()
+  const cacheManager = store.audioCacheManager
+
+  const fileId = libraryId ?? `${bucket}/${path}`
+
+  const blobUrl = await cacheManager.getAudioURL(fileId, async () => {
+    const { data: fileData, error: fileError } = await supabase.storage
+      .from(bucket)
+      .download(path)
 
     if (fileError) {
       console.error(`Failed to download:`, fileError)
-      return
+      return new Blob()
     }
 
-    const blobUrl = URL.createObjectURL(fileData)
-    let audio = null
-    if (populateAudio) {
-      audio = new Audio(blobUrl)
-      audio.preload = 'auto'
+    return fileData
+  })
 
-      if (stopPlayback){
-        // Handle natural end of audio (shorter than preview window)
+  let audio = null
+  if (populateAudio) {
+    audio = new Audio(blobUrl)
+    audio.preload = 'auto'
+
+    if (stopPlayback) {
+      // Handle natural end of audio (shorter than preview window)
       audio.addEventListener('ended', () => {
         stopPlayback()
       })
-      }
-      
     }
+  }
 
-    return {blobUrl, audio}
+  return { blobUrl, audio }
 }
 
-export async function downloadMultipleAudio(sourcesList, populateAudio = false, stopPlayback = null) {
-  const results = await Promise.all(sourcesList.map(async (src) => {
-    const result = await downloadAudio(src.bucket, src.path, populateAudio, stopPlayback);
-    return result ? { id: src.id, audioPath: result.blobUrl } : null;
-  }));
+export async function downloadMultipleAudio(
+  sourcesList,
+  populateAudio = false,
+  stopPlayback = null
+) {
+  const results = await Promise.all(
+    sourcesList.map(async (src) => {
+      const result = await downloadAudio(
+        src.bucket,
+        src.path,
+        populateAudio,
+        stopPlayback,
+        src.id
+      )
+      return result ? { id: src.id, audioPath: result.blobUrl } : null
+    })
+  )
 
   return results.filter(Boolean); // filter out any failed downloads
 }


### PR DESCRIPTION
## Summary
- use `AudioCacheManager` for audio downloads
- remove explicit URL cleanup
- hook cache manager into draggable actions and library components
- clear cached sounds when clearing library

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863d46209a8832f960c49ae48fed58c