### PR TITLE
Cleanup SoundRoom audio cache on unmount

### DIFF
--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -160,5 +160,9 @@ onBeforeMount(() => {
 onUnmounted(() => {
   unregisterSoundRoomActions()
   audioEngine.value.dispose()
+  // Revoke object URLs to avoid memory leaks
+  store.audioCacheManager.clearMemoryCache()
+  // Uncomment to also wipe IndexedDB cache if long-term storage isn't desired
+  // void store.audioCacheManager.clearPersistentCache()
 })
 </script>


### PR DESCRIPTION
## Summary
- clear in-memory audio cache when leaving the SoundRoom page
- include optional line for clearing persistent cache

## Testing
- `npx playwright test` *(fails: 15 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6863dd3681c4832f922813f4dc28fdcd