### PR TITLE
Fix cleanup of scheduler on dispose

### DIFF
--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -404,6 +404,14 @@ export default class AudioEngine {
   dispose() {
     // Tear down all nodes and close the audio context entirely.
     this.pauseAll()
+
+    // Stop all scheduler timers and remove reactive watchers
+    this.#scheduler.stop()
+    this.#scheduleWatchers.forEach(watchers => {
+      watchers.forEach(unwatch => unwatch())
+    })
+    this.#scheduleWatchers.clear()
+
     this.soundSources.value.forEach(s => s.instance.dispose())
     this.soundSources.value.length = 0
   


### PR DESCRIPTION
## Summary
- stop the scheduler and unwatch reactive schedule watchers when disposing the audio engine
- keep cleaning up audio nodes and context

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68791fe3e250832fa043411cf3bc8284