### PR TITLE
Fix scheduler pause/resume logic

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -108,7 +108,7 @@ const emit = defineEmits(['select'])
 const sched = computed(() => props.source.instance.state.schedule)
 const isScheduled = computed(() => sched.value?.enabled)
 const isScheduledPlaying = computed(() => sched.value?.isPlaying)
-const sourceIsPlaying = computed(() => props.source.instance.playing);
+const sourceIsPlaying = computed(() => props.source.instance.playing.value);
 
 const getFillColor = computed(() => {
   if (props.selected) return '#ff0' // Yellow for selected node

--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -108,7 +108,7 @@ const emit = defineEmits(['select'])
 const sched = computed(() => props.source.instance.state.schedule)
 const isScheduled = computed(() => sched.value?.enabled)
 const isScheduledPlaying = computed(() => sched.value?.isPlaying)
-const sourceIsPlaying = computed(() => props.source.instance.playing.value);
+const sourceIsPlaying = computed(() => props.source.instance.playing);
 
 const getFillColor = computed(() => {
   if (props.selected) return '#ff0' // Yellow for selected node

--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -172,7 +172,7 @@ const playPauseLabel = computed(() => {
   if (sched.enabled) {
     return sched.paused ? 'Play' : 'Pause';
   }
-  return src.instance.playing.value ? 'Pause' : 'Play';
+  return src.instance.playing ? 'Pause' : 'Play';
 });
 
 const playPauseSource = () => {
@@ -181,7 +181,7 @@ const playPauseSource = () => {
   if (sched.enabled) {
     sched.paused ? audioEngineStore.playSoundSource(src) : audioEngineStore.pauseSoundSource(src);
   } else {
-    src.instance.playing.value ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
+    src.instance.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
   }
 };
 

--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -172,7 +172,7 @@ const playPauseLabel = computed(() => {
   if (sched.enabled) {
     return sched.paused ? 'Play' : 'Pause';
   }
-  return src.instance.playing ? 'Pause' : 'Play';
+  return src.instance.playing.value ? 'Pause' : 'Play';
 });
 
 const playPauseSource = () => {
@@ -181,7 +181,7 @@ const playPauseSource = () => {
   if (sched.enabled) {
     sched.paused ? audioEngineStore.playSoundSource(src) : audioEngineStore.pauseSoundSource(src);
   } else {
-    src.instance.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
+    src.instance.playing.value ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
   }
 };
 

--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -166,13 +166,23 @@ const schedulingEnabled = computed({
 
 const { onStart, onChange, onEnd } = useVolumeSlider(selectedSource, actionManager);
 
-const playPauseLabel = computed(() =>
-  selectedSource.value.instance.playing ? "Pause" : "Play"
-);
+const playPauseLabel = computed(() => {
+  const src = selectedSource.value;
+  const sched = src.instance.state.schedule;
+  if (sched.enabled) {
+    return sched.paused ? 'Play' : 'Pause';
+  }
+  return src.instance.playing ? 'Pause' : 'Play';
+});
 
 const playPauseSource = () => {
   const src = selectedSource.value;
-  src.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
+  const sched = src.instance.state.schedule;
+  if (sched.enabled) {
+    sched.paused ? audioEngineStore.playSoundSource(src) : audioEngineStore.pauseSoundSource(src);
+  } else {
+    src.instance.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
+  }
 };
 
 const deleteSource = () => {

--- a/src/composables/useContextMenuLogic.js
+++ b/src/composables/useContextMenuLogic.js
@@ -38,7 +38,7 @@ export function useContextMenuLogic(selectedSource) {
         if (sched?.enabled) {
           return sched.paused ? 'Play' : 'Pause';
         }
-        return src?.instance.playing ? 'Pause' : 'Play';
+        return src?.instance.playing.value ? 'Pause' : 'Play';
       }),
       function: () => {
         const src = selectedSource.value;
@@ -46,7 +46,7 @@ export function useContextMenuLogic(selectedSource) {
         if (sched.enabled) {
           sched.paused ? audioEngineStore.playSoundSource(src) : audioEngineStore.pauseSoundSource(src);
         } else {
-          src.instance.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
+          src.instance.playing.value ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
         }
       },
     },

--- a/src/composables/useContextMenuLogic.js
+++ b/src/composables/useContextMenuLogic.js
@@ -32,12 +32,22 @@ export function useContextMenuLogic(selectedSource) {
 
   const contextMenuActions = [
     {
-      label: computed(() =>
-        selectedSource.value?.instance.playing ? 'Pause' : 'Play'
-      ),
+      label: computed(() => {
+        const src = selectedSource.value;
+        const sched = src?.instance.state.schedule;
+        if (sched?.enabled) {
+          return sched.paused ? 'Play' : 'Pause';
+        }
+        return src?.instance.playing ? 'Pause' : 'Play';
+      }),
       function: () => {
         const src = selectedSource.value;
-        src.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
+        const sched = src.instance.state.schedule;
+        if (sched.enabled) {
+          sched.paused ? audioEngineStore.playSoundSource(src) : audioEngineStore.pauseSoundSource(src);
+        } else {
+          src.instance.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
+        }
       },
     },
     {

--- a/src/composables/useContextMenuLogic.js
+++ b/src/composables/useContextMenuLogic.js
@@ -38,7 +38,7 @@ export function useContextMenuLogic(selectedSource) {
         if (sched?.enabled) {
           return sched.paused ? 'Play' : 'Pause';
         }
-        return src?.instance.playing.value ? 'Pause' : 'Play';
+        return src?.instance.playing ? 'Pause' : 'Play';
       }),
       function: () => {
         const src = selectedSource.value;
@@ -46,7 +46,7 @@ export function useContextMenuLogic(selectedSource) {
         if (sched.enabled) {
           sched.paused ? audioEngineStore.playSoundSource(src) : audioEngineStore.pauseSoundSource(src);
         } else {
-          src.instance.playing.value ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
+          src.instance.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
         }
       },
     },

--- a/src/composables/useSaveAndLoadRoom.js
+++ b/src/composables/useSaveAndLoadRoom.js
@@ -5,9 +5,6 @@ import { useAudioCacheStore } from "@/stores/useAudioCacheStore";
 import { useActionManagerStore } from "@/stores/useActionManagerStore";
 import { useCanvasStore } from "@/stores/useCanvasStore";
 import { storeToRefs } from "pinia";
-import Room from '@/lib/Room'
-import Listener from '@/lib/Listener'
-import AudioEngine from '@/lib/AudioEngine'
 
 import { supabase } from "@/utils/supabase";
 import { downloadMultipleAudio } from "@/utils/downloadAudio";
@@ -315,9 +312,9 @@ export function useSaveAndLoadRoom() {
       audioEngine.value.dispose();
       listener.value.dispose();
 
-      room.value = Room.fromJSON(roomData.room);
-      listener.value = Listener.fromJSON(roomData.listener);
-      audioEngine.value = AudioEngine.fromJSON(roomData.audioEngine);
+      roomStore.loadRoom(roomData.room);
+      listenerStore.loadListener(roomData.listener);
+      audioEngineStore.loadAudioEngine(roomData.audioEngine);
 
       audioEngineStore.setupAudioContext();
     }

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -203,7 +203,12 @@ export default class AudioEngine {
           } else {
             this.#scheduler.cancelSchedule(instance)
             instance.play()
+            this.updateIsPlaying()
           }
+        } else if (!enabled) {
+          // Scheduler isn't active so just ensure manual looping resumes
+          instance.play()
+          this.updateIsPlaying()
         }
       },
       { immediate: true }

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -201,7 +201,9 @@ export default class AudioEngine {
         const schedulerActive = this.#scheduler.roomStartTime !== null && !this.#scheduler.isPaused
         if (!enabled) {
           this.#scheduler.cancelSchedule(instance)
-          instance.play()
+          if (schedulerActive) {
+            instance.play()
+          }
           this.updateIsPlaying()
         } else if (schedulerActive) {
           this.#scheduler.updateSchedule(instance)

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -57,12 +57,8 @@ export default class AudioEngine {
       this.soundSources.value.some(src => {
         if (!src.instance) return false
         const sched = src.instance.state.schedule
-        if (sched?.enabled) {
-          // Consider the engine playing if a schedule is active or the source
-          // itself is currently playing
-          return src.instance.playing.value || (!sched.paused && this.#scheduler.roomStartTime !== null)
-        }
-        return src.instance.playing.value
+        
+        return src.instance.playing
       })
     )
 
@@ -188,7 +184,7 @@ export default class AudioEngine {
     if (this.#audioContext?.state === 'suspended') {
       this.#audioContext.resume()
     }
-    if (!src.instance.state.schedule?.enabled && instance.playing.value) {
+    if (!src.instance.state.schedule?.enabled && instance.playing) {
       instance.play()
     }
     
@@ -463,7 +459,7 @@ export default class AudioEngine {
             angle: src.instance.state.angle,
             coneInner: src.instance.state.coneInner,
             coneOuter: src.instance.state.coneOuter,
-            isPlaying: src.instance.playing.value,
+            isPlaying: src.instance.playing,
             volume: src.instance?.getVolume?.() ?? 1,
             schedule: src.instance.state.schedule
           }

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -49,8 +49,11 @@ export default class AudioEngine {
       }
     })
 
-    // Computed: tracks if anything is playing
-    this.isPlaying = computed(() =>
+    // Reactive flag: true while playback is active via playAll()
+    this.isPlaying = ref(false)
+
+    // Computed helper to know if any source audio is currently audible
+    this.isAudioPlaying = computed(() =>
       this.soundSources.value.some(s => s.instance?.playing)
     )
   }
@@ -333,6 +336,8 @@ export default class AudioEngine {
     } else {
       this.#scheduler.resume(); // resume from pause
     }
+
+    this.isPlaying.value = true
   
     if ('mediaSession' in navigator) {
       navigator.mediaSession.playbackState = 'playing'
@@ -362,6 +367,8 @@ export default class AudioEngine {
       this.pauseSoundSource(s) // pause each source
     })
     this.#scheduler.pause();
+
+    this.isPlaying.value = false
     
     if ('mediaSession' in navigator) {
       navigator.mediaSession.playbackState = 'paused'

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -49,12 +49,19 @@ export default class AudioEngine {
       }
     })
 
-    // Reactive flag: true while playback is active via playAll()
+    // Reactive flag reflecting whether the engine has any active playback
     this.isPlaying = ref(false)
 
-    // Computed helper to know if any source audio is currently audible
+    // Computed helper to check if any source is currently audible or scheduled
     this.isAudioPlaying = computed(() =>
-      this.soundSources.value.some(s => s.instance?.playing)
+      this.soundSources.value.some(src => {
+        if (!src.instance) return false
+        const sched = src.instance.state.schedule
+        if (sched?.enabled) {
+          return !sched.paused
+        }
+        return src.instance.playing
+      })
     )
   }
 
@@ -264,6 +271,11 @@ export default class AudioEngine {
     }
   }
 
+  /** Update the reactive playback flag based on current sources */
+  updateIsPlaying() {
+    this.isPlaying.value = this.isAudioPlaying.value
+  }
+
 
   async loadImpulseResponse(irName, url) {
     // Ensure audio context and convolver are ready
@@ -303,6 +315,7 @@ export default class AudioEngine {
         src.instance._audioElement.loop = true
         src.instance?.play?.()
       }
+    this.updateIsPlaying()
   }
 
   pauseSoundSource(src) {
@@ -315,6 +328,7 @@ export default class AudioEngine {
       this.#scheduler.pauseSource(src.instance);
     }
     src.instance.stop();
+    this.updateIsPlaying()
   }
 
 
@@ -329,7 +343,9 @@ export default class AudioEngine {
     }
   
     this.soundSources.value.forEach(s => {
-      this.playSoundSource(s) // play each source
+      if (!s.instance.state.schedule?.enabled) {
+        this.playSoundSource(s)
+      }
     })
     if (this.#scheduler.roomStartTime === null) {
       this.#scheduler.start(); // initial start
@@ -337,7 +353,7 @@ export default class AudioEngine {
       this.#scheduler.resume(); // resume from pause
     }
 
-    this.isPlaying.value = true
+    this.updateIsPlaying()
   
     if ('mediaSession' in navigator) {
       navigator.mediaSession.playbackState = 'playing'
@@ -368,7 +384,7 @@ export default class AudioEngine {
     })
     this.#scheduler.pause();
 
-    this.isPlaying.value = false
+    this.updateIsPlaying()
     
     if ('mediaSession' in navigator) {
       navigator.mediaSession.playbackState = 'paused'

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -63,6 +63,11 @@ export default class AudioEngine {
         return src.instance.playing
       })
     )
+
+    // Keep the public flag in sync with the computed value so UI updates
+    watch(this.isAudioPlaying, (v) => {
+      this.isPlaying.value = v
+    }, { immediate: true })
   }
 
   /**

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -58,7 +58,9 @@ export default class AudioEngine {
         if (!src.instance) return false
         const sched = src.instance.state.schedule
         if (sched?.enabled) {
-          return !sched.paused
+          // Consider the engine playing if a schedule is active or the source
+          // itself is currently playing
+          return src.instance.playing || (!sched.paused && this.#scheduler.roomStartTime !== null)
         }
         return src.instance.playing
       })

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -196,7 +196,8 @@ export default class AudioEngine {
       () => sched.enabled,
       (enabled) => {
         instance._audioElement.loop = !enabled
-        if (this.isPlaying.value) {
+        const schedulerActive = this.#scheduler.roomStartTime !== null && !this.#scheduler.isPaused
+        if (schedulerActive) {
           if (enabled) {
             this.#scheduler.updateSchedule(instance)
           } else {
@@ -211,7 +212,8 @@ export default class AudioEngine {
     const paramsUnwatch = watch(
       () => [sched.gapMin, sched.gapMax, sched.activeStart, sched.activeEnd, sched.count, sched.mode],
       () => {
-        if (this.isPlaying.value && sched.enabled) {
+        const schedulerActive = this.#scheduler.roomStartTime !== null && !this.#scheduler.isPaused
+        if (schedulerActive && sched.enabled) {
           this.#scheduler.updateSchedule(instance)
         }
       }

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -199,18 +199,12 @@ export default class AudioEngine {
       (enabled) => {
         instance._audioElement.loop = !enabled
         const schedulerActive = this.#scheduler.roomStartTime !== null && !this.#scheduler.isPaused
-        if (schedulerActive) {
-          if (enabled) {
-            this.#scheduler.updateSchedule(instance)
-          } else {
-            this.#scheduler.cancelSchedule(instance)
-            instance.play()
-            this.updateIsPlaying()
-          }
-        } else if (!enabled) {
-          // Scheduler isn't active so just ensure manual looping resumes
+        if (!enabled) {
+          this.#scheduler.cancelSchedule(instance)
           instance.play()
           this.updateIsPlaying()
+        } else if (schedulerActive) {
+          this.#scheduler.updateSchedule(instance)
         }
       },
       { immediate: true }

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -501,9 +501,9 @@ export default class AudioEngine {
           index: src.index,
           src: {
             libraryId: src.libraryId,
-            name: src.name,  
-            state: src.instance.state,
-            audioPath: src.audioPath, 
+            name: src.name,
+            state: reactive({ ...src.instance.state }),
+            audioPath: src.audioPath,
           }
         }))
       engine = new AudioEngine(uninitializedSoundSources, json.masterVolume ?? 1)

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -404,6 +404,14 @@ export default class AudioEngine {
   dispose() {
     // Tear down all nodes and close the audio context entirely.
     this.pauseAll()
+
+    // Stop all scheduler timers and remove reactive watchers
+    this.#scheduler.stop()
+    this.#scheduleWatchers.forEach(watchers => {
+      watchers.forEach(unwatch => unwatch())
+    })
+    this.#scheduleWatchers.clear()
+
     this.soundSources.value.forEach(s => s.instance.dispose())
     this.soundSources.value.length = 0
   

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -60,9 +60,9 @@ export default class AudioEngine {
         if (sched?.enabled) {
           // Consider the engine playing if a schedule is active or the source
           // itself is currently playing
-          return src.instance.playing || (!sched.paused && this.#scheduler.roomStartTime !== null)
+          return src.instance.playing.value || (!sched.paused && this.#scheduler.roomStartTime !== null)
         }
-        return src.instance.playing
+        return src.instance.playing.value
       })
     )
 
@@ -188,7 +188,7 @@ export default class AudioEngine {
     if (this.#audioContext?.state === 'suspended') {
       this.#audioContext.resume()
     }
-    if (!src.instance.state.schedule?.enabled && instance.isPlaying) {
+    if (!src.instance.state.schedule?.enabled && instance.playing.value) {
       instance.play()
     }
     
@@ -246,7 +246,7 @@ export default class AudioEngine {
     const watchers = this.#scheduleWatchers.get(schedId)
     watchers?.forEach(unwatch => unwatch())
     this.#scheduleWatchers.delete(schedId)
-    this.#scheduler.cancelSchedule(src)
+    this.#scheduler.cancelSchedule(src.instance)
 
     if (!src) {
       console.warn("Tried to delete sound source but index", index, "was invalid.")
@@ -461,7 +461,7 @@ export default class AudioEngine {
             angle: src.instance.state.angle,
             coneInner: src.instance.state.coneInner,
             coneOuter: src.instance.state.coneOuter,
-            isPlaying: src.instance.playing,
+            isPlaying: src.instance.playing.value,
             volume: src.instance?.getVolume?.() ?? 1,
             schedule: src.instance.state.schedule
           }

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -24,6 +24,9 @@ export default class SoundScheduler {
     // can be started immediately when playback is active
     this.isPaused = true;
 
+    // Flag to indicate when the scheduler is fully stopped
+    this._stopped = true;
+
   }
 
   /**
@@ -33,6 +36,7 @@ export default class SoundScheduler {
   start() {
     this.roomStartTime = performance.now();
     this.isPaused = false;
+    this._stopped = false;
 
     for (const wrapper of this.audioEngine.soundSources.value) {
       const src = wrapper.instance;
@@ -52,6 +56,7 @@ export default class SoundScheduler {
    * @param {SoundSource} source - the sound source with a scheduling config
    */
   _schedule(source) {
+    if (this._stopped) return;
     const sched = source.state.schedule;
     const { id: scheduleId } = sched;
 
@@ -95,20 +100,22 @@ export default class SoundScheduler {
     };
 
       const loop = async () => {
-        if (!sched.enabled) return;
+        if (this._stopped || !sched.enabled) return;
 
         await playAndWait();
+        if (this._stopped) return;
         sched.isPlaying = false;
 
         if (sched.stopCurrentLoop) {
           sched.stopCurrentLoop = false;
           return;
         }
+        if (this._stopped) return;
         const now = (performance.now() - this.roomStartTime) / 1000;
         sched.lastPlayedAt = now;
       sched.timesPlayed = (sched.timesPlayed || 0) + 1;
 
-      if (sched.enabled) {
+      if (sched.enabled && !this._stopped) {
         const min = sched.mode == "loop" ? 0 : sched.gapMin;
         const max = sched.mode == "loop" ? 0 : sched.gapMax;
         const nextGap = randomInRange(min, max) * 1000;
@@ -279,10 +286,12 @@ export default class SoundScheduler {
    */
   stop() {
     this.isPaused = true;
+    this._stopped = true;
     for (const id of this.intervals.values()) {
       clearTimeout(id);
     }
     this.intervals.clear();
+    this.pauseInfo.clear();
   }
 
   /**

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -1,363 +1,186 @@
 // SoundScheduler.js
 
 /**
- * A standalone Scheduler class that manages timed playback of scheduled sound sources
- * from an AudioEngine instance. Each scheduled sound is played at a random interval
- * within its configured min/max gap, and only during its active playback window.
+ * Scheduler for interval-based sound playback.
+ * Handles play/pause/resume for multiple SoundSource instances.
  */
 export default class SoundScheduler {
   /**
-   * @param {AudioEngine} audioEngine - a reference to the main AudioEngine instance
+   * @param {import('./AudioEngine').default} audioEngine
    */
   constructor(audioEngine) {
     this.audioEngine = audioEngine;
-
-    // Map of active timeouts: key = sound's libraryId, value = timeout ID
-    this.intervals = new Map();
-
-    // Time when scheduling started, used to calculate relative play windows
+    this.timers = new Map();
+    this.pauseInfo = new Map(); // scheduleId -> {remainingMs, expectedTime, loop, isPaused}
     this.roomStartTime = null;
-
-    this.pauseInfo = new Map(); // key = scheduleId, value = pause data
-
-    // Track whether scheduling is currently paused so newly enabled schedules
-    // can be started immediately when playback is active
     this.isPaused = true;
-
-    // Flag to indicate when the scheduler is fully stopped
     this._stopped = true;
-
   }
 
-  /**
-   * Starts scheduling for all sound sources that have scheduling enabled.
-   * This should be called when the room starts playing.
-   */
+  /** Start scheduling for all enabled sources */
   start() {
     this.roomStartTime = performance.now();
     this.isPaused = false;
     this._stopped = false;
-
     for (const wrapper of this.audioEngine.soundSources.value) {
       const src = wrapper.instance;
       if (src.state.schedule?.enabled) {
-        src.state.schedule.paused = false;
-        src.state.schedule.stopCurrentLoop = false;
-        src.state.schedule.timesPlayed = 0; // reset play count
-        this._schedule(src);
+        const sched = src.state.schedule;
+        sched.timesPlayed = 0;
+        sched.paused = false;
+        this._schedule(src, 0);
       }
     }
   }
 
-
-  /**
-   * Internal method: sets up a self-repeating timeout loop for a scheduled sound source.
-   * Plays the sound if within the allowed time window, then re-schedules itself.
-   * @param {SoundSource} source - the sound source with a scheduling config
-   */
-  _schedule(source) {
+  /** Internal helper to schedule a single source */
+  _schedule(source, delayMs = 0) {
     if (this._stopped) return;
     const sched = source.state.schedule;
-    const { id: scheduleId } = sched;
+    const scheduleId = sched.id;
 
-    sched.loopFn = null;
-    sched.paused = false;
-    sched.stopCurrentLoop = false;
+    const run = async () => {
+      if (this._stopped || !sched.enabled) return;
+      const nowSec = (performance.now() - this.roomStartTime) / 1000;
+      const within = nowSec >= sched.activeStart && nowSec <= sched.activeEnd;
+      const countOk = sched.count == null || sched.timesPlayed < sched.count;
 
-    // Ensure pause info exists so pausing before the first loop works
-    this.pauseInfo.set(scheduleId, {
-      remainingGapMs: 0,
-      isPaused: false,
-      resumeTimer: null,
-      queuedLoop: null,
-    });
+      if (within && countOk) {
+        await this._playAndWait(source);
+        if (this._stopped) return;
+        sched.timesPlayed++;
+        sched.lastPlayedAt = nowSec;
+      }
 
-    const playAndWait = async () => {
-      return new Promise((resolve) => {
-        const el = source._audioElement;
-
-        const cleanup = () => {
-          el.removeEventListener('ended', onEnded);
-          el.removeEventListener('pause', onPause);
-        };
-
-        const onEnded = () => {
-          cleanup();
-          resolve();
-        };
-
-        const onPause = () => {
-          cleanup();
-          resolve();
-        };
-
-        el.addEventListener('ended', onEnded);
-        el.addEventListener('pause', onPause);
-
-        sched.isPlaying = true;
-        source.forcePlayFromStart();
-      });
+      if (this._stopped || !sched.enabled) return;
+      if (countOk && nowSec <= sched.activeEnd) {
+        const nextGap = sched.mode === 'loop' ? 0 : randomInRange(sched.gapMin, sched.gapMax) * 1000;
+        this._schedule(source, nextGap);
+      }
     };
 
-      const loop = async () => {
-        if (this._stopped || !sched.enabled) return;
+    const timeoutId = setTimeout(run, delayMs);
+    this.timers.set(scheduleId, timeoutId);
+    this.pauseInfo.set(scheduleId, {
+      remainingMs: delayMs,
+      expectedTime: performance.now() + delayMs,
+      loop: run,
+      isPaused: false,
+    });
+  }
 
-        await playAndWait();
-        if (this._stopped) return;
-        sched.isPlaying = false;
-
-        if (sched.stopCurrentLoop) {
-          sched.stopCurrentLoop = false;
-          return;
-        }
-        if (this._stopped) return;
-        const now = (performance.now() - this.roomStartTime) / 1000;
-        sched.lastPlayedAt = now;
-      sched.timesPlayed = (sched.timesPlayed || 0) + 1;
-
-      if (sched.enabled && !this._stopped) {
-        const min = sched.mode == "loop" ? 0 : sched.gapMin;
-        const max = sched.mode == "loop" ? 0 : sched.gapMax;
-        const nextGap = randomInRange(min, max) * 1000;
-
-        const timeoutId = setTimeout(loop, nextGap);
-        this.intervals.set(scheduleId, timeoutId);
-
-        // Save the delay in case we need to pause later
-        const info = this.pauseInfo.get(scheduleId) || {};
-        info.remainingGapMs = nextGap;
-        info.isPaused = false;
-        info.resumeTimer = null;
-        info.queuedLoop = loop;
-        this.pauseInfo.set(scheduleId, info);
-      }
+  /** Play audio and wait for it to finish */
+  async _playAndWait(source) {
+    return new Promise((resolve) => {
+      const el = source._audioElement;
+      const cleanup = () => {
+        el.removeEventListener('ended', onEnded);
+        el.removeEventListener('pause', onPause);
+        resolve();
       };
-
-      const initInfo = this.pauseInfo.get(scheduleId);
-      if (initInfo && !initInfo.queuedLoop) {
-        initInfo.queuedLoop = loop;
-      }
-
-      sched.loopFn = loop;
-
-      loop(); // kickoff
+      const onEnded = () => cleanup();
+      const onPause = () => cleanup();
+      el.addEventListener('ended', onEnded);
+      el.addEventListener('pause', onPause);
+      source.forcePlayFromStart();
+    });
   }
 
+  /** Pause all scheduled sounds */
   pause() {
+    if (this.isPaused) return;
     this.isPaused = true;
-    for (const source of this.audioEngine.soundSources.value) {
-      const sched = source.state.schedule;
-      const { id } = sched;
-      let info = this.pauseInfo.get(id);
-
-      if (!sched.enabled) continue;
-      if (!info) {
-        info = { remainingGapMs: 0, isPaused: false, resumeTimer: null, queuedLoop: sched.loopFn || null };
-        this.pauseInfo.set(id, info);
-      }
-
-      sched.paused = true;
-
-      // Pause audio if it's currently playing
-      if (sched.isPlaying) {
-        source.instance._audioElement.pause();
-        sched.isPlaying = false;
-      }
-
-      // Cancel upcoming loop timeout
-      const timeoutId = this.intervals.get(id);
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-
-        // Save remaining delay time for resume
-        const last = sched.lastPlayedAt ?? 0;
-        const elapsed = performance.now() - (last * 1000 + this.roomStartTime);
-        info.remainingGapMs = Math.max(0, info.remainingGapMs - elapsed);
-        info.isPaused = true;
-        this.intervals.delete(id);
-      }
+    for (const wrapper of this.audioEngine.soundSources.value) {
+      this.pauseSource(wrapper.instance);
     }
   }
 
+  /** Resume all scheduled sounds */
   resume() {
+    if (!this.isPaused) return;
     this.isPaused = false;
-    for (const source of this.audioEngine.soundSources.value) {
-      const sched = source.state.schedule;
-      const { id } = sched;
-      const info = this.pauseInfo.get(id);
-
-      if (!sched.enabled) continue;
-      if (!info) {
-        this._schedule(source);
-        continue;
-      }
-      if (!info.isPaused) continue;
-
-      sched.paused = false;
-      sched.stopCurrentLoop = false;
-
-      info.isPaused = false;
-
-      // Resume loop after the remaining delay
-      const resumeTimer = setTimeout(() => {
-        info.queuedLoop();
-      }, info.remainingGapMs);
-
-      info.resumeTimer = resumeTimer;
-      this.intervals.set(id, resumeTimer);
+    for (const wrapper of this.audioEngine.soundSources.value) {
+      this.resumeSource(wrapper.instance);
     }
   }
 
-  /**
-   * Pause scheduling for a single sound source.
-   * Stores remaining delay and stops any pending loop.
-   * @param {SoundSource} source
-   */
+  /** Pause a single source */
   pauseSource(source) {
     const sched = source.state.schedule;
-    const { id } = sched;
-    let info = this.pauseInfo.get(id);
-
     if (!sched.enabled) return;
+    const id = sched.id;
+    const timer = this.timers.get(id);
+    let info = this.pauseInfo.get(id);
     if (!info) {
-      info = { remainingGapMs: 0, isPaused: false, resumeTimer: null, queuedLoop: sched.loopFn || null };
-      this.pauseInfo.set(id, info);
+      info = { remainingMs: 0, expectedTime: performance.now(), loop: null, isPaused: false };
     }
-
+    if (timer) {
+      clearTimeout(timer);
+      this.timers.delete(id);
+      info.remainingMs = Math.max(0, info.expectedTime - performance.now());
+    }
+    info.isPaused = true;
+    this.pauseInfo.set(id, info);
     if (sched.isPlaying) {
       source._audioElement.pause();
       sched.isPlaying = false;
     }
-
-    const timeoutId = this.intervals.get(id);
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-
-      const last = sched.lastPlayedAt ?? 0;
-      const elapsed = performance.now() - (last * 1000 + this.roomStartTime);
-      info.remainingGapMs = Math.max(0, info.remainingGapMs - elapsed);
-      info.isPaused = true;
-      this.intervals.delete(id);
-    }
-
-    sched.stopCurrentLoop = true;
     sched.paused = true;
   }
 
-  /**
-   * Resume scheduling for a single sound source that was paused.
-   * @param {SoundSource} source
-   */
+  /** Resume a single paused source */
   resumeSource(source) {
     const sched = source.state.schedule;
-    const { id } = sched;
-    const info = this.pauseInfo.get(id);
-
     if (!sched.enabled) return;
-
+    const id = sched.id;
+    const info = this.pauseInfo.get(id);
     if (!info) {
-      this._schedule(source);
+      this._schedule(source, 0);
       return;
     }
-
     if (!info.isPaused) return;
-
+    const timeoutId = setTimeout(info.loop || (() => this._schedule(source, 0)), info.remainingMs);
+    info.expectedTime = performance.now() + info.remainingMs;
     info.isPaused = false;
-    sched.stopCurrentLoop = false;
+    this.timers.set(id, timeoutId);
+    this.pauseInfo.set(id, info);
     sched.paused = false;
-
-    const resumeTimer = setTimeout(() => {
-      if (info.queuedLoop) {
-        info.queuedLoop();
-      } else {
-        this._schedule(source);
-      }
-    }, info.remainingGapMs);
-
-    info.resumeTimer = resumeTimer;
-    this.intervals.set(id, resumeTimer);
   }
 
-
-
-  /**
-   * Stops all active scheduling loops and clears their timers.
-   * This should be called when the room stops or pauses.
-   */
+  /** Completely stop scheduling */
   stop() {
     this.isPaused = true;
     this._stopped = true;
-    for (const id of this.intervals.values()) {
+    for (const id of this.timers.values()) {
       clearTimeout(id);
     }
-    this.intervals.clear();
+    this.timers.clear();
     this.pauseInfo.clear();
   }
 
-  /**
-   * Updates the schedule for a given source (e.g., after the user changes settings).
-   * Clears the old timeout and starts a fresh one with new settings.
-   * @param {SoundSource} source - the updated sound source
-   */
+  /** Update schedule settings for a sound */
   updateSchedule(source) {
-    const sched = source.state.schedule;
-    const forceRestart = sched.restart;
-
-
-    this.cancelSchedule(source); // stop any pending timers
-
-    if (!forceRestart && sched.isPlaying) {
-      // Defer restart until current audio finishes
-      if (!sched.pendingUpdate) {
-        sched.stopCurrentLoop = true;
-        sched.pendingUpdate = true;
-
-        const el = source._audioElement;
-        const onEnded = () => {
-          el.removeEventListener('ended', onEnded);
-          sched.pendingUpdate = false;
-          if (sched.enabled) {
-            this._schedule(source);
-          }
-        };
-
-        el.addEventListener('ended', onEnded);
-      }
-    } else if (sched.enabled) {
-      this._schedule(source); // restart or start with new config
+    this.cancelSchedule(source);
+    if (source.state.schedule?.enabled && !this._stopped) {
+      this._schedule(source, 0);
     }
   }
 
-  /**
-   * Cancels a specific sound's scheduling loop, if it exists.
-   * @param {SoundSource} source - the sound source to cancel
-   */
+  /** Cancel scheduling for a sound */
   cancelSchedule(source) {
     const sched = source.state.schedule;
-    const id = this.intervals.get(sched?.id);
-    if (id) {
-      clearTimeout(id);
-      this.intervals.delete(sched?.id);
+    const id = sched.id;
+    const timer = this.timers.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      this.timers.delete(id);
     }
-
-    const info = this.pauseInfo.get(sched?.id);
-    if (info?.resumeTimer) {
-      clearTimeout(info.resumeTimer);
-    }
-    // Reset any scheduling state so the sound can loop manually
-    sched.stopCurrentLoop = true;
+    this.pauseInfo.delete(id);
     sched.paused = false;
     sched.isPlaying = false;
-    sched.loopFn = null;
-    this.pauseInfo.delete(sched?.id);
   }
 }
 
-/**
- * Utility function: returns a random number between min and max (inclusive)
- * @param {number} min - minimum value
- * @param {number} max - maximum value
- */
 function randomInRange(min, max) {
   return Math.random() * (max - min) + min;
 }

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -179,7 +179,12 @@ export default class SoundScheduler {
       const { id } = sched;
       const info = this.pauseInfo.get(id);
 
-      if (!sched.enabled || !info || !info.isPaused) continue;
+      if (!sched.enabled) continue;
+      if (!info) {
+        this._schedule(source);
+        continue;
+      }
+      if (!info.isPaused) continue;
 
       sched.paused = false;
       sched.stopCurrentLoop = false;

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -330,8 +330,12 @@ export default class SoundScheduler {
     if (info?.resumeTimer) {
       clearTimeout(info.resumeTimer);
     }
-
+    // Reset any scheduling state so the sound can loop manually
     sched.stopCurrentLoop = true;
+    sched.paused = false;
+    sched.isPlaying = false;
+    sched.loopFn = null;
+    this.pauseInfo.delete(sched?.id);
   }
 }
 

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -42,7 +42,7 @@ export default class SoundScheduler {
     const run = async () => {
       if (this._stopped || !sched.enabled) return;
       const nowSec = (performance.now() - this.roomStartTime) / 1000;
-      const within = nowSec >= sched.activeStart && nowSec <= sched.activeEnd;
+      const within = (sched.activeStart === null && sched.activeEnd === null) || (nowSec >= sched.activeStart && nowSec <= sched.activeEnd);
       const countOk = sched.count == null || sched.timesPlayed < sched.count;
 
       if (within && countOk) {
@@ -53,7 +53,7 @@ export default class SoundScheduler {
       }
 
       if (this._stopped || !sched.enabled) return;
-      if (countOk && nowSec <= sched.activeEnd) {
+      if (countOk && (sched.activeEnd === null || nowSec <= sched.activeEnd)) {
         const nextGap = sched.mode === 'loop' ? 0 : randomInRange(sched.gapMin, sched.gapMax) * 1000;
         this._schedule(source, nextGap);
       }

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -33,6 +33,7 @@ export default class SoundScheduler {
       const src = wrapper.instance;
       if (src.state.schedule?.enabled) {
         src.state.schedule.paused = false;
+        src.state.schedule.stopCurrentLoop = false;
         src.state.schedule.timesPlayed = 0; // reset play count
         this._schedule(src);
       }
@@ -173,6 +174,7 @@ export default class SoundScheduler {
       if (!sched.enabled || !info || !info.isPaused) continue;
 
       sched.paused = false;
+      sched.stopCurrentLoop = false;
 
       info.isPaused = false;
 

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -57,6 +57,7 @@ export default class SoundScheduler {
 
     sched.loopFn = null;
     sched.paused = false;
+    sched.stopCurrentLoop = false;
 
     // Ensure pause info exists so pausing before the first loop works
     this.pauseInfo.set(scheduleId, {
@@ -288,7 +289,6 @@ export default class SoundScheduler {
     const sched = source.state.schedule;
     const forceRestart = sched.restart;
 
-    console.log(sched)
 
     this.cancelSchedule(source); // stop any pending timers
 

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -73,13 +73,16 @@ export default class SoundScheduler {
   async _playAndWait(source) {
     return new Promise((resolve) => {
       const el = source._audioElement;
+      const sched = source.state.schedule;
       const cleanup = () => {
         el.removeEventListener('ended', onEnded);
         el.removeEventListener('pause', onPause);
+        sched.isPlaying = false;
         resolve();
       };
       const onEnded = () => cleanup();
       const onPause = () => cleanup();
+      sched.isPlaying = true;
       el.addEventListener('ended', onEnded);
       el.addEventListener('pause', onPause);
       source.forcePlayFromStart();

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -155,7 +155,8 @@ export default class SoundScheduler {
         clearTimeout(timeoutId);
 
         // Save remaining delay time for resume
-        const elapsed = performance.now() - (sched.lastPlayedAt * 1000 + this.roomStartTime);
+        const last = sched.lastPlayedAt ?? 0;
+        const elapsed = performance.now() - (last * 1000 + this.roomStartTime);
         info.remainingGapMs = Math.max(0, info.remainingGapMs - elapsed);
         info.isPaused = true;
         this.intervals.delete(id);
@@ -210,7 +211,8 @@ export default class SoundScheduler {
     if (timeoutId) {
       clearTimeout(timeoutId);
 
-      const elapsed = performance.now() - (sched.lastPlayedAt * 1000 + this.roomStartTime);
+      const last = sched.lastPlayedAt ?? 0;
+      const elapsed = performance.now() - (last * 1000 + this.roomStartTime);
       info.remainingGapMs = Math.max(0, info.remainingGapMs - elapsed);
       info.isPaused = true;
       this.intervals.delete(id);

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -20,6 +20,10 @@ export default class SoundScheduler {
 
     this.pauseInfo = new Map(); // key = scheduleId, value = pause data
 
+    // Track whether scheduling is currently paused so newly enabled schedules
+    // can be started immediately when playback is active
+    this.isPaused = true;
+
   }
 
   /**
@@ -28,6 +32,7 @@ export default class SoundScheduler {
    */
   start() {
     this.roomStartTime = performance.now();
+    this.isPaused = false;
 
     for (const wrapper of this.audioEngine.soundSources.value) {
       const src = wrapper.instance;
@@ -131,6 +136,7 @@ export default class SoundScheduler {
   }
 
   pause() {
+    this.isPaused = true;
     for (const source of this.audioEngine.soundSources.value) {
       const sched = source.state.schedule;
       const { id } = sched;
@@ -166,6 +172,7 @@ export default class SoundScheduler {
   }
 
   resume() {
+    this.isPaused = false;
     for (const source of this.audioEngine.soundSources.value) {
       const sched = source.state.schedule;
       const { id } = sched;
@@ -265,6 +272,7 @@ export default class SoundScheduler {
    * This should be called when the room stops or pauses.
    */
   stop() {
+    this.isPaused = true;
     for (const id of this.intervals.values()) {
       clearTimeout(id);
     }

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -32,6 +32,7 @@ export default class SoundScheduler {
     for (const wrapper of this.audioEngine.soundSources.value) {
       const src = wrapper.instance;
       if (src.state.schedule?.enabled) {
+        src.state.schedule.paused = false;
         src.state.schedule.timesPlayed = 0; // reset play count
         this._schedule(src);
       }
@@ -47,6 +48,17 @@ export default class SoundScheduler {
   _schedule(source) {
     const sched = source.state.schedule;
     const { id: scheduleId } = sched;
+
+    sched.loopFn = null;
+    sched.paused = false;
+
+    // Ensure pause info exists so pausing before the first loop works
+    this.pauseInfo.set(scheduleId, {
+      remainingGapMs: 0,
+      isPaused: false,
+      resumeTimer: null,
+      queuedLoop: null,
+    });
 
     const playAndWait = async () => {
       return new Promise((resolve) => {
@@ -75,19 +87,18 @@ export default class SoundScheduler {
       });
     };
 
-    const loop = async () => {
-      const now = (performance.now() - this.roomStartTime) / 1000;
-      if (!sched.enabled) return;
+      const loop = async () => {
+        if (!sched.enabled) return;
 
-      await playAndWait();
-      sched.isPlaying = false;
+        await playAndWait();
+        sched.isPlaying = false;
 
-      if (sched.stopCurrentLoop) {
-        sched.stopCurrentLoop = false;
-        return;
-      }
-
-      sched.lastPlayedAt = now;
+        if (sched.stopCurrentLoop) {
+          sched.stopCurrentLoop = false;
+          return;
+        }
+        const now = (performance.now() - this.roomStartTime) / 1000;
+        sched.lastPlayedAt = now;
       sched.timesPlayed = (sched.timesPlayed || 0) + 1;
 
       if (sched.enabled) {
@@ -99,25 +110,38 @@ export default class SoundScheduler {
         this.intervals.set(scheduleId, timeoutId);
 
         // Save the delay in case we need to pause later
-        this.pauseInfo.set(scheduleId, {
-          remainingGapMs: nextGap,
-          isPaused: false,
-          resumeTimer: null,
-          queuedLoop: loop,
-        });
+        const info = this.pauseInfo.get(scheduleId) || {};
+        info.remainingGapMs = nextGap;
+        info.isPaused = false;
+        info.resumeTimer = null;
+        info.queuedLoop = loop;
+        this.pauseInfo.set(scheduleId, info);
       }
-    };
+      };
 
-    loop(); // kickoff
+      const initInfo = this.pauseInfo.get(scheduleId);
+      if (initInfo && !initInfo.queuedLoop) {
+        initInfo.queuedLoop = loop;
+      }
+
+      sched.loopFn = loop;
+
+      loop(); // kickoff
   }
 
   pause() {
     for (const source of this.audioEngine.soundSources.value) {
       const sched = source.state.schedule;
       const { id } = sched;
-      const info = this.pauseInfo.get(id);
+      let info = this.pauseInfo.get(id);
 
-      if (!sched.enabled || !info) continue;
+      if (!sched.enabled) continue;
+      if (!info) {
+        info = { remainingGapMs: 0, isPaused: false, resumeTimer: null, queuedLoop: sched.loopFn || null };
+        this.pauseInfo.set(id, info);
+      }
+
+      sched.paused = true;
 
       // Pause audio if it's currently playing
       if (sched.isPlaying) {
@@ -147,6 +171,8 @@ export default class SoundScheduler {
 
       if (!sched.enabled || !info || !info.isPaused) continue;
 
+      sched.paused = false;
+
       info.isPaused = false;
 
       // Resume loop after the remaining delay
@@ -167,9 +193,13 @@ export default class SoundScheduler {
   pauseSource(source) {
     const sched = source.state.schedule;
     const { id } = sched;
-    const info = this.pauseInfo.get(id);
+    let info = this.pauseInfo.get(id);
 
-    if (!sched.enabled || !info) return;
+    if (!sched.enabled) return;
+    if (!info) {
+      info = { remainingGapMs: 0, isPaused: false, resumeTimer: null, queuedLoop: sched.loopFn || null };
+      this.pauseInfo.set(id, info);
+    }
 
     if (sched.isPlaying) {
       source._audioElement.pause();
@@ -187,6 +217,7 @@ export default class SoundScheduler {
     }
 
     sched.stopCurrentLoop = true;
+    sched.paused = true;
   }
 
   /**
@@ -198,13 +229,25 @@ export default class SoundScheduler {
     const { id } = sched;
     const info = this.pauseInfo.get(id);
 
-    if (!sched.enabled || !info || !info.isPaused) return;
+    if (!sched.enabled) return;
+
+    if (!info) {
+      this._schedule(source);
+      return;
+    }
+
+    if (!info.isPaused) return;
 
     info.isPaused = false;
     sched.stopCurrentLoop = false;
+    sched.paused = false;
 
     const resumeTimer = setTimeout(() => {
-      info.queuedLoop();
+      if (info.queuedLoop) {
+        info.queuedLoop();
+      } else {
+        this._schedule(source);
+      }
     }, info.remainingGapMs);
 
     info.resumeTimer = resumeTimer;

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -283,6 +283,15 @@ export default class SoundScheduler {
       clearTimeout(id);
     }
     this.intervals.clear();
+
+    // Clear any pending resume timers so no callbacks fire after stopping
+    for (const info of this.pauseInfo.values()) {
+      if (info?.resumeTimer) {
+        clearTimeout(info.resumeTimer);
+      }
+    }
+    // Remove all pause information so timers cannot be revived
+    this.pauseInfo.clear();
   }
 
   /**

--- a/src/lib/SoundSource.js
+++ b/src/lib/SoundSource.js
@@ -135,6 +135,8 @@ export default class SoundSource {
   play() {
     this._audioElement.play();
     this.updateAudio();
+    // immediately flag as playing for reactive UI updates
+    this._playing.value = true;
   }
 
   /** Force playback from the start of the audio file. */
@@ -142,11 +144,13 @@ export default class SoundSource {
     this._audioElement.currentTime = 0;
     this._audioElement.play();
     this.updateAudio();
+    this._playing.value = true;
   }
 
   /** Pause playback of the audio element. */
   stop() {
     this._audioElement.pause();
+    this._playing.value = false;
   }
 
   /**

--- a/src/lib/SoundSource.js
+++ b/src/lib/SoundSource.js
@@ -97,6 +97,9 @@ export default class SoundSource {
 
     this.outputNode.connect(this.reverbSend) // split the signal for reverb
 
+    // `_playing` tracks whether the underlying audio element is currently
+    // playing. Historically this was a simple boolean so guard against any
+    // stale data by converting booleans to a Vue ref.
     this._playing = ref(false);
     this._volume = this.state.volume ?? 1; // default to 1 if not set
 
@@ -108,15 +111,27 @@ export default class SoundSource {
 
   }
   _onPlay = () => {
-    this._playing.value = true;
+    if (typeof this._playing === 'object') {
+      this._playing.value = true;
+    } else {
+      this._playing = true;
+    }
   };
 
   _onPause = () => {
-    this._playing.value = false;
+    if (typeof this._playing === 'object') {
+      this._playing.value = false;
+    } else {
+      this._playing = false;
+    }
   };
 
   _onEnded = () => {
-    this._playing.value = false;
+    if (typeof this._playing === 'object') {
+      this._playing.value = false;
+    } else {
+      this._playing = false;
+    }
   };
 
   /**
@@ -136,7 +151,11 @@ export default class SoundSource {
     this._audioElement.play();
     this.updateAudio();
     // immediately flag as playing for reactive UI updates
-    this._playing.value = true;
+    if (typeof this._playing === 'object') {
+      this._playing.value = true;
+    } else {
+      this._playing = true;
+    }
   }
 
   /** Force playback from the start of the audio file. */
@@ -144,13 +163,21 @@ export default class SoundSource {
     this._audioElement.currentTime = 0;
     this._audioElement.play();
     this.updateAudio();
-    this._playing.value = true;
+    if (typeof this._playing === 'object') {
+      this._playing.value = true;
+    } else {
+      this._playing = true;
+    }
   }
 
   /** Pause playback of the audio element. */
   stop() {
     this._audioElement.pause();
-    this._playing.value = false;
+    if (typeof this._playing === 'object') {
+      this._playing.value = false;
+    } else {
+      this._playing = false;
+    }
   }
 
   /**
@@ -158,7 +185,7 @@ export default class SoundSource {
    * @returns {boolean}
    */
   get playing() {
-    return this._playing.value;
+    return typeof this._playing === 'object' ? this._playing.value : this._playing;
   }
 
   /**

--- a/src/lib/SoundSource.js
+++ b/src/lib/SoundSource.js
@@ -1,4 +1,5 @@
 // lib/SoundSource.js
+import { ref } from 'vue';
 
 /**
  * Wrapper around a DOM `<audio>` element and the Web Audio nodes used to
@@ -47,8 +48,9 @@ export default class SoundSource {
 
       // Internal state
       timesPlayed: 0,
-      isPlaying: true, // whether the sound is currently playing
+      isPlaying: false, // whether the sound is currently playing
       lastPlayedAt: null,
+      paused: false,
     };
 
 
@@ -95,7 +97,7 @@ export default class SoundSource {
 
     this.outputNode.connect(this.reverbSend) // split the signal for reverb
 
-    this._playing = false;
+    this._playing = ref(false);
     this._volume = this.state.volume ?? 1; // default to 1 if not set
 
     this._audioElement.addEventListener('play', this._onPlay);
@@ -106,15 +108,15 @@ export default class SoundSource {
 
   }
   _onPlay = () => {
-    this._playing = true;
+    this._playing.value = true;
   };
 
   _onPause = () => {
-    this._playing = false;
+    this._playing.value = false;
   };
 
   _onEnded = () => {
-    this._playing = false;
+    this._playing.value = false;
   };
 
   /**
@@ -152,7 +154,7 @@ export default class SoundSource {
    * @returns {boolean}
    */
   get playing() {
-    return this._playing;
+    return this._playing.value;
   }
 
   /**

--- a/src/lib/SoundSource.js
+++ b/src/lib/SoundSource.js
@@ -97,10 +97,10 @@ export default class SoundSource {
 
     this.outputNode.connect(this.reverbSend) // split the signal for reverb
 
-    // `_playing` tracks whether the underlying audio element is currently
-    // playing. Historically this was a simple boolean so guard against any
-    // stale data by converting booleans to a Vue ref.
-    this._playing = ref(false);
+    // `playing` is a Vue ref tracking whether the underlying audio element is
+    // currently playing. Older data may serialise this as a boolean so we
+    // initialise from whatever is provided and normalise to a ref.
+    this._playing = ref(!!this.state.isPlaying);
     this._volume = this.state.volume ?? 1; // default to 1 if not set
 
     this._audioElement.addEventListener('play', this._onPlay);
@@ -111,27 +111,15 @@ export default class SoundSource {
 
   }
   _onPlay = () => {
-    if (typeof this._playing === 'object') {
-      this._playing.value = true;
-    } else {
-      this._playing = true;
-    }
+    this._playing.value = true;
   };
 
   _onPause = () => {
-    if (typeof this._playing === 'object') {
-      this._playing.value = false;
-    } else {
-      this._playing = false;
-    }
+    this._playing.value = false;
   };
 
   _onEnded = () => {
-    if (typeof this._playing === 'object') {
-      this._playing.value = false;
-    } else {
-      this._playing = false;
-    }
+    this._playing.value = false;
   };
 
   /**
@@ -151,11 +139,7 @@ export default class SoundSource {
     this._audioElement.play();
     this.updateAudio();
     // immediately flag as playing for reactive UI updates
-    if (typeof this._playing === 'object') {
-      this._playing.value = true;
-    } else {
-      this._playing = true;
-    }
+    this._playing.value = true;
   }
 
   /** Force playback from the start of the audio file. */
@@ -163,21 +147,13 @@ export default class SoundSource {
     this._audioElement.currentTime = 0;
     this._audioElement.play();
     this.updateAudio();
-    if (typeof this._playing === 'object') {
-      this._playing.value = true;
-    } else {
-      this._playing = true;
-    }
+    this._playing.value = true;
   }
 
   /** Pause playback of the audio element. */
   stop() {
     this._audioElement.pause();
-    if (typeof this._playing === 'object') {
-      this._playing.value = false;
-    } else {
-      this._playing = false;
-    }
+    this._playing.value = false;
   }
 
   /**
@@ -185,7 +161,7 @@ export default class SoundSource {
    * @returns {boolean}
    */
   get playing() {
-    return typeof this._playing === 'object' ? this._playing.value : this._playing;
+    return this._playing;
   }
 
   /**

--- a/src/lib/SoundSource.js
+++ b/src/lib/SoundSource.js
@@ -139,7 +139,11 @@ export default class SoundSource {
     this._audioElement.play();
     this.updateAudio();
     // immediately flag as playing for reactive UI updates
-    this._playing.value = true;
+    if (typeof this._playing === 'object' && 'value' in this._playing) {
+      this._playing.value = true;
+    } else {
+      this._playing = ref(true);
+    }
   }
 
   /** Force playback from the start of the audio file. */
@@ -147,13 +151,21 @@ export default class SoundSource {
     this._audioElement.currentTime = 0;
     this._audioElement.play();
     this.updateAudio();
-    this._playing.value = true;
+    if (typeof this._playing === 'object' && 'value' in this._playing) {
+      this._playing.value = true;
+    } else {
+      this._playing = ref(true);
+    }
   }
 
   /** Pause playback of the audio element. */
   stop() {
     this._audioElement.pause();
-    this._playing.value = false;
+    if (typeof this._playing === 'object' && 'value' in this._playing) {
+      this._playing.value = false;
+    } else {
+      this._playing = ref(false);
+    }
   }
 
   /**

--- a/src/lib/SoundSource.js
+++ b/src/lib/SoundSource.js
@@ -39,9 +39,9 @@ export default class SoundSource {
       gapMax: 10,
 
       // Applies to time-bound or count-based schedules
-      count: 5,           // null = unlimited
-      activeStart: 0,     // time window start (in seconds)
-      activeEnd: 300,     // time window end
+      count: null,           // null = unlimited
+      activeStart: null,     // time window start (in seconds) null = no limit
+      activeEnd: null,       // time window end (in seconds) null = no limit
 
       // Restart behaviour
       restart: false,     // force immediate restart when schedule changes

--- a/src/lib/SoundSource.js
+++ b/src/lib/SoundSource.js
@@ -100,7 +100,7 @@ export default class SoundSource {
     // `playing` is a Vue ref tracking whether the underlying audio element is
     // currently playing. Older data may serialise this as a boolean so we
     // initialise from whatever is provided and normalise to a ref.
-    this._playing = ref(!!this.state.isPlaying);
+    this._playing = ref(this.state.isPlaying);
     this._volume = this.state.volume ?? 1; // default to 1 if not set
 
     this._audioElement.addEventListener('play', this._onPlay);
@@ -138,12 +138,7 @@ export default class SoundSource {
   play() {
     this._audioElement.play();
     this.updateAudio();
-    // immediately flag as playing for reactive UI updates
-    if (typeof this._playing === 'object' && 'value' in this._playing) {
-      this._playing.value = true;
-    } else {
-      this._playing = ref(true);
-    }
+    this._playing.value = true;
   }
 
   /** Force playback from the start of the audio file. */
@@ -151,21 +146,13 @@ export default class SoundSource {
     this._audioElement.currentTime = 0;
     this._audioElement.play();
     this.updateAudio();
-    if (typeof this._playing === 'object' && 'value' in this._playing) {
-      this._playing.value = true;
-    } else {
-      this._playing = ref(true);
-    }
+    this._playing.value = true;
   }
 
   /** Pause playback of the audio element. */
   stop() {
     this._audioElement.pause();
-    if (typeof this._playing === 'object' && 'value' in this._playing) {
-      this._playing.value = false;
-    } else {
-      this._playing = ref(false);
-    }
+    this._playing.value = false;
   }
 
   /**
@@ -173,7 +160,7 @@ export default class SoundSource {
    * @returns {boolean}
    */
   get playing() {
-    return this._playing;
+    return this._playing.value;
   }
 
   /**


### PR DESCRIPTION
## Summary
- refactor SoundSource `_playing` to a `ref` for reactivity
- track paused state on each scheduling config
- update scheduler methods to maintain `schedule.paused`
- wire pause/resume buttons to scheduling state

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876d7f96630832fa3a38d2b382de1ed