### PR TITLE
Fix scheduler pause/resume logic

### DIFF
--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -166,13 +166,23 @@ const schedulingEnabled = computed({
 
 const { onStart, onChange, onEnd } = useVolumeSlider(selectedSource, actionManager);
 
-const playPauseLabel = computed(() =>
-  selectedSource.value.instance.playing ? "Pause" : "Play"
-);
+const playPauseLabel = computed(() => {
+  const src = selectedSource.value;
+  const sched = src.instance.state.schedule;
+  if (sched.enabled) {
+    return sched.paused ? 'Play' : 'Pause';
+  }
+  return src.instance.playing ? 'Pause' : 'Play';
+});
 
 const playPauseSource = () => {
   const src = selectedSource.value;
-  src.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
+  const sched = src.instance.state.schedule;
+  if (sched.enabled) {
+    sched.paused ? audioEngineStore.playSoundSource(src) : audioEngineStore.pauseSoundSource(src);
+  } else {
+    src.instance.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
+  }
 };
 
 const deleteSource = () => {

--- a/src/composables/useContextMenuLogic.js
+++ b/src/composables/useContextMenuLogic.js
@@ -32,12 +32,22 @@ export function useContextMenuLogic(selectedSource) {
 
   const contextMenuActions = [
     {
-      label: computed(() =>
-        selectedSource.value?.instance.playing ? 'Pause' : 'Play'
-      ),
+      label: computed(() => {
+        const src = selectedSource.value;
+        const sched = src?.instance.state.schedule;
+        if (sched?.enabled) {
+          return sched.paused ? 'Play' : 'Pause';
+        }
+        return src?.instance.playing ? 'Pause' : 'Play';
+      }),
       function: () => {
         const src = selectedSource.value;
-        src.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
+        const sched = src.instance.state.schedule;
+        if (sched.enabled) {
+          sched.paused ? audioEngineStore.playSoundSource(src) : audioEngineStore.pauseSoundSource(src);
+        } else {
+          src.instance.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
+        }
       },
     },
     {

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -32,6 +32,7 @@ export default class SoundScheduler {
     for (const wrapper of this.audioEngine.soundSources.value) {
       const src = wrapper.instance;
       if (src.state.schedule?.enabled) {
+        src.state.schedule.paused = false;
         src.state.schedule.timesPlayed = 0; // reset play count
         this._schedule(src);
       }
@@ -47,6 +48,17 @@ export default class SoundScheduler {
   _schedule(source) {
     const sched = source.state.schedule;
     const { id: scheduleId } = sched;
+
+    sched.loopFn = null;
+    sched.paused = false;
+
+    // Ensure pause info exists so pausing before the first loop works
+    this.pauseInfo.set(scheduleId, {
+      remainingGapMs: 0,
+      isPaused: false,
+      resumeTimer: null,
+      queuedLoop: null,
+    });
 
     const playAndWait = async () => {
       return new Promise((resolve) => {
@@ -75,19 +87,18 @@ export default class SoundScheduler {
       });
     };
 
-    const loop = async () => {
-      const now = (performance.now() - this.roomStartTime) / 1000;
-      if (!sched.enabled) return;
+      const loop = async () => {
+        if (!sched.enabled) return;
 
-      await playAndWait();
-      sched.isPlaying = false;
+        await playAndWait();
+        sched.isPlaying = false;
 
-      if (sched.stopCurrentLoop) {
-        sched.stopCurrentLoop = false;
-        return;
-      }
-
-      sched.lastPlayedAt = now;
+        if (sched.stopCurrentLoop) {
+          sched.stopCurrentLoop = false;
+          return;
+        }
+        const now = (performance.now() - this.roomStartTime) / 1000;
+        sched.lastPlayedAt = now;
       sched.timesPlayed = (sched.timesPlayed || 0) + 1;
 
       if (sched.enabled) {
@@ -99,25 +110,38 @@ export default class SoundScheduler {
         this.intervals.set(scheduleId, timeoutId);
 
         // Save the delay in case we need to pause later
-        this.pauseInfo.set(scheduleId, {
-          remainingGapMs: nextGap,
-          isPaused: false,
-          resumeTimer: null,
-          queuedLoop: loop,
-        });
+        const info = this.pauseInfo.get(scheduleId) || {};
+        info.remainingGapMs = nextGap;
+        info.isPaused = false;
+        info.resumeTimer = null;
+        info.queuedLoop = loop;
+        this.pauseInfo.set(scheduleId, info);
       }
-    };
+      };
 
-    loop(); // kickoff
+      const initInfo = this.pauseInfo.get(scheduleId);
+      if (initInfo && !initInfo.queuedLoop) {
+        initInfo.queuedLoop = loop;
+      }
+
+      sched.loopFn = loop;
+
+      loop(); // kickoff
   }
 
   pause() {
     for (const source of this.audioEngine.soundSources.value) {
       const sched = source.state.schedule;
       const { id } = sched;
-      const info = this.pauseInfo.get(id);
+      let info = this.pauseInfo.get(id);
 
-      if (!sched.enabled || !info) continue;
+      if (!sched.enabled) continue;
+      if (!info) {
+        info = { remainingGapMs: 0, isPaused: false, resumeTimer: null, queuedLoop: sched.loopFn || null };
+        this.pauseInfo.set(id, info);
+      }
+
+      sched.paused = true;
 
       // Pause audio if it's currently playing
       if (sched.isPlaying) {
@@ -147,6 +171,8 @@ export default class SoundScheduler {
 
       if (!sched.enabled || !info || !info.isPaused) continue;
 
+      sched.paused = false;
+
       info.isPaused = false;
 
       // Resume loop after the remaining delay
@@ -167,9 +193,13 @@ export default class SoundScheduler {
   pauseSource(source) {
     const sched = source.state.schedule;
     const { id } = sched;
-    const info = this.pauseInfo.get(id);
+    let info = this.pauseInfo.get(id);
 
-    if (!sched.enabled || !info) return;
+    if (!sched.enabled) return;
+    if (!info) {
+      info = { remainingGapMs: 0, isPaused: false, resumeTimer: null, queuedLoop: sched.loopFn || null };
+      this.pauseInfo.set(id, info);
+    }
 
     if (sched.isPlaying) {
       source._audioElement.pause();
@@ -187,6 +217,7 @@ export default class SoundScheduler {
     }
 
     sched.stopCurrentLoop = true;
+    sched.paused = true;
   }
 
   /**
@@ -198,13 +229,25 @@ export default class SoundScheduler {
     const { id } = sched;
     const info = this.pauseInfo.get(id);
 
-    if (!sched.enabled || !info || !info.isPaused) return;
+    if (!sched.enabled) return;
+
+    if (!info) {
+      this._schedule(source);
+      return;
+    }
+
+    if (!info.isPaused) return;
 
     info.isPaused = false;
     sched.stopCurrentLoop = false;
+    sched.paused = false;
 
     const resumeTimer = setTimeout(() => {
-      info.queuedLoop();
+      if (info.queuedLoop) {
+        info.queuedLoop();
+      } else {
+        this._schedule(source);
+      }
     }, info.remainingGapMs);
 
     info.resumeTimer = resumeTimer;

--- a/src/lib/SoundSource.js
+++ b/src/lib/SoundSource.js
@@ -1,4 +1,5 @@
 // lib/SoundSource.js
+import { ref } from 'vue';
 
 /**
  * Wrapper around a DOM `<audio>` element and the Web Audio nodes used to
@@ -47,8 +48,9 @@ export default class SoundSource {
 
       // Internal state
       timesPlayed: 0,
-      isPlaying: true, // whether the sound is currently playing
+      isPlaying: false, // whether the sound is currently playing
       lastPlayedAt: null,
+      paused: false,
     };
 
 
@@ -95,7 +97,7 @@ export default class SoundSource {
 
     this.outputNode.connect(this.reverbSend) // split the signal for reverb
 
-    this._playing = false;
+    this._playing = ref(false);
     this._volume = this.state.volume ?? 1; // default to 1 if not set
 
     this._audioElement.addEventListener('play', this._onPlay);
@@ -106,15 +108,15 @@ export default class SoundSource {
 
   }
   _onPlay = () => {
-    this._playing = true;
+    this._playing.value = true;
   };
 
   _onPause = () => {
-    this._playing = false;
+    this._playing.value = false;
   };
 
   _onEnded = () => {
-    this._playing = false;
+    this._playing.value = false;
   };
 
   /**
@@ -152,7 +154,7 @@ export default class SoundSource {
    * @returns {boolean}
    */
   get playing() {
-    return this._playing;
+    return this._playing.value;
   }
 
   /**


### PR DESCRIPTION
## Summary
- refactor SoundSource `_playing` to a `ref` for reactivity
- track paused state on each scheduling config
- update scheduler methods to maintain `schedule.paused`
- wire pause/resume buttons to scheduling state

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876d7f96630832fa3a38d2b382de1ed