### PR TITLE
Add helper to reset room state

### DIFF
--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -50,6 +50,7 @@ import { useRouter } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import { useRoomStore } from '@/stores/useRoomStore';
 import { useAuth } from '@/composables/useAuth';
+import { resetRoomState } from '@/utils/resetRoomState';
 import BaseButton from '@/components/ui/input/BaseButton.vue';
 import YesNoModal from '@/components/ui/modals/YesNoModal.vue';
 
@@ -82,10 +83,12 @@ function handleSaveThenNewRoom() {
     return;
   }
   emit('saveRoom');
+  resetRoomState();
   router.push('/');
 }
 
 function handleSkipSaveThenNewRoom() {
+  resetRoomState();
   router.push('/');
 }
 </script>

--- a/src/components/ui/modals/RoomManager/RoomManager.vue
+++ b/src/components/ui/modals/RoomManager/RoomManager.vue
@@ -143,6 +143,7 @@ import { useRouter } from 'vue-router'
 import { useSaveAndLoadRoom } from '@/composables/useSaveAndLoadRoom'
 import { useRoomStore } from '@/stores/useRoomStore'
 import PulsingOverlay from '@/components/ui/overlays/PulsingOverlay.vue'
+import { resetRoomState } from '@/utils/resetRoomState'
 
 const router = useRouter()
 const buttons = ref([
@@ -251,6 +252,7 @@ onMounted(async () => {
 })
 
 const createNewRoom = () => {
+  resetRoomState()
   router.push('/')
 }
 

--- a/src/utils/resetRoomState.js
+++ b/src/utils/resetRoomState.js
@@ -1,0 +1,43 @@
+import { useActionManagerStore } from '@/stores/useActionManagerStore'
+import { useListenerStore } from '@/stores/useListenerStore'
+import { useAudioEngineStore } from '@/stores/useAudioEngineStore'
+import { useAudioCacheStore } from '@/stores/useAudioCacheStore'
+import { useRoomStore } from '@/stores/useRoomStore'
+import ActionManager from '@/lib/ActionManager'
+import Listener from '@/lib/Listener'
+import AudioEngine from '@/lib/AudioEngine'
+import Room from '@/lib/Room'
+
+/**
+ * Reset all core stores to their initial state.
+ *
+ * Disposes of active audio objects and recreates fresh instances so a
+ * brand new room can be instantiated without leftover state.
+ */
+export function resetRoomState() {
+  const actionStore = useActionManagerStore()
+  const listenerStore = useListenerStore()
+  const engineStore = useAudioEngineStore()
+  const cacheStore = useAudioCacheStore()
+  const roomStore = useRoomStore()
+
+  // Clear undo/redo history and create a new manager instance
+  actionStore.actionManager.value.clearHistory()
+  actionStore.actionManager.value = new ActionManager()
+
+  // Dispose of audio engine and start from scratch
+  engineStore.audioEngine.value.dispose()
+  engineStore.audioEngine.value = new AudioEngine([])
+
+  // Reset listener
+  listenerStore.listener.value.dispose()
+  listenerStore.listener.value = new Listener()
+
+  // Remove any loaded library sounds and cached blobs
+  cacheStore.clearSoundLibrarySources()
+  cacheStore.audioCacheManager.value.clearMemoryCache()
+
+  // Reset room metadata
+  roomStore.room.value = new Room()
+  roomStore.getSaveSnapshot()
+}


### PR DESCRIPTION
## Summary
- add `resetRoomState` helper for clearing all stores
- use reset helper when creating new rooms

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686acc2ea2f4832fb8440372fb1a460c