### PR TITLE
Fix scheduler pause/resume logic

### DIFF
--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -172,7 +172,7 @@ const playPauseLabel = computed(() =>
 
 const playPauseSource = () => {
   const src = selectedSource.value;
-  src.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
+  src.instance.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
 };
 
 const deleteSource = () => {

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -48,6 +48,16 @@ export default class SoundScheduler {
     const sched = source.state.schedule;
     const { id: scheduleId } = sched;
 
+    sched.loopFn = null;
+
+    // Ensure pause info exists so pausing before the first loop works
+    this.pauseInfo.set(scheduleId, {
+      remainingGapMs: 0,
+      isPaused: false,
+      resumeTimer: null,
+      queuedLoop: null,
+    });
+
     const playAndWait = async () => {
       return new Promise((resolve) => {
         const el = source._audioElement;
@@ -75,19 +85,18 @@ export default class SoundScheduler {
       });
     };
 
-    const loop = async () => {
-      const now = (performance.now() - this.roomStartTime) / 1000;
-      if (!sched.enabled) return;
+      const loop = async () => {
+        if (!sched.enabled) return;
 
-      await playAndWait();
-      sched.isPlaying = false;
+        await playAndWait();
+        sched.isPlaying = false;
 
-      if (sched.stopCurrentLoop) {
-        sched.stopCurrentLoop = false;
-        return;
-      }
-
-      sched.lastPlayedAt = now;
+        if (sched.stopCurrentLoop) {
+          sched.stopCurrentLoop = false;
+          return;
+        }
+        const now = (performance.now() - this.roomStartTime) / 1000;
+        sched.lastPlayedAt = now;
       sched.timesPlayed = (sched.timesPlayed || 0) + 1;
 
       if (sched.enabled) {
@@ -99,25 +108,36 @@ export default class SoundScheduler {
         this.intervals.set(scheduleId, timeoutId);
 
         // Save the delay in case we need to pause later
-        this.pauseInfo.set(scheduleId, {
-          remainingGapMs: nextGap,
-          isPaused: false,
-          resumeTimer: null,
-          queuedLoop: loop,
-        });
+        const info = this.pauseInfo.get(scheduleId) || {};
+        info.remainingGapMs = nextGap;
+        info.isPaused = false;
+        info.resumeTimer = null;
+        info.queuedLoop = loop;
+        this.pauseInfo.set(scheduleId, info);
       }
-    };
+      };
 
-    loop(); // kickoff
+      const initInfo = this.pauseInfo.get(scheduleId);
+      if (initInfo && !initInfo.queuedLoop) {
+        initInfo.queuedLoop = loop;
+      }
+
+      sched.loopFn = loop;
+
+      loop(); // kickoff
   }
 
   pause() {
     for (const source of this.audioEngine.soundSources.value) {
       const sched = source.state.schedule;
       const { id } = sched;
-      const info = this.pauseInfo.get(id);
+      let info = this.pauseInfo.get(id);
 
-      if (!sched.enabled || !info) continue;
+      if (!sched.enabled) continue;
+      if (!info) {
+        info = { remainingGapMs: 0, isPaused: false, resumeTimer: null, queuedLoop: sched.loopFn || null };
+        this.pauseInfo.set(id, info);
+      }
 
       // Pause audio if it's currently playing
       if (sched.isPlaying) {
@@ -167,9 +187,13 @@ export default class SoundScheduler {
   pauseSource(source) {
     const sched = source.state.schedule;
     const { id } = sched;
-    const info = this.pauseInfo.get(id);
+    let info = this.pauseInfo.get(id);
 
-    if (!sched.enabled || !info) return;
+    if (!sched.enabled) return;
+    if (!info) {
+      info = { remainingGapMs: 0, isPaused: false, resumeTimer: null, queuedLoop: sched.loopFn || null };
+      this.pauseInfo.set(id, info);
+    }
 
     if (sched.isPlaying) {
       source._audioElement.pause();
@@ -198,13 +222,24 @@ export default class SoundScheduler {
     const { id } = sched;
     const info = this.pauseInfo.get(id);
 
-    if (!sched.enabled || !info || !info.isPaused) return;
+    if (!sched.enabled) return;
+
+    if (!info) {
+      this._schedule(source);
+      return;
+    }
+
+    if (!info.isPaused) return;
 
     info.isPaused = false;
     sched.stopCurrentLoop = false;
 
     const resumeTimer = setTimeout(() => {
-      info.queuedLoop();
+      if (info.queuedLoop) {
+        info.queuedLoop();
+      } else {
+        this._schedule(source);
+      }
     }, info.remainingGapMs);
 
     info.resumeTimer = resumeTimer;

--- a/src/lib/SoundSource.js
+++ b/src/lib/SoundSource.js
@@ -47,7 +47,7 @@ export default class SoundSource {
 
       // Internal state
       timesPlayed: 0,
-      isPlaying: true, // whether the sound is currently playing
+      isPlaying: false, // whether the sound is currently playing
       lastPlayedAt: null,
     };
 


### PR DESCRIPTION
## Summary
- fix Play/Pause toggle in SelectedSourcePanel
- correct default `isPlaying` value for sound scheduling
- improve SoundScheduler pause/resume logic to handle early pauses
- record correct playback times for scheduling

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876d7f96630832fa3a38d2b382de1ed