### PR TITLE
Refactor SoundLibrary into modular subcomponents

### DIFF
--- a/src/components/ui/modals/SoundLibrary/CategoryList.vue
+++ b/src/components/ui/modals/SoundLibrary/CategoryList.vue
@@ -1,0 +1,47 @@
+<template>
+  <aside class="w-60 bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-300 dark:border-neutral-800 p-4 space-y-3 overflow-y-auto">
+    <h2 class="font-bold text-sm mb-2">Categories</h2>
+    <BaseButton
+      v-for="cat in categories"
+      :key="cat.id"
+      @click="$emit('update:active', cat.id)"
+      :class="['sound-lib-button', { active: active === cat.id }]"
+    >
+      {{ cat.label }}
+    </BaseButton>
+  </aside>
+</template>
+
+<script setup>
+import BaseButton from '@/components/ui/input/BaseButton.vue'
+
+const props = defineProps({
+  categories: Array,
+  active: String
+})
+
+defineEmits(['update:active'])
+</script>
+
+<style scoped>
+.sound-lib-button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  border-radius: 0.375rem;
+  transition: background-color 0.2s;
+}
+.sound-lib-button:hover { background-color: #e5e5e5; }
+@media (prefers-color-scheme: dark) {
+  .sound-lib-button:hover { background-color: #1f2937; }
+}
+.sound-lib-button.active {
+  font-weight: 600;
+  background-color: #d4d4d4;
+}
+@media (prefers-color-scheme: dark) {
+  .sound-lib-button.active { background-color: #1f2937; }
+}
+</style>

--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="flex-1 relative overflow-hidden">
+    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-white/50 dark:bg-neutral-950/50 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800">
+      <h2 class="text-2xl font-bold">SoundLibrary</h2>
+      <BaseButton class="text-sm" @click="$emit('close')">Close</BaseButton>
+    </div>
+    <div ref="gridScroll" class="mt-5 place-content-start p-6 pt-20 overflow-y-auto h-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+      <SoundGridItem
+        v-for="sound in sounds"
+        :key="sound.id"
+        :sound="sound"
+        v-bind="{ waiting, soundLibrarySources, currentlyPlayingId }"
+        @toggle="$emit('toggleSound', $event)"
+        @sendAudio="$emit('sendAudio', $event)"
+        @updateCurrent="$emit('updateCurrent', $event)"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, defineExpose } from 'vue'
+import BaseButton from '@/components/ui/input/BaseButton.vue'
+import SoundGridItem from './SoundGridItem.vue'
+
+const props = defineProps({
+  sounds: Array,
+  waiting: Boolean,
+  soundLibrarySources: Array,
+  currentlyPlayingId: String
+})
+
+defineEmits(['close', 'toggleSound', 'sendAudio', 'updateCurrent'])
+
+const gridScroll = ref(null)
+function scrollTop() {
+  gridScroll.value?.scrollTo({ top: 0 })
+}
+
+defineExpose({ scrollTop })
+</script>

--- a/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="aspect-square flex flex-col items-center justify-between p-4 rounded-xl bg-neutral-100 dark:bg-neutral-800 shadow border border-neutral-300 dark:border-neutral-700">
+    <MarqueeTitle :text="getSourceName(sound.name)" />
+    <SoundPreviewCircle
+      :soundData="sound"
+      :sendAudioUp="sound.send"
+      :currentlyPlayingId="currentlyPlayingId"
+      @sendAudio="$emit('sendAudio', { source: $event, sound })"
+      @updateCurrent="$emit('updateCurrent', $event)"
+    />
+    <BaseButton
+      class="load-BaseButton text-xs px-3 py-1 rounded hover:bg-blue-700 transition-colors"
+      @click="$emit('toggle', sound)"
+      :disabled="waiting || sound.send"
+    >
+      {{ soundLibrarySources.find((s) => s.libraryId == sound.libraryId) ? 'Remove' : 'Load' }}
+    </BaseButton>
+  </div>
+</template>
+
+<script setup>
+import BaseButton from '@/components/ui/input/BaseButton.vue'
+import SoundPreviewCircle from '@/components/ui/modals/SoundLibrary/SoundPreviewCircle.vue'
+import MarqueeTitle from '@/components/ui/text/MarqueeTitle.vue'
+import { getSourceName } from '@/composables/useSelectedSource'
+
+const props = defineProps({
+  sound: Object,
+  waiting: Boolean,
+  soundLibrarySources: Array,
+  currentlyPlayingId: String
+})
+
+defineEmits(['toggle', 'sendAudio', 'updateCurrent'])
+</script>

--- a/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
@@ -4,73 +4,24 @@
     @click.self="emit('close')"
     class="modal-backdrop"
   >
-    <div
-      class="modal-panel flex"
-    >
-      <!-- Left Sidebar: Categories -->
-      <aside
-        class="w-60 bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-300 dark:border-neutral-800 p-4 space-y-3 overflow-y-auto"
-      >
-        <h2 class="font-bold text-sm mb-2">Categories</h2>
-        <BaseButton
-          v-for="cat in categories"
-          :key="cat.id"
-          @click="activeCategory = cat.id"
-          :class="['sound-lib-button', { active: activeCategory === cat.id }]"
-        >
-          {{ cat.label }}
-        </BaseButton>
-      </aside>
+    <div class="modal-panel flex">
+      <CategoryList
+        :categories="categories"
+        :active="activeCategory"
+        @update:active="val => activeCategory = val"
+      />
 
-      <!-- Main Content: Sound Grid -->
-      <div class="flex-1 relative overflow-hidden">
-        <!-- Floating Top Bar -->
-        <div
-          class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-white/50 dark:bg-neutral-950/50 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800"
-        >
-          <h2 class="text-2xl font-bold">SoundLibrary</h2>
-          <BaseButton class="text-sm" @click="$emit('close')">Close</BaseButton>
-        </div>
-
-        <!-- Scrollable Sound Grid -->
-        <div
-          ref="gridScroll"
-          class="mt-5 place-content-start p-6 pt-20 overflow-y-auto h-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4"
-        >
-          <div
-            v-for="sound in filteredSounds"
-            :key="sound.id"
-            class="aspect-square flex flex-col items-center justify-between p-4 rounded-xl bg-neutral-100 dark:bg-neutral-800 shadow border border-neutral-300 dark:border-neutral-700"
-          >
-            <!-- Title -->
-            <MarqueeTitle :text="getSourceName(sound.name)" />
-
-            <!-- Preview Button -->
-            <SoundPreviewCircle
-              :soundData="sound"
-              :sendAudioUp="sound.send"
-              :currentlyPlayingId="currentlyPlayingId"
-              @sendAudio="(soundData) => { handleAudioSent(soundData, sound) }"
-              @updateCurrent="currentlyPlayingId = $event"
-            />
-
-            <!-- Load Button -->
-            <BaseButton
-              class="load-BaseButton text-xs px-3 py-1 rounded hover:bg-blue-700 transition-colors"
-              @click="() => { toggleAddSource(sound) }"
-              :disabled="waiting || sound.send"
-            >
-              {{
-                soundLibrarySources.find(
-                  (s) => s.libraryId == sound.libraryId
-                )
-                  ? 'Remove'
-                  : 'Load'
-              }}
-            </BaseButton>
-          </div>
-        </div>
-      </div>
+      <SoundGrid
+        ref="gridRef"
+        :sounds="filteredSounds"
+        :waiting="waiting"
+        :soundLibrarySources="soundLibrarySources"
+        :currentlyPlayingId="currentlyPlayingId"
+        @close="$emit('close')"
+        @toggleSound="toggleAddSource"
+        @sendAudio="payload => handleAudioSent(payload.source, payload.sound)"
+        @updateCurrent="currentlyPlayingId = $event"
+      />
 
       <!-- Bottom Upload Panel -->
       <div
@@ -98,10 +49,8 @@ import { ref, watch, nextTick } from 'vue'
 
 import { supabase } from '@/utils/supabase'
 
-import SoundPreviewCircle from '@/components/ui/modals/SoundLibrary/SoundPreviewCircle.vue'
-import MarqueeTitle from '@/components/ui/text/MarqueeTitle.vue'
-import { getSourceName } from '@/composables/useSelectedSource'
-import BaseButton from '@/components/ui/input/BaseButton.vue'
+import CategoryList from '@/components/ui/modals/SoundLibrary/CategoryList.vue'
+import SoundGrid from '@/components/ui/modals/SoundLibrary/SoundGrid.vue'
 
 import { useAudioCacheStore } from '@/stores/useAudioCacheStore'
 import { useActionManagerStore } from '@/stores/useActionManagerStore'
@@ -145,17 +94,14 @@ async function toggleAddSource(s) {
 const currentlyPlayingId = ref(null) // id of current sound playing to stop multiple previews playing at once
 
 const activeCategory = ref(categories?.[0]?.id || '')
-const gridScroll = ref(null) // ref to scrollable div of library sounds
-
-const isLoading = ref(false)
+const gridRef = ref(null) // ref to SoundGrid component
 const filteredSounds = ref([])
 watch(
   activeCategory,
   async (newCategory) => {
     currentlyPlayingId.value = null
-    isLoading.value = true
     await nextTick()
-    gridScroll.value?.scrollTo({ top: 0 }) // scroll up when new category is selected
+    gridRef.value?.scrollTop() // scroll up when new category is selected
 
     const sounds = await listCategoryFiles(newCategory)
     filteredSounds.value = sounds.map(({ id, ...rest }) => ({
@@ -163,7 +109,6 @@ watch(
       ...rest,
     }))
 
-    isLoading.value = false
   },
   { immediate: true }
 ) // run at least once, like a do while
@@ -200,37 +145,4 @@ function handleUpload(event) {
   }
 }
 
-/* Base button styling */
-.sound-lib-button {
-  display: block;
-  width: 100%;
-  text-align: left;
-  padding: 0.5rem 0.75rem;
-  font-size: 0.875rem; /* text-sm */
-  border-radius: 0.375rem; /* rounded */
-  transition: background-color 0.2s;
-}
-
-/* Hover state */
-.sound-lib-button:hover {
-  background-color: #e5e5e5; /* neutral-200 */
-}
-
-@media (prefers-color-scheme: dark) {
-  .sound-lib-button:hover {
-    background-color: #1f2937; /* neutral-800 */
-  }
-}
-
-/* Active/selected state */
-.sound-lib-button.active {
-  font-weight: 600;
-  background-color: #d4d4d4; /* neutral-200 */
-}
-
-@media (prefers-color-scheme: dark) {
-  .sound-lib-button.active {
-    background-color: #1f2937; /* neutral-800 */
-  }
-}
 </style>


### PR DESCRIPTION
## Summary
- split large `SoundLibrary.vue` into smaller components
- add `CategoryList`, `SoundGrid` and `SoundGridItem`
- update `SoundLibrary.vue` to use new pieces

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68700c721cf8832f8cbef8903ae03fc9