### PR TITLE
Refactor room store

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
@@ -53,11 +53,15 @@
 
 <script setup>
 import { ref, onBeforeUnmount } from 'vue';
+import { useListenerStore } from '@/stores/useListenerStore';
+import { useActionManagerStore } from '@/stores/useActionManagerStore';
 import { useRoomStore } from '@/stores/useRoomStore';
 import { storeToRefs } from 'pinia';
 
 
-const { listener, actionManager, room } = storeToRefs(useRoomStore())
+const { listener } = storeToRefs(useListenerStore())
+const { actionManager } = storeToRefs(useActionManagerStore())
+const { room } = storeToRefs(useRoomStore())
 
 let moveListenerPayload = null
 let initialMouseAngle = null

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -59,10 +59,12 @@ import ListenerNode from '@/components/SoundRoom/MainCanvasStage/ListenerNode.vu
 import SoundSourceLabel from '@/components/ui/text/SoundSourceLabel.vue'
 
 import { useRoomStore } from '@/stores/useRoomStore'
+import { useAudioEngineStore } from '@/stores/useAudioEngineStore'
 import { useCanvasStore } from '@/stores/useCanvasStore'
 import { storeToRefs } from 'pinia'
 
-const { room, audioEngine } = storeToRefs(useRoomStore())
+const { room } = storeToRefs(useRoomStore())
+const { audioEngine } = storeToRefs(useAudioEngineStore())
 
 const props = defineProps({
   handleDrop: Function,

--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -82,6 +82,7 @@
 <script setup>
 import { computed } from 'vue'
 import { useRoomStore } from '@/stores/useRoomStore'
+import { useActionManagerStore } from '@/stores/useActionManagerStore'
 import { storeToRefs } from 'pinia'
 // Props and emits
 const props = defineProps({
@@ -90,7 +91,8 @@ const props = defineProps({
   selected: Boolean
 })
 
-const { room, actionManager } = storeToRefs(useRoomStore())
+const { room } = storeToRefs(useRoomStore())
+const { actionManager } = storeToRefs(useActionManagerStore())
 const emit = defineEmits(['select'])
 
 

--- a/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
@@ -33,7 +33,8 @@ import { ref } from 'vue'
 
 import LibrarySource from '@/components/SoundRoom/SidebarLeft/LibrarySource.vue'
 import ContextMenu from '@/components/ui/context/ContextMenu.vue'
-import { useRoomStore } from '@/stores/useRoomStore'
+import { useAudioCacheStore } from '@/stores/useAudioCacheStore'
+import { useActionManagerStore } from '@/stores/useActionManagerStore'
 import { storeToRefs } from 'pinia'
 
 const props = defineProps({
@@ -42,8 +43,9 @@ const props = defineProps({
   addSourceClick: Function
 })
 
-const store = useRoomStore()
-const { soundLibrarySources } = storeToRefs(store)
+const cacheStore = useAudioCacheStore()
+const actionStore = useActionManagerStore()
+const { soundLibrarySources } = storeToRefs(cacheStore)
 
 
 const menuRef = ref(null)
@@ -59,7 +61,7 @@ function openContextMenu(e, source) {
 }
 
 function deleteSound() {
-  store.deleteLibrarySoundSource(contextSound.value)
+  actionStore.deleteLibrarySoundSource(contextSound.value)
   contextSound.value = null
 }
 

--- a/src/components/SoundRoom/SidebarLeft/LibrarySource.vue
+++ b/src/components/SoundRoom/SidebarLeft/LibrarySource.vue
@@ -8,14 +8,14 @@
 </template>
 <script setup>
 import { onUnmounted } from 'vue'
-import { useRoomStore } from '@/stores/useRoomStore'
+import { useAudioCacheStore } from '@/stores/useAudioCacheStore'
 
 const props = defineProps({
   librarySource: Object
 })
 
 onUnmounted(() => {
-  const store = useRoomStore()
-  store.audioCacheManager.remove(props.librarySource.libraryId)
+  const cacheStore = useAudioCacheStore()
+  cacheStore.audioCacheManager.remove(props.librarySource.libraryId)
 })
 </script>

--- a/src/components/SoundRoom/SidebarLeft/ListenerReadout.vue
+++ b/src/components/SoundRoom/SidebarLeft/ListenerReadout.vue
@@ -11,9 +11,9 @@
 
 <script setup>
 import { computed } from 'vue';
-import { useRoomStore } from '@/stores/useRoomStore';
+import { useListenerStore } from '@/stores/useListenerStore';
 
-const store = useRoomStore()
+const store = useListenerStore()
 
 // normalizes the angle of the listener into a 0–359° range, rotating the origin from the default right (0°) to top (0°)
 const displayListenerAngle = computed(() => Math.round(((store.listener.angle - 180) % 360 + 360) % 360))

--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -48,14 +48,14 @@
 import { computed, inject } from 'vue';
 import VueSlider from 'vue-3-slider-component';
 import { useVolumeSlider } from '@/composables/useVolumeSlider';
-import { useRoomStore } from '@/stores/useRoomStore';
+import { useActionManagerStore } from '@/stores/useActionManagerStore';
 import { storeToRefs } from 'pinia';
 
 const props = defineProps({
   selectedSource: Object
 });
 
-const { actionManager } = storeToRefs(useRoomStore());
+const { actionManager } = storeToRefs(useActionManagerStore());
 
 const selectedSource = inject('selectedSource');
 

--- a/src/components/SoundRoom/Toolbar.vue
+++ b/src/components/SoundRoom/Toolbar.vue
@@ -51,10 +51,16 @@ import VueSlider from 'vue-3-slider-component'
 import { useAuth } from '@/composables/useAuth'
 
 import { useRoomStore } from '@/stores/useRoomStore'
+import { useAudioEngineStore } from '@/stores/useAudioEngineStore'
+import { useActionManagerStore } from '@/stores/useActionManagerStore'
 import { storeToRefs } from 'pinia'
 
-const store = useRoomStore()
-const { audioEngine, room, actionManager } = storeToRefs(store)
+const roomStore = useRoomStore()
+const engineStore = useAudioEngineStore()
+const actionStore = useActionManagerStore()
+const { room } = storeToRefs(roomStore)
+const { audioEngine } = storeToRefs(engineStore)
+const { actionManager } = storeToRefs(actionStore)
 
 const { isAuthenticated } = useAuth()
 

--- a/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
@@ -102,20 +102,22 @@ import MarqueeTitle from '@/components/ui/text/MarqueeTitle.vue'
 import { getSourceName } from '@/composables/useSelectedSource'
 import BaseButton from '@/components/ui/input/BaseButton.vue'
 
-import { useRoomStore } from '@/stores/useRoomStore'
+import { useAudioCacheStore } from '@/stores/useAudioCacheStore'
+import { useActionManagerStore } from '@/stores/useActionManagerStore'
 import { storeToRefs } from 'pinia'
 
 const props = defineProps({
   isLibraryOpen: Boolean
 })
 
-const store = useRoomStore()
-const { soundLibrarySources } = storeToRefs(store)
+const cacheStore = useAudioCacheStore()
+const actionStore = useActionManagerStore()
+const { soundLibrarySources } = storeToRefs(cacheStore)
 const emit = defineEmits(['close'])
 
 function handleAudioSent(source, sound) {
   sound.send = false
-  store.addLibrarySoundSource(source)
+  actionStore.addLibrarySoundSource(source)
 }
 
 const categories = [
@@ -131,7 +133,7 @@ function toggleAddSource(s) {
   // if source in soundlibrarysources (draggable sources), delete, otherwise add
   if (soundLibrarySources.value.find((sound) => s.libraryId == sound.libraryId)) {
     s.send = false
-    store.deleteLibrarySoundSource(s)
+    actionStore.deleteLibrarySoundSource(s)
   } else {
     s.send = true
   }

--- a/src/components/ui/modals/SoundLibrary/SoundPreviewCircle.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundPreviewCircle.vue
@@ -41,7 +41,7 @@
 <script setup>
 import { ref, onUnmounted, computed, watch, onMounted, nextTick } from 'vue'
 import downloadAudio from '@/utils/downloadAudio'
-import { useRoomStore } from '@/stores/useRoomStore'
+import { useAudioCacheStore } from '@/stores/useAudioCacheStore'
 
 
 // Cache the downloaded preview locally to avoid redundant network calls
@@ -205,8 +205,8 @@ function stopPlayback() {
 onUnmounted(() => {
   stopPlayback()
   if (!hasBeenPromoted.value && cachedPreview) {
-    const store = useRoomStore()
-    store.audioCacheManager.remove(props.soundData.libraryId)
+    const cacheStore = useAudioCacheStore()
+    cacheStore.audioCacheManager.remove(props.soundData.libraryId)
     cachedPreview = null
   }
 })

--- a/src/composables/useContextMenuLogic.js
+++ b/src/composables/useContextMenuLogic.js
@@ -1,13 +1,13 @@
 import { computed, reactive } from 'vue'
-import { useRoomStore } from '@/stores/useRoomStore'
+import { useActionManagerStore } from '@/stores/useActionManagerStore'
 import { useCanvasStore } from '@/stores/useCanvasStore'
 import { storeToRefs } from 'pinia'
 // Central constant for sound node part identifier
 export const SOUND_NODE_PART_NAME = 'sound-node-part'
 
 export function useContextMenuLogic(selectedSource) {
-  const roomStore = useRoomStore()
-  const { actionManager } = storeToRefs(roomStore)
+  const actionStore = useActionManagerStore()
+  const { actionManager } = storeToRefs(actionStore)
   const canvasStore = useCanvasStore()
   function showContextMenu(e) {
     e.evt.preventDefault()

--- a/src/composables/useDragDropAudio.js
+++ b/src/composables/useDragDropAudio.js
@@ -1,12 +1,12 @@
 import { reactive } from "vue"
-import { useRoomStore } from "@/stores/useRoomStore";
+import { useActionManagerStore } from "@/stores/useActionManagerStore";
 import { useCanvasStore } from "@/stores/useCanvasStore";
 import { storeToRefs } from "pinia";  
 
 // useDragDropAudio.js
 export function useDragDropAudio({ draggedSource }) {
-  const roomStore = useRoomStore()
-  const { actionManager } = storeToRefs(roomStore)
+  const actionStore = useActionManagerStore()
+  const { actionManager } = storeToRefs(actionStore)
   const handleDragStart = (e, source) => {
     draggedSource.value = source
   }

--- a/src/composables/useKeyboardControls.js
+++ b/src/composables/useKeyboardControls.js
@@ -1,9 +1,18 @@
 import { useRoomStore } from "@/stores/useRoomStore"
+import { useListenerStore } from "@/stores/useListenerStore"
+import { useActionManagerStore } from "@/stores/useActionManagerStore"
+import { useAudioEngineStore } from "@/stores/useAudioEngineStore"
 import { storeToRefs } from "pinia"
 
 export function useKeyboardControls({selectedSource, selectedIndex}) {
-  const store = useRoomStore()
-  const { room, listener, actionManager, audioEngine } = storeToRefs(store)
+  const roomStore = useRoomStore()
+  const listenerStore = useListenerStore()
+  const actionStore = useActionManagerStore()
+  const engineStore = useAudioEngineStore()
+  const { room } = storeToRefs(roomStore)
+  const { listener } = storeToRefs(listenerStore)
+  const { actionManager } = storeToRefs(actionStore)
+  const { audioEngine } = storeToRefs(engineStore)
   const rotationKeys = new Set()
   let listenerAngleStart = null
   let sourceAngleStart = null

--- a/src/composables/useSaveAndLoadRoom.js
+++ b/src/composables/useSaveAndLoadRoom.js
@@ -1,6 +1,13 @@
 import { useRoomStore } from "@/stores/useRoomStore";
+import { useListenerStore } from "@/stores/useListenerStore";
+import { useAudioEngineStore } from "@/stores/useAudioEngineStore";
+import { useAudioCacheStore } from "@/stores/useAudioCacheStore";
+import { useActionManagerStore } from "@/stores/useActionManagerStore";
 import { useCanvasStore } from "@/stores/useCanvasStore";
 import { storeToRefs } from "pinia";
+import Room from '@/lib/Room'
+import Listener from '@/lib/Listener'
+import AudioEngine from '@/lib/AudioEngine'
 
 import { supabase } from "@/utils/supabase";
 import { downloadMultipleAudio } from "@/utils/downloadAudio";
@@ -12,8 +19,16 @@ export function useSaveAndLoadRoom() {
   const isSavingRoom = ref(false);
   const { user } = useAuth();
   const roomStore = useRoomStore();
+  const listenerStore = useListenerStore();
+  const audioEngineStore = useAudioEngineStore();
+  const cacheStore = useAudioCacheStore();
+  const actionStore = useActionManagerStore();
   const canvasStore = useCanvasStore();
-  const { room, listener, audioEngine, soundLibrarySources, actionManager } = storeToRefs(roomStore);
+  const { room } = storeToRefs(roomStore);
+  const { listener } = storeToRefs(listenerStore);
+  const { audioEngine } = storeToRefs(audioEngineStore);
+  const { soundLibrarySources } = storeToRefs(cacheStore);
+  const { actionManager } = storeToRefs(actionStore);
 
   function saveRoom() {
     isSavingRoom.value = true;
@@ -147,10 +162,10 @@ export function useSaveAndLoadRoom() {
     listener.value.dispose();
 
     roomStore.loadRoom(roomData.room);
-    roomStore.loadListener(roomData.listener);
-    roomStore.loadAudioEngine(roomData.audioEngine);
-    
-    roomStore.setupAudioContext(audioEngine, listener);
+    listenerStore.loadListener(roomData.listener);
+    audioEngineStore.loadAudioEngine(roomData.audioEngine);
+
+    audioEngineStore.setupAudioContext();
     
     setTimeout(() => {
       isLoadingRoom.value = false;
@@ -237,7 +252,7 @@ export function useSaveAndLoadRoom() {
       listener.value = Listener.fromJSON(roomData.listener);
       audioEngine.value = AudioEngine.fromJSON(roomData.audioEngine);
 
-      roomStore.setupAudioContext();
+      audioEngineStore.setupAudioContext();
     }
     localStorage.removeItem("tempSoundRoomData");
     setTimeout(() => {

--- a/src/composables/useSelectedSource.js
+++ b/src/composables/useSelectedSource.js
@@ -1,5 +1,5 @@
 import { computed } from "vue";
-import { useRoomStore } from "@/stores/useRoomStore";
+import { useAudioEngineStore } from "@/stores/useAudioEngineStore";
 import { storeToRefs } from "pinia";
 
 export function getSourceName(path) {
@@ -8,7 +8,7 @@ export function getSourceName(path) {
 }
 
 export function useSelectedSource(selectedIndex) {
-  const { audioEngine } = storeToRefs(useRoomStore());
+  const { audioEngine } = storeToRefs(useAudioEngineStore());
   const selectedSource = computed(() => {
     const index = selectedIndex.value;
     if (index == null || index < 0 || index >= audioEngine.value.soundSources.value.length) return null;

--- a/src/composables/useSoundRoomActions.js
+++ b/src/composables/useSoundRoomActions.js
@@ -1,5 +1,8 @@
 import downloadAudio from '@/utils/downloadAudio'
-import { useRoomStore } from '@/stores/useRoomStore'
+import { useActionManagerStore } from '@/stores/useActionManagerStore'
+import { useAudioEngineStore } from '@/stores/useAudioEngineStore'
+import { useListenerStore } from '@/stores/useListenerStore'
+import { useAudioCacheStore } from '@/stores/useAudioCacheStore'
 import { storeToRefs } from 'pinia'
 
 let actionsRegistered = false
@@ -13,7 +16,7 @@ export function registerSoundRoomActions() {
 
 export function unregisterSoundRoomActions() {
   if (!actionsRegistered) return
-  const { actionManager } = storeToRefs(useRoomStore())
+  const { actionManager } = storeToRefs(useActionManagerStore())
   actionManager.value.unregisterActionHandlers([
     'add_canvas_sound_source',
     'delete_canvas_sound_source',
@@ -25,7 +28,10 @@ export function unregisterSoundRoomActions() {
 }
 
 function registerCanvasActions() {
-  const { audioEngine,  actionManager, listener, soundLibrarySources} = storeToRefs(useRoomStore())
+  const { audioEngine } = storeToRefs(useAudioEngineStore())
+  const { actionManager } = storeToRefs(useActionManagerStore())
+  const { listener } = storeToRefs(useListenerStore())
+  const { soundLibrarySources } = storeToRefs(useAudioCacheStore())
   const moveSoundSource = (src, coords) => {
     src.instance.state.x = coords.x
     src.instance.state.y = coords.y
@@ -71,7 +77,10 @@ const maxLibSourcesReached = function(soundLibrarySources){
   return false
 }
 function registerDraggableActions() {
-  const { audioEngine, actionManager, soundLibrarySources } = storeToRefs(useRoomStore())
+  const { audioEngine } = storeToRefs(useAudioEngineStore())
+  const { actionManager } = storeToRefs(useActionManagerStore())
+  const cacheStore = useAudioCacheStore()
+  const { soundLibrarySources } = storeToRefs(cacheStore)
 
   const deleteDraggableSoundSource = (payload) => {
       const originalSrc = payload.src // 🔐 store it safely
@@ -106,8 +115,7 @@ function registerDraggableActions() {
       }
 
 
-      const store = useRoomStore()
-      store.audioCacheManager.remove(originalSrc.libraryId)
+      cacheStore.audioCacheManager.remove(originalSrc.libraryId)
     }
 
   

--- a/src/composables/useVolumeSlider.js
+++ b/src/composables/useVolumeSlider.js
@@ -1,8 +1,8 @@
 import { storeToRefs } from "pinia"
-import { useRoomStore } from "@/stores/useRoomStore"
+import { useActionManagerStore } from "@/stores/useActionManagerStore"
 export function useVolumeSlider(selectedSource) {
-  const roomStore = useRoomStore()
-  const { actionManager } = storeToRefs(roomStore)
+  const actionStore = useActionManagerStore()
+  const { actionManager } = storeToRefs(actionStore)
   actionManager.value.registerActionHandlers(
     "set_sound_source_volume",
     (payload) => {

--- a/src/stores/useActionManagerStore.js
+++ b/src/stores/useActionManagerStore.js
@@ -1,0 +1,26 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import ActionManager from '@/lib/ActionManager'
+
+export const useActionManagerStore = defineStore('actionManager', () => {
+  const actionManager = ref(new ActionManager())
+
+  const actionStackEmpty = computed(() => actionManager.value.actionStackEmpty.value)
+  const redoStackEmpty = computed(() => actionManager.value.redoStackEmpty.value)
+
+  async function addLibrarySoundSource(src) {
+    await actionManager.value.doAction('add_draggable_sound_source', { src })
+  }
+
+  async function deleteLibrarySoundSource(src) {
+    await actionManager.value.doAction('delete_draggable_sound_source', { src })
+  }
+
+  return {
+    actionManager,
+    actionStackEmpty,
+    redoStackEmpty,
+    addLibrarySoundSource,
+    deleteLibrarySoundSource
+  }
+})

--- a/src/stores/useAudioCacheStore.js
+++ b/src/stores/useAudioCacheStore.js
@@ -1,0 +1,36 @@
+import { defineStore } from 'pinia'
+import { ref, shallowRef } from 'vue'
+import AudioCacheManager from '@/lib/AudioCacheManager'
+
+export const useAudioCacheStore = defineStore('audioCache', () => {
+  const soundLibrarySources = ref([])
+  const audioCacheManager = shallowRef(new AudioCacheManager())
+
+  function addLibrarySource(src) {
+    soundLibrarySources.value.push(src)
+  }
+
+  function clearSoundLibrarySources() {
+    soundLibrarySources.value.forEach(src => {
+      audioCacheManager.value.remove(src.libraryId)
+    })
+    soundLibrarySources.value = []
+  }
+
+  function soundLibrarySourcesToJSON() {
+    return soundLibrarySources.value.map(src => ({
+      libraryId: src.libraryId,
+      coneInner: src.coneInner,
+      coneOuter: src.coneOuter,
+      name: src.name
+    }))
+  }
+
+  return {
+    soundLibrarySources,
+    audioCacheManager,
+    addLibrarySource,
+    clearSoundLibrarySources,
+    soundLibrarySourcesToJSON
+  }
+})

--- a/src/stores/useAudioEngineStore.js
+++ b/src/stores/useAudioEngineStore.js
@@ -1,0 +1,46 @@
+import { defineStore } from 'pinia'
+import { shallowRef, computed } from 'vue'
+import AudioEngine from '@/lib/AudioEngine'
+import { useListenerStore } from './useListenerStore'
+import { useAudioCacheStore } from './useAudioCacheStore'
+
+export const useAudioEngineStore = defineStore('audioEngine', () => {
+  const audioEngine = shallowRef(new AudioEngine([]))
+
+  function loadAudioEngine(data) {
+    audioEngine.value = AudioEngine.fromJSON(data)
+  }
+
+  function audioEngineToJSON() {
+    return audioEngine.value.toJSON()
+  }
+
+  function setMaxCanvasSources(max) {
+    if (audioEngine.value) {
+      audioEngine.value.maxSourceCount = max
+    }
+  }
+
+  function setupAudioContext() {
+    const listenerStore = useListenerStore()
+    const cacheStore = useAudioCacheStore()
+    const audioContext = audioEngine.value.getAudioContext()
+    listenerStore.listener.setAudioContext(audioContext)
+    cacheStore.audioCacheManager.setAudioContext(audioContext)
+    audioEngine.value.setupAudioEngine()
+    listenerStore.listener.updateAudio()
+  }
+
+  const isPlaying = computed(() => audioEngine.value.isPlaying.value)
+  const MAX_CANVAS_SOURCES = computed(() => audioEngine.value.maxSourceCount)
+
+  return {
+    audioEngine,
+    loadAudioEngine,
+    audioEngineToJSON,
+    setMaxCanvasSources,
+    setupAudioContext,
+    isPlaying,
+    MAX_CANVAS_SOURCES
+  }
+})

--- a/src/stores/useListenerStore.js
+++ b/src/stores/useListenerStore.js
@@ -1,0 +1,21 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import Listener from '@/lib/Listener'
+
+export const useListenerStore = defineStore('listener', () => {
+  const listener = ref(new Listener())
+
+  function loadListener(data) {
+    listener.value = Listener.fromJSON(data)
+  }
+
+  function listenerToJSON() {
+    return listener.value.toJSON()
+  }
+
+  return {
+    listener,
+    loadListener,
+    listenerToJSON
+  }
+})

--- a/src/stores/useRoomStore.js
+++ b/src/stores/useRoomStore.js
@@ -1,112 +1,47 @@
-// stores/useRoomStore.js
 import { defineStore } from 'pinia'
-import { ref, shallowRef, computed } from 'vue'
+import { ref, computed } from 'vue'
 import Room from '@/lib/Room'
-import Listener from '@/lib/Listener'
-import AudioEngine from '@/lib/AudioEngine'
-import ActionManager from '@/lib/ActionManager'
-import AudioCacheManager from '@/lib/AudioCacheManager'
+import { useListenerStore } from './useListenerStore'
+import { useAudioEngineStore } from './useAudioEngineStore'
+import { useAudioCacheStore } from './useAudioCacheStore'
 
 export const useRoomStore = defineStore('room', () => {
-  // reactive refs
   const room = ref(new Room())
-  const listener = ref(new Listener())
-  const audioEngine = shallowRef(new AudioEngine([]))
-  const soundLibrarySources = ref([])
-  const actionManager = ref(new ActionManager())
-  const audioCacheManager = shallowRef(new AudioCacheManager())
   const _lastSavedSnapshot = ref(null)
 
-  // actions
-  function setupAudioContext() {
-    const audioContext = audioEngine.value.getAudioContext()
-    listener.value.setAudioContext(audioContext)
-    audioCacheManager.value.setAudioContext(audioContext) // ensure cache manager uses the same context
-    audioEngine.value.setupAudioEngine() // run after listener audio context is set because it plays saved sounds
-    listener.value.updateAudio() // ensure listener is ready with the new context
-    getSaveSnapshot()
-  }
   function loadRoom(roomData) {
     room.value = Room.fromJSON(roomData)
-  }
-
-  function loadListener(data) {
-    listener.value = Listener.fromJSON(data)
-  }
-
-  function loadAudioEngine(data) {
-    audioEngine.value = AudioEngine.fromJSON(data)
-  }
-
-  function clearSoundLibrarySources() {
-    soundLibrarySources.value.forEach(src => {
-      audioCacheManager.value.remove(src.libraryId)
-    })
-    soundLibrarySources.value = []
   }
 
   function roomToJSON() {
     return room.value.toJSON()
   }
-  function listenerToJSON() {
-    return listener.value.toJSON()
-  }
-  function audioEngineToJSON() {
-    return audioEngine.value.toJSON()
-  }
 
   function getSaveSnapshot() {
+    const listenerStore = useListenerStore()
+    const audioEngineStore = useAudioEngineStore()
+    const cacheStore = useAudioCacheStore()
     const savedState = {
       room: roomToJSON(),
-      listener: listenerToJSON(), 
-      audioEngine: audioEngineToJSON(),
-      soundLibrarySources: soundLibrarySourcesToJSON()
+      listener: listenerStore.listenerToJSON(),
+      audioEngine: audioEngineStore.audioEngineToJSON(),
+      soundLibrarySources: cacheStore.soundLibrarySourcesToJSON()
     }
     _lastSavedSnapshot.value = JSON.stringify(savedState)
     return savedState
   }
 
-  function soundLibrarySourcesToJSON() {
-    return soundLibrarySources.value.map((src) => ({ 
-      libraryId: src.libraryId, 
-      coneInner: src.coneInner, 
-      coneOuter: src.coneOuter,  
-      name: src.name 
-    }))
-  }
-
-  function addLibrarySource(src) {
-    soundLibrarySources.value.push(src)
-  }
-
-  function setMaxCanvasSources(max) {
-    if (audioEngine.value) {
-      audioEngine.value.maxSourceCount = max
-    }
-  }
-
-  async function addLibrarySoundSource(src) {
-    await actionManager.value.doAction('add_draggable_sound_source', { src })
-  }
-
-  async function deleteLibrarySoundSource(src) {
-    await actionManager.value.doAction('delete_draggable_sound_source', { src })
-  }
-
-  const isPlaying = computed(() => audioEngine.value.isPlaying.value)
-  const actionStackEmpty = computed(() => actionManager.value.actionStackEmpty)
-  const redoStackEmpty = computed(() => actionManager.value.redoStackEmpty)
-  const MAX_CANVAS_SOURCES = computed(() => audioEngine.value.maxSourceCount)
   const isRoomSaveable = computed(() => {
-  // 👇 this line makes Vue re-evaluate when any relevant part changes
-    void room.value && void listener.value && void audioEngine.value && void soundLibrarySources.value
-
+    const listenerStore = useListenerStore()
+    const audioEngineStore = useAudioEngineStore()
+    const cacheStore = useAudioCacheStore()
+    void room.value && void listenerStore.listener && void audioEngineStore.audioEngine && void cacheStore.soundLibrarySources
     try {
       const currentSnapshot = JSON.stringify({
         room: roomToJSON(),
-        listener: listenerToJSON(),
-        audioEngine: audioEngineToJSON(),
-        soundLibrarySources: soundLibrarySourcesToJSON(),
+        listener: listenerStore.listenerToJSON(),
+        audioEngine: audioEngineStore.audioEngineToJSON(),
+        soundLibrarySources: cacheStore.soundLibrarySourcesToJSON()
       })
       return currentSnapshot !== _lastSavedSnapshot.value
     } catch (e) {
@@ -117,29 +52,9 @@ export const useRoomStore = defineStore('room', () => {
 
   return {
     room,
-    listener,
-    audioEngine,
-    soundLibrarySources,
-    actionManager,
     loadRoom,
-    loadListener,
-    loadAudioEngine,
-    addLibrarySource,
-    setMaxCanvasSources,
-    addLibrarySoundSource,
-    deleteLibrarySoundSource,
-    clearSoundLibrarySources,
-    isPlaying,
-    actionStackEmpty,
-    redoStackEmpty,
-    MAX_CANVAS_SOURCES,
     roomToJSON,
-    listenerToJSON,
-    audioEngineToJSON,
-    soundLibrarySourcesToJSON,
-    setupAudioContext,
-    isRoomSaveable,
     getSaveSnapshot,
-    audioCacheManager
+    isRoomSaveable
   }
 })

--- a/src/utils/downloadAudio.js
+++ b/src/utils/downloadAudio.js
@@ -1,4 +1,4 @@
-import { useRoomStore } from '@/stores/useRoomStore'
+import { useAudioCacheStore } from '@/stores/useAudioCacheStore'
 
 
 async function fetchAudioBlob(key) {
@@ -25,8 +25,8 @@ export default async function downloadAudio(
   stopPlayback = null,
   libraryId = null
 ) {
-  const store = useRoomStore()
-  const cacheManager = store.audioCacheManager
+  const cacheStore = useAudioCacheStore()
+  const cacheManager = cacheStore.audioCacheManager
 
   // uncomment for debugging cache and download issues
   //cacheManager.clearPersistentCache()

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -84,6 +84,9 @@ import WelcomeOverlay from '@/components/ui/overlays/WelcomeOverlay.vue'
 
 // Store
 import { useRoomStore } from '@/stores/useRoomStore'
+import { useListenerStore } from '@/stores/useListenerStore'
+import { useAudioEngineStore } from '@/stores/useAudioEngineStore'
+import { useAudioCacheStore } from '@/stores/useAudioCacheStore'
 
 // Composables
 import { useKeyboardControls } from '@/composables/useKeyboardControls'
@@ -99,14 +102,18 @@ const isLibraryOpen = ref(false)
 const selectedIndex = ref(null)
 const draggedSource = ref(null)
 
-const store = useRoomStore()
-const { listener, audioEngine, } = storeToRefs(store)
+const roomStore = useRoomStore()
+const listenerStore = useListenerStore()
+const engineStore = useAudioEngineStore()
+const cacheStore = useAudioCacheStore()
+const { listener } = storeToRefs(listenerStore)
+const { audioEngine } = storeToRefs(engineStore)
 
 const MAX_LIB_SOURCES = 20
 const MAX_CANVAS_SOURCES = 30
 
 
-store.setMaxCanvasSources(MAX_CANVAS_SOURCES)
+engineStore.setMaxCanvasSources(MAX_CANVAS_SOURCES)
 
 
 // Selection
@@ -138,7 +145,7 @@ setMaxLibSources(MAX_LIB_SOURCES)
 const showWelcomeOverlay = ref(false)
 onBeforeMount(() => {
   registerSoundRoomActions()
-  store.clearSoundLibrarySources() // Clear any previous sound library sources
+  cacheStore.clearSoundLibrarySources() // Clear any previous sound library sources
   if (sessionStorage.getItem('justLoggedIn') === 'true') {
     sessionStorage.removeItem('justLoggedIn')
     showWelcomeOverlay.value = true
@@ -150,15 +157,15 @@ onBeforeMount(() => {
     //const router = useRouter()
     //router.push('/welcome')
   }
-  store.setupAudioContext()
+  engineStore.setupAudioContext()
 })
 
 onUnmounted(() => {
   unregisterSoundRoomActions()
   audioEngine.value.dispose()
   // Revoke object URLs to avoid memory leaks
-  store.audioCacheManager.clearMemoryCache()
+  cacheStore.audioCacheManager.clearMemoryCache()
   // Uncomment to also wipe IndexedDB cache if long-term storage isn't desired
-  // void store.audioCacheManager.clearPersistentCache()
+  // void cacheStore.audioCacheManager.clearPersistentCache()
 })
 </script>


### PR DESCRIPTION
## Summary
- split `useRoomStore` into dedicated stores
- update imports across composables and components
- adjust `SoundRoom.vue` to use new stores

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68661d5f0bcc832f8b4733eff43b7148