### PR TITLE
Improve AudioCacheManager pruning

### DIFF
--- a/src/lib/AudioCacheManager.js
+++ b/src/lib/AudioCacheManager.js
@@ -58,6 +58,11 @@ export default class AudioCacheManager {
     const arrayBuffer = await blob.arrayBuffer()
     return await this.audioContext.decodeAudioData(arrayBuffer)
   }
+    // Add a blob to persistent cache and trigger pruning
+  async addBlob(fileId, blob) {
+    await set(fileId, blob)
+    await this._ensurePersistentLimit([fileId])
+  }
 
   async getOrFetchBlob(fileId, fetchFn) {
     let blob = await get(fileId)
@@ -70,6 +75,10 @@ export default class AudioCacheManager {
   }
 
   async _ensurePersistentLimit(extraKeep = []) {
+    if (this._maxPersistentEntries === 0) return // infinite allowed
+    const allKeys = await keys()
+    if (allKeys.length <= this._maxPersistentEntries) return
+
     const keepKeys = [...this.memoryCache.keys(), ...extraKeep]
     await this.prunePersistentCache({
       keep: keepKeys,

--- a/src/lib/AudioCacheManager.js
+++ b/src/lib/AudioCacheManager.js
@@ -1,10 +1,23 @@
 import { get, set, del, keys } from 'idb-keyval'
 
 export default class AudioCacheManager {
-  constructor(audioContext, maxEntries = 20) {
+  constructor(audioContext, maxEntries = 20, maxPersistentEntries = 100) {
     this.memoryCache = new Map()
     this.audioContext = audioContext || null
     this._maxEntries = maxEntries
+    this._maxPersistentEntries = maxPersistentEntries
+  }
+
+  setAudioContext(audioContext) {
+    if (this.audioContext) {
+      console.warn('AudioContext already set, ignoring new context')
+      return
+    }
+    this.audioContext = audioContext
+  }
+
+  setMaxPersistentEntries(max) {
+    this._maxPersistentEntries = max
   }
 
   // 🔁 Used by memory Map to evict old items
@@ -51,8 +64,17 @@ export default class AudioCacheManager {
     if (!blob) {
       blob = await fetchFn()
       await set(fileId, blob)
+      await this._ensurePersistentLimit([fileId])
     }
     return blob
+  }
+
+  async _ensurePersistentLimit(extraKeep = []) {
+    const keepKeys = [...this.memoryCache.keys(), ...extraKeep]
+    await this.prunePersistentCache({
+      keep: keepKeys,
+      maxCount: this._maxPersistentEntries,
+    })
   }
 
   clearMemoryCache() {


### PR DESCRIPTION
## Summary
- add persistent cache limit support to `AudioCacheManager`
- automatically prune IndexedDB entries whenever new audio files are cached
- expose `setAudioContext` and `setMaxPersistentEntries` helpers

## Testing
- `npx playwright test` *(fails: 15 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6864b9518d28832fa51b2011bdeb1f10