### PR TITLE
Cancel resume timers on scheduler stop

### DIFF
--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -283,6 +283,15 @@ export default class SoundScheduler {
       clearTimeout(id);
     }
     this.intervals.clear();
+
+    // Clear any pending resume timers so no callbacks fire after stopping
+    for (const info of this.pauseInfo.values()) {
+      if (info?.resumeTimer) {
+        clearTimeout(info.resumeTimer);
+      }
+    }
+    // Remove all pause information so timers cannot be revived
+    this.pauseInfo.clear();
   }
 
   /**


### PR DESCRIPTION
## Summary
- when stopping scheduled playback, clear any pending resume timers
- empty pause info map so timers don't linger

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68792c747694832f8c687343b7c1fbf7