### PR TITLE
Fix scheduler pause/resume for individual sources

### DIFF
--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -289,7 +289,12 @@ export default class AudioEngine {
       return
     }
     if (src.instance.state.schedule?.enabled) {
-        this.#scheduler.updateSchedule(src.instance);
+        const schedId = src.instance.state.schedule.id;
+        if (this.#scheduler.pauseInfo.has(schedId) && this.#scheduler.pauseInfo.get(schedId).isPaused) {
+          this.#scheduler.resumeSource(src.instance);
+        } else {
+          this.#scheduler.updateSchedule(src.instance);
+        }
         src.instance._audioElement.loop = false
       } else {
         src.instance._audioElement.loop = true
@@ -304,7 +309,7 @@ export default class AudioEngine {
     }
     const sched = src.instance.state.schedule;
     if (sched?.enabled) {
-      this.#scheduler.cancelSchedule(src);
+      this.#scheduler.pauseSource(src.instance);
     }
     src.instance.stop();
   }
@@ -345,7 +350,6 @@ export default class AudioEngine {
       })
     }
     
-    this.isPlaying.value = true
   }
   
 

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -52,12 +52,23 @@ export default class SoundScheduler {
       return new Promise((resolve) => {
         const el = source._audioElement;
 
-        const onEnded = () => {
+        const cleanup = () => {
           el.removeEventListener('ended', onEnded);
+          el.removeEventListener('pause', onPause);
+        };
+
+        const onEnded = () => {
+          cleanup();
+          resolve();
+        };
+
+        const onPause = () => {
+          cleanup();
           resolve();
         };
 
         el.addEventListener('ended', onEnded);
+        el.addEventListener('pause', onPause);
 
         sched.isPlaying = true;
         source.forcePlayFromStart();
@@ -148,6 +159,58 @@ export default class SoundScheduler {
     }
   }
 
+  /**
+   * Pause scheduling for a single sound source.
+   * Stores remaining delay and stops any pending loop.
+   * @param {SoundSource} source
+   */
+  pauseSource(source) {
+    const sched = source.state.schedule;
+    const { id } = sched;
+    const info = this.pauseInfo.get(id);
+
+    if (!sched.enabled || !info) return;
+
+    if (sched.isPlaying) {
+      source._audioElement.pause();
+      sched.isPlaying = false;
+    }
+
+    const timeoutId = this.intervals.get(id);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+
+      const elapsed = performance.now() - (sched.lastPlayedAt * 1000 + this.roomStartTime);
+      info.remainingGapMs = Math.max(0, info.remainingGapMs - elapsed);
+      info.isPaused = true;
+      this.intervals.delete(id);
+    }
+
+    sched.stopCurrentLoop = true;
+  }
+
+  /**
+   * Resume scheduling for a single sound source that was paused.
+   * @param {SoundSource} source
+   */
+  resumeSource(source) {
+    const sched = source.state.schedule;
+    const { id } = sched;
+    const info = this.pauseInfo.get(id);
+
+    if (!sched.enabled || !info || !info.isPaused) return;
+
+    info.isPaused = false;
+    sched.stopCurrentLoop = false;
+
+    const resumeTimer = setTimeout(() => {
+      info.queuedLoop();
+    }, info.remainingGapMs);
+
+    info.resumeTimer = resumeTimer;
+    this.intervals.set(id, resumeTimer);
+  }
+
 
 
   /**
@@ -201,11 +264,19 @@ export default class SoundScheduler {
    * @param {SoundSource} source - the sound source to cancel
    */
   cancelSchedule(source) {
-    const id = this.intervals.get(source.state.schedule?.id);
+    const sched = source.state.schedule;
+    const id = this.intervals.get(sched?.id);
     if (id) {
       clearTimeout(id);
-      this.intervals.delete(source.state.schedule?.id);
+      this.intervals.delete(sched?.id);
     }
+
+    const info = this.pauseInfo.get(sched?.id);
+    if (info?.resumeTimer) {
+      clearTimeout(info.resumeTimer);
+    }
+
+    sched.stopCurrentLoop = true;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure scheduler's playAndWait resolves on pause
- add pauseSource/resumeSource helpers
- update cancelSchedule to fully stop loops
- use new scheduler helpers from AudioEngine

## Testing
- `npm run build`
- `npx playwright test`

------
https://chatgpt.com/codex/tasks/task_e_6876d37ae700832f839ef9d8f3b4c3bf