### PR TITLE
Add central Room class

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,7 @@ This document provides a high level overview of the major files and modules that
 - **Listener.js** – Represents the user's listening position in the room. It synchronises its orientation with the `AudioContext` listener so rotations and movements are heard correctly.
 - **ActionManager.js** – Provides undo and redo functionality. Actions are registered with handlers which are executed and stored on a stack for later reversal.
 - **SoundScheduler.js** – Handles interval based playback for sources that have a schedule enabled. It keeps track of timers and supports pausing/resuming when the engine is stopped.
-- **Room.js** – Simple container describing room dimensions and metadata with helper methods for clamping values and serialising to JSON.
+- **Room.js** – Central class that stores room dimensions and owns the `AudioEngine`, `Listener` and `SoundSource` instances. Provides helpers for clamping values, adding sources and serialising basic metadata.
 
 ## src/utils
 

--- a/src/lib/Room.js
+++ b/src/lib/Room.js
@@ -1,10 +1,19 @@
 // lib/Room.js
 
+import AudioEngine from './AudioEngine'
+import Listener from './Listener'
+
 export default class Room {
   width = 0
   height = 0
   name = ''
   id = null
+  /** @type {AudioEngine|null} */
+  audioEngine = null
+  /** @type {Listener|null} */
+  listener = null
+  /** @type {Array<any>} */
+  soundSources = []
 
   /**
    * Create a new room instance.
@@ -19,6 +28,61 @@ export default class Room {
     this.height = height
     this.name = name
     this.id = id
+    this.audioEngine = new AudioEngine([])
+    this.listener = new Listener()
+    this.soundSources = []
+  }
+
+  /**
+   * Assign an existing AudioEngine instance to this room.
+   * @param {AudioEngine} engine
+   */
+  setAudioEngine(engine) {
+    this.audioEngine = engine
+  }
+
+  /**
+   * Assign a listener instance to this room.
+   * @param {Listener} listener
+   */
+  setListener(listener) {
+    this.listener = listener
+  }
+
+  /**
+   * Add a sound source to the room and inform the source about its new context.
+   * @param {any} source
+   */
+  addSoundSource(source) {
+    if (!source) return
+    if (typeof source.setRoom === 'function') {
+      source.setRoom(this)
+    }
+    this.soundSources.push(source)
+  }
+
+  /**
+   * Remove a sound source from the room.
+   * @param {any} source
+   */
+  removeSoundSource(source) {
+    const i = this.soundSources.indexOf(source)
+    if (i !== -1) this.soundSources.splice(i, 1)
+  }
+
+  /**
+   * Update the room dimensions and notify sound sources.
+   * @param {number} width
+   * @param {number} height
+   */
+  updateRoomSize(width, height) {
+    this.width = width
+    this.height = height
+    this.soundSources.forEach(s => {
+      if (typeof s.onRoomResize === 'function') {
+        s.onRoomResize(width, height)
+      }
+    })
   }
 
   /**

--- a/src/lib/SoundSource.js
+++ b/src/lib/SoundSource.js
@@ -6,6 +6,8 @@
  * source so the canvas and audio remain in sync.
  */
 export default class SoundSource {
+  /** @type {import('./Room').default|null} */
+  _room = null
   /**
    * Create a new SoundSource wrapper.
    *
@@ -185,6 +187,24 @@ export default class SoundSource {
       p.setPosition(x, y, 0);
       p.setOrientation(Math.cos(angleRad), Math.sin(angleRad), 0);
     }
+  }
+
+  /**
+   * Provide a reference to the room this source belongs to.
+   * @param {import('./Room').default} room
+   */
+  setRoom(room) {
+    this._room = room
+  }
+
+  /**
+   * Optional hook for responding to room size changes.
+   * Currently a no-op but reserved for future use.
+   * @param {number} _width
+   * @param {number} _height
+   */
+  onRoomResize(_width, _height) {
+    // placeholder
   }
 
   /**


### PR DESCRIPTION
## Summary
- centralize audio state in Room class with audio engine, listener, and source management
- allow SoundSource to receive Room references via `setRoom` and optional resize hook
- document the new class in ARCHITECTURE.md

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873dde8a990832f95381cd68dc94b02