### PR TITLE
Refactor room name update flow

### DIFF
--- a/src/components/ui/modals/RoomManager/EditableRoomName.vue
+++ b/src/components/ui/modals/RoomManager/EditableRoomName.vue
@@ -53,12 +53,13 @@ function cancelEdit() {
 
 async function handleBlur() {
   isEditing.value = false
-  const newName = localName.value.trim()
+  const baseName = localName.value.trim()
+  const uniqueName = roomStore.generateUniqueRoomName(roomId.value, baseName)
   const oldName = name.value?.trim()
 
-  if (newName === oldName || !newName) return
+  if (uniqueName === oldName) return
 
-  emit('updated', roomStore.generateUniqueRoomName(roomId.value, newName))
+  emit('updated', uniqueName)
 }
 </script>
 

--- a/src/components/ui/modals/RoomManager/RoomManager.vue
+++ b/src/components/ui/modals/RoomManager/RoomManager.vue
@@ -182,6 +182,7 @@ const handleUpdateRoomName = async (room, newName) => {
   const success = await updateRoomName(room.id, newName)
   if (success) {
     room.name = newName
+    roomStore.commitRoomName(room.id, newName)
   } else {
     console.error('Failed to update room name')
   }

--- a/src/composables/useSaveAndLoadRoom.js
+++ b/src/composables/useSaveAndLoadRoom.js
@@ -62,6 +62,7 @@ export function useSaveAndLoadRoom() {
           console.error("Error updating room:", error);
         } else {
           room.value.id = data[0].id; // Update the room ID with the returned ID
+          roomStore.commitRoomName(room.value.id, room.value.name)
         }
       });
   }
@@ -76,6 +77,8 @@ export function useSaveAndLoadRoom() {
       console.error("Error updating room:", error)
       return false
     }
+
+    roomStore.commitRoomName(roomId, name)
 
     return true
   }
@@ -97,6 +100,7 @@ export function useSaveAndLoadRoom() {
           console.error("Error inserting room:", error);
         } else {
           room.value.id = id; // Update the room ID with the returned ID
+          roomStore.commitRoomName(room.value.id, room.value.name)
         }
       });
   }

--- a/src/stores/useRoomStore.js
+++ b/src/stores/useRoomStore.js
@@ -47,30 +47,34 @@ export const useRoomStore = defineStore('room', () => {
     let name = base
     let count = 1
 
-    //console.log(typeof name, name)
-
-    // Find if a room with the same ID already exists
-    const existingRoomIndex = existingRoomNames.value.findIndex(room => room.id === id)
-    console.log(`Checking for existing room with ID: ${id}, found at index: ${existingRoomIndex}`)
-    // If the room exists, remove it temporarily from the list (we'll update it later)
-    if (existingRoomIndex !== -1) {
-      console.log(`Updating existing room with ID: ${id}`)
-      existingRoomNames.value = existingRoomNames.value.filter(room => room.id !== id)
-    }
-
-    // Get a list of all normalized (lowercase) names for collision checking
-    const normalizedNames = existingRoomNames.value.map(room => room.name.toLowerCase())
+    // Filter out the current room (if it exists) so it doesn't collide with itself
+    const normalizedNames = existingRoomNames.value
+      .filter(room => room.id !== id)
+      .map(room => room.name.toLowerCase())
 
     // Add suffix until the name is unique
     while (normalizedNames.includes(name.toLowerCase())) {
       name = `${base} (${count})`
       count++
     }
-    
-    // Add or re-add the updated room name
-    existingRoomNames.value.push({ name, id })
-    console.log('Updated existingRoomNames:', existingRoomNames.value)
+
     return name
+  }
+
+  /**
+   * Update the tracked room name list once a name is successfully saved.
+   * Reuses existing entry if ID already exists, or adds a new one if not.
+   *
+   * @param {string} id
+   * @param {string} name
+   */
+  function commitRoomName(id, name) {
+    const index = existingRoomNames.value.findIndex(r => r.id === id)
+    if (index !== -1) {
+      existingRoomNames.value[index].name = name
+    } else {
+      existingRoomNames.value.push({ id, name })
+    }
   }
 
 
@@ -124,5 +128,6 @@ export const useRoomStore = defineStore('room', () => {
     isRoomSaveable,
     setExistingRoomNames,
     generateUniqueRoomName,
+    commitRoomName,
   }
 })


### PR DESCRIPTION
## Summary
- decouple unique name checking from updating existing names
- update EditableRoomName to emit unique name only
- update RoomManager and SaveAndLoad composable to commit names on success

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68698df74224832fb82c3d3f52e618e2