### PR TITLE
Fix convolver hookup for reverb

### DIFF
--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -76,6 +76,13 @@ export default class AudioEngine {
 
       this.#convolver.connect(this.#reverbGain)
       this.#reverbGain.connect(this.#masterGain)
+
+      // Ensure any already-created sources are routed through the new convolver
+      this.soundSources.value.forEach(s => {
+        if (s.instance?.reverbSend) {
+          s.instance.reverbSend.connect(this.#convolver)
+        }
+      })
     }
 
     return this.#audioContext
@@ -139,7 +146,8 @@ export default class AudioEngine {
       state: src.state,
       loop: !src.state.schedule?.enabled,
     })
-    this.connectToReverb(instance.reverbSend)
+    // Route the new source through the reverb chain
+    this.connectToReverb(instance)
 
 
     src.instance = instance
@@ -220,18 +228,40 @@ export default class AudioEngine {
   }
 
   connectToReverb(node) {
-    if (this.#convolver) {
-      node.connect(this.#convolver)
+    // Ensure the convolver node exists then route the provided node through it
+    this.getAudioContext()
+
+    if (!this.#convolver || !node) return
+
+    try {
+      if (typeof node.connectReverb === 'function') {
+        node.connectReverb(this.#convolver)
+      } else if (typeof node.connect === 'function') {
+        node.connect(this.#convolver)
+      }
+    } catch (err) {
+      console.warn('Failed to connect node to convolver:', err)
     }
   }
 
 
   async loadImpulseResponse(irName, url) {
+    // Ensure audio context and convolver are ready
+    this.getAudioContext()
+
     const response = await fetch(url)
     const arrayBuffer = await response.arrayBuffer()
-    const audioBuffer = await this.getAudioContext().decodeAudioData(arrayBuffer)
+    const audioBuffer = await this.#audioContext.decodeAudioData(arrayBuffer)
+
     this.#convolver.buffer = audioBuffer
     this.#currentIRName = irName
+
+    // Reconnect all sources to ensure they use the new impulse
+    this.soundSources.value.forEach(s => {
+      if (s.instance?.connectReverb) {
+        s.instance.connectReverb(this.#convolver)
+      }
+    })
 
     console.log('Loaded IR:', irName, audioBuffer)
 
@@ -406,11 +436,11 @@ export default class AudioEngine {
         }
 
         const presetName = json.reverb.preset
-        const url = '/impulses/1st_baptist_nashville_far_wide.wav'
+        const url = IR_PRESETS[presetName]
         if (url) {
-          engine.getAudioContext(); // force context setup early
+          engine.getAudioContext() // ensure nodes exist
           setTimeout(() => {
-            engine.loadImpulseResponse('Mi Blood', url)
+            engine.loadImpulseResponse(presetName, url)
           }, 0)
         }
 

--- a/src/lib/SoundSource.js
+++ b/src/lib/SoundSource.js
@@ -102,6 +102,18 @@ export default class SoundSource {
 
   }
 
+  /**
+   * Connect this source's reverb send to the provided convolver.
+   * @param {AudioNode} convolver
+   */
+  connectReverb(convolver) {
+    try {
+      this.reverbSend.connect(convolver)
+    } catch (err) {
+      console.warn('Failed to connect reverb send:', err)
+    }
+  }
+
   /** Start playback of the audio element. */
   play() {
     this._audioElement.play();
@@ -191,10 +203,12 @@ export default class SoundSource {
       this._sourceNode?.disconnect()
       this._gainNode?.disconnect()
       this._pannerNode?.disconnect()
-  
+      this.reverbSend?.disconnect()
+
       this._sourceNode = null
       this._gainNode = null
       this._pannerNode = null
+      this.reverbSend = null
   
       this._audioContext = null
       this.state = null


### PR DESCRIPTION
## Summary
- hook up reverb sends when audio context is created
- add `connectReverb` method to `SoundSource`
- route sound sources through reverb on creation
- ensure impulse response loading reconnects sources
- load correct IR preset when restoring from JSON

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6872af34bd8c832fa9a1f8bf8ab77c1b