### PR TITLE
Fix room name editing for unsaved rooms

### DIFF
--- a/src/components/SoundRoom/Toolbar.vue
+++ b/src/components/SoundRoom/Toolbar.vue
@@ -29,7 +29,7 @@
       :roomId="room.id"
       :name="room.name"
       class="w-1/3"
-      @updated="room.name = $event"
+      @updated="handleRoomNameUpdate"
     />
     <div class="flex items-center justify-center space-x-2 w-1/3">
      
@@ -50,10 +50,10 @@
 
 <script setup>
 import BaseButton from '@/components/ui/input/BaseButton.vue'
-import BaseInput from '@/components/ui/input/BaseInput.vue'
 import EditableRoomName from '@/components/ui/modals/RoomManager/EditableRoomName.vue'
 import VueSlider from 'vue-3-slider-component'
 import { useAuth } from '@/composables/useAuth'
+import { useSaveAndLoadRoom } from '@/composables/useSaveAndLoadRoom'
 
 import { useRoomStore } from '@/stores/useRoomStore'
 import { useAudioEngineStore } from '@/stores/useAudioEngineStore'
@@ -69,4 +69,21 @@ const { actionManager, actionStackEmpty, redoStackEmpty, waiting } = storeToRefs
 
 const { isAuthenticated } = useAuth()
 
+const { updateRoomName } = useSaveAndLoadRoom()
+
+async function handleRoomNameUpdate(newName) {
+  // Skip if the name didn't actually change
+  if (room.value.name === newName) return
+
+  room.value.name = newName
+
+  if (room.value.id) {
+    const success = await updateRoomName(room.value.id, newName)
+    if (!success) {
+      console.error('Failed to update room name')
+    }
+  } else {
+    roomStore.commitRoomName(room.value.id, newName)
+  }
+}
 </script>

--- a/src/stores/useRoomStore.js
+++ b/src/stores/useRoomStore.js
@@ -68,7 +68,24 @@ export const useRoomStore = defineStore('room', () => {
    * @param {string} id
    * @param {string} name
    */
+  const TEMP_ID = 'temp-room'
+
   function commitRoomName(id, name) {
+    // Handle rooms that haven't been saved to the DB yet
+    if (!id) {
+      const tempIndex = existingRoomNames.value.findIndex(r => r.id === TEMP_ID)
+      if (tempIndex !== -1) {
+        existingRoomNames.value[tempIndex].name = name
+      } else {
+        existingRoomNames.value.push({ id: TEMP_ID, name })
+      }
+      return
+    }
+
+    // Remove any temporary entry once we have a real ID
+    const tempIndex = existingRoomNames.value.findIndex(r => r.id === TEMP_ID)
+    if (tempIndex !== -1) existingRoomNames.value.splice(tempIndex, 1)
+
     const index = existingRoomNames.value.findIndex(r => r.id === id)
     if (index !== -1) {
       existingRoomNames.value[index].name = name


### PR DESCRIPTION
## Summary
- wire up EditableRoomName in the Toolbar to save changes
- allow `useRoomStore` to track a temporary room ID for new rooms

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6869b5c6fdc8832facd499010c53aefe