### PR TITLE
Add JSDoc to audio modules

### DIFF
--- a/src/composables/useContextMenuLogic.js
+++ b/src/composables/useContextMenuLogic.js
@@ -5,10 +5,21 @@ import { storeToRefs } from 'pinia'
 // Central constant for sound node part identifier
 export const SOUND_NODE_PART_NAME = 'sound-node-part'
 
+/**
+ * Provide context menu behaviour for sound source nodes on the canvas.
+ *
+ * @param {import('vue').Ref<Object|null>} selectedSource - currently selected source
+ * @returns {{showContextMenu: Function, contextMenuActions: Array}}
+ */
 export function useContextMenuLogic(selectedSource) {
   const actionStore = useActionManagerStore()
   const { actionManager } = storeToRefs(actionStore)
   const canvasStore = useCanvasStore()
+  /**
+   * Display the context menu when the user right-clicks a sound node.
+   *
+   * @param {import('vue').KonvaEventObject<MouseEvent>} e - Konva event wrapper
+   */
   function showContextMenu(e) {
     e.evt.preventDefault()
     e.evt.stopPropagation()

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -22,6 +22,12 @@ export default class AudioEngine {
   #scheduler = null
   #scheduleWatchers = null
 
+  /**
+   * Create a new AudioEngine instance.
+   *
+   * @param {Array} [uninitializedSoundSources=[]] sound sources to create on setup
+   * @param {number} [volume=1] initial master volume
+   */
   constructor(uninitializedSoundSources, volume = 1 ) {
     this.#uninitializedSoundSources = uninitializedSoundSources || []
     this.soundSources.value = []  // reactive array of sources
@@ -41,6 +47,11 @@ export default class AudioEngine {
     )
   }
 
+  /**
+   * Lazily create and return the shared `AudioContext` instance.
+   *
+   * @returns {AudioContext}
+   */
   getAudioContext() {
     // Lazily create the audio context and master gain node on first use.
     // Subsequent calls return the same context.
@@ -55,6 +66,9 @@ export default class AudioEngine {
     return this.#audioContext
   }
 
+  /**
+   * Re-create sound sources and register media session handlers.
+   */
   setupAudioEngine() {
     // Recreate `SoundSource` instances from any previously saved data and
     // register media session handlers so hardware play/pause keys work.
@@ -89,9 +103,13 @@ export default class AudioEngine {
     
   }
 
+  /**
+   * Create a new `SoundSource` instance from a library entry and insert it
+   * into the reactive `soundSources` array.
+   *
+   * @param {{src:Object, index?:number}} payload
+   */
   addSoundSource(payload) {
-    // Create a new `SoundSource` instance from a library entry and place it
-    // into the reactive `soundSources` array.
     if (this.maxSourceCountReached){
       window.alert(`Limit of ${this.#MAX_SOURCE_COUNT} sound${this.#MAX_SOURCE_COUNT == 1 ? '' : 's'} in room reached.`);
       return
@@ -145,6 +163,12 @@ export default class AudioEngine {
     this.#scheduleWatchers.set(sched.id, [enabledUnwatch, paramsUnwatch])
   }
 
+  /**
+   * Remove a `SoundSource` from the engine and clean up its audio nodes.
+   *
+   * @param {{index:number, src:Object}} payload
+   * @returns {?Object} serialized source data for undo
+   */
   deleteSoundSource(payload) {
     // Remove a `SoundSource` from the canvas and clean up its audio nodes.
     // The index logic is defensive to handle stale state from undo/redo.
@@ -179,6 +203,9 @@ export default class AudioEngine {
   }
 
 
+  /**
+   * Start playback of all sound sources and initialise scheduling.
+   */
   playAll() {
     // Ensure the context is running then start every source. This also updates
     // the Media Session API so system controls display the correct state.
@@ -217,6 +244,9 @@ export default class AudioEngine {
   }
   
 
+  /**
+   * Pause all active sound sources and suspend scheduling.
+   */
   pauseAll() {
     // Stop playback on all active sources and update the Media Session state.
     this.soundSources.value.forEach(s => {
@@ -232,6 +262,9 @@ export default class AudioEngine {
     
   }
 
+  /**
+   * Tear down all audio nodes and close the context.
+   */
   dispose() {
     // Tear down all nodes and close the audio context entirely.
     this.pauseAll()
@@ -249,21 +282,33 @@ export default class AudioEngine {
     }
   }
 
+  /**
+   * Set the maximum number of sound sources allowed in the room.
+   * @param {number} count
+   */
   set maxSourceCount(count){
     this.#MAX_SOURCE_COUNT = count
   }
+  /** @returns {number} */
   get maxSourceCount() {
     return this.#MAX_SOURCE_COUNT
   }
 
+  /** @returns {boolean} */
   get maxSourceCountReached(){
     return this.soundSourceCount == this.maxSourceCount
   }
 
+  /** @returns {number} */
   get soundSourceCount() {
     return this.soundSources.value.length
   }
   
+  /**
+   * Serialise the engine state so it can be saved.
+   *
+   * @returns {Object}
+   */
   toJSON() {
     // Serialize the minimal state required to recreate the engine and all
     // currently loaded sources. This is used when saving a room layout.
@@ -293,6 +338,12 @@ export default class AudioEngine {
     }
   }
 
+  /**
+   * Rehydrate an AudioEngine instance from JSON produced by {@link toJSON}.
+   *
+   * @param {Object} json
+   * @returns {AudioEngine}
+   */
   static fromJSON(json) {
     // Rehydrate an AudioEngine instance from data produced by `toJSON`.
     let engine = null;

--- a/src/lib/SoundSource.js
+++ b/src/lib/SoundSource.js
@@ -6,6 +6,16 @@
  * source so the canvas and audio remain in sync.
  */
 export default class SoundSource {
+  /**
+   * Create a new SoundSource wrapper.
+   *
+   * @param {Object} options
+   * @param {AudioContext} options.audioContext - context used for nodes
+   * @param {GainNode} options.masterGain - master gain node
+   * @param {string} options.file - URL or blob to load
+   * @param {Object} options.state - reactive state object
+   * @param {boolean} [options.loop=true] - loop playback by default
+   */
   constructor({
     audioContext,
     masterGain,
@@ -81,12 +91,14 @@ export default class SoundSource {
 
   }
 
+  /** Start playback of the audio element. */
   play() {
     this._audioElement.play();
     this.updateAudio();
     this._playing = true;
   }
 
+  /** Force playback from the start of the audio file. */
   forcePlayFromStart() {
     this._audioElement.currentTime = 0;
     this._audioElement.play();
@@ -94,24 +106,40 @@ export default class SoundSource {
     this._playing = true;
   }
 
+  /** Pause playback of the audio element. */
   stop() {
     this._audioElement.pause();
     this._playing = false;
   }
 
+  /**
+   * Whether the sound is currently playing.
+   * @returns {boolean}
+   */
   get playing() {
     return this._playing;
   }
 
+  /**
+   * Set the playback volume for this source.
+   * @param {number} v
+   */
   setVolume(v) {
     this._volume = v;
     this._audioElement.volume = v;
   }
 
+  /**
+   * Retrieve the current playback volume.
+   * @returns {number}
+   */
   getVolume() {
     return this._volume;
   }
 
+  /**
+   * Sync Web Audio panner position and orientation with the state used by the canvas.
+   */
   updateAudio() {
     // Sync the Web Audio panner with the state used by the canvas. Both
     // position and orientation are updated each time the source moves.
@@ -136,6 +164,9 @@ export default class SoundSource {
     }
   }
 
+  /**
+   * Gracefully disconnect and release all Web Audio nodes and associated resources.
+   */
   dispose() {
     // Gracefully disconnect and release all Web Audio nodes and the underlying
     // <audio> element when a source is removed from the room.


### PR DESCRIPTION
## Summary
- document canvas context menu logic
- add comprehensive JSDoc to `AudioEngine`
- add JSDoc for methods in `SoundSource`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68705cb44da4832fbc03ffb99822159a