### PR TITLE
Refactor sound scheduler

### DIFF
--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -1,363 +1,186 @@
 // SoundScheduler.js
 
 /**
- * A standalone Scheduler class that manages timed playback of scheduled sound sources
- * from an AudioEngine instance. Each scheduled sound is played at a random interval
- * within its configured min/max gap, and only during its active playback window.
+ * Scheduler for interval-based sound playback.
+ * Handles play/pause/resume for multiple SoundSource instances.
  */
 export default class SoundScheduler {
   /**
-   * @param {AudioEngine} audioEngine - a reference to the main AudioEngine instance
+   * @param {import('./AudioEngine').default} audioEngine
    */
   constructor(audioEngine) {
     this.audioEngine = audioEngine;
-
-    // Map of active timeouts: key = sound's libraryId, value = timeout ID
-    this.intervals = new Map();
-
-    // Time when scheduling started, used to calculate relative play windows
+    this.timers = new Map();
+    this.pauseInfo = new Map(); // scheduleId -> {remainingMs, expectedTime, loop, isPaused}
     this.roomStartTime = null;
-
-    this.pauseInfo = new Map(); // key = scheduleId, value = pause data
-
-    // Track whether scheduling is currently paused so newly enabled schedules
-    // can be started immediately when playback is active
     this.isPaused = true;
-
-    // Flag to indicate when the scheduler is fully stopped
     this._stopped = true;
-
   }
 
-  /**
-   * Starts scheduling for all sound sources that have scheduling enabled.
-   * This should be called when the room starts playing.
-   */
+  /** Start scheduling for all enabled sources */
   start() {
     this.roomStartTime = performance.now();
     this.isPaused = false;
     this._stopped = false;
-
     for (const wrapper of this.audioEngine.soundSources.value) {
       const src = wrapper.instance;
       if (src.state.schedule?.enabled) {
-        src.state.schedule.paused = false;
-        src.state.schedule.stopCurrentLoop = false;
-        src.state.schedule.timesPlayed = 0; // reset play count
-        this._schedule(src);
+        const sched = src.state.schedule;
+        sched.timesPlayed = 0;
+        sched.paused = false;
+        this._schedule(src, 0);
       }
     }
   }
 
-
-  /**
-   * Internal method: sets up a self-repeating timeout loop for a scheduled sound source.
-   * Plays the sound if within the allowed time window, then re-schedules itself.
-   * @param {SoundSource} source - the sound source with a scheduling config
-   */
-  _schedule(source) {
+  /** Internal helper to schedule a single source */
+  _schedule(source, delayMs = 0) {
     if (this._stopped) return;
     const sched = source.state.schedule;
-    const { id: scheduleId } = sched;
+    const scheduleId = sched.id;
 
-    sched.loopFn = null;
-    sched.paused = false;
-    sched.stopCurrentLoop = false;
+    const run = async () => {
+      if (this._stopped || !sched.enabled) return;
+      const nowSec = (performance.now() - this.roomStartTime) / 1000;
+      const within = nowSec >= sched.activeStart && nowSec <= sched.activeEnd;
+      const countOk = sched.count == null || sched.timesPlayed < sched.count;
 
-    // Ensure pause info exists so pausing before the first loop works
-    this.pauseInfo.set(scheduleId, {
-      remainingGapMs: 0,
-      isPaused: false,
-      resumeTimer: null,
-      queuedLoop: null,
-    });
+      if (within && countOk) {
+        await this._playAndWait(source);
+        if (this._stopped) return;
+        sched.timesPlayed++;
+        sched.lastPlayedAt = nowSec;
+      }
 
-    const playAndWait = async () => {
-      return new Promise((resolve) => {
-        const el = source._audioElement;
-
-        const cleanup = () => {
-          el.removeEventListener('ended', onEnded);
-          el.removeEventListener('pause', onPause);
-        };
-
-        const onEnded = () => {
-          cleanup();
-          resolve();
-        };
-
-        const onPause = () => {
-          cleanup();
-          resolve();
-        };
-
-        el.addEventListener('ended', onEnded);
-        el.addEventListener('pause', onPause);
-
-        sched.isPlaying = true;
-        source.forcePlayFromStart();
-      });
+      if (this._stopped || !sched.enabled) return;
+      if (countOk && nowSec <= sched.activeEnd) {
+        const nextGap = sched.mode === 'loop' ? 0 : randomInRange(sched.gapMin, sched.gapMax) * 1000;
+        this._schedule(source, nextGap);
+      }
     };
 
-      const loop = async () => {
-        if (this._stopped || !sched.enabled) return;
+    const timeoutId = setTimeout(run, delayMs);
+    this.timers.set(scheduleId, timeoutId);
+    this.pauseInfo.set(scheduleId, {
+      remainingMs: delayMs,
+      expectedTime: performance.now() + delayMs,
+      loop: run,
+      isPaused: false,
+    });
+  }
 
-        await playAndWait();
-        if (this._stopped) return;
-        sched.isPlaying = false;
-
-        if (sched.stopCurrentLoop) {
-          sched.stopCurrentLoop = false;
-          return;
-        }
-        if (this._stopped) return;
-        const now = (performance.now() - this.roomStartTime) / 1000;
-        sched.lastPlayedAt = now;
-      sched.timesPlayed = (sched.timesPlayed || 0) + 1;
-
-      if (sched.enabled && !this._stopped) {
-        const min = sched.mode == "loop" ? 0 : sched.gapMin;
-        const max = sched.mode == "loop" ? 0 : sched.gapMax;
-        const nextGap = randomInRange(min, max) * 1000;
-
-        const timeoutId = setTimeout(loop, nextGap);
-        this.intervals.set(scheduleId, timeoutId);
-
-        // Save the delay in case we need to pause later
-        const info = this.pauseInfo.get(scheduleId) || {};
-        info.remainingGapMs = nextGap;
-        info.isPaused = false;
-        info.resumeTimer = null;
-        info.queuedLoop = loop;
-        this.pauseInfo.set(scheduleId, info);
-      }
+  /** Play audio and wait for it to finish */
+  async _playAndWait(source) {
+    return new Promise((resolve) => {
+      const el = source._audioElement;
+      const cleanup = () => {
+        el.removeEventListener('ended', onEnded);
+        el.removeEventListener('pause', onPause);
+        resolve();
       };
-
-      const initInfo = this.pauseInfo.get(scheduleId);
-      if (initInfo && !initInfo.queuedLoop) {
-        initInfo.queuedLoop = loop;
-      }
-
-      sched.loopFn = loop;
-
-      loop(); // kickoff
+      const onEnded = () => cleanup();
+      const onPause = () => cleanup();
+      el.addEventListener('ended', onEnded);
+      el.addEventListener('pause', onPause);
+      source.forcePlayFromStart();
+    });
   }
 
+  /** Pause all scheduled sounds */
   pause() {
+    if (this.isPaused) return;
     this.isPaused = true;
-    for (const source of this.audioEngine.soundSources.value) {
-      const sched = source.state.schedule;
-      const { id } = sched;
-      let info = this.pauseInfo.get(id);
-
-      if (!sched.enabled) continue;
-      if (!info) {
-        info = { remainingGapMs: 0, isPaused: false, resumeTimer: null, queuedLoop: sched.loopFn || null };
-        this.pauseInfo.set(id, info);
-      }
-
-      sched.paused = true;
-
-      // Pause audio if it's currently playing
-      if (sched.isPlaying) {
-        source.instance._audioElement.pause();
-        sched.isPlaying = false;
-      }
-
-      // Cancel upcoming loop timeout
-      const timeoutId = this.intervals.get(id);
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-
-        // Save remaining delay time for resume
-        const last = sched.lastPlayedAt ?? 0;
-        const elapsed = performance.now() - (last * 1000 + this.roomStartTime);
-        info.remainingGapMs = Math.max(0, info.remainingGapMs - elapsed);
-        info.isPaused = true;
-        this.intervals.delete(id);
-      }
+    for (const wrapper of this.audioEngine.soundSources.value) {
+      this.pauseSource(wrapper.instance);
     }
   }
 
+  /** Resume all scheduled sounds */
   resume() {
+    if (!this.isPaused) return;
     this.isPaused = false;
-    for (const source of this.audioEngine.soundSources.value) {
-      const sched = source.state.schedule;
-      const { id } = sched;
-      const info = this.pauseInfo.get(id);
-
-      if (!sched.enabled) continue;
-      if (!info) {
-        this._schedule(source);
-        continue;
-      }
-      if (!info.isPaused) continue;
-
-      sched.paused = false;
-      sched.stopCurrentLoop = false;
-
-      info.isPaused = false;
-
-      // Resume loop after the remaining delay
-      const resumeTimer = setTimeout(() => {
-        info.queuedLoop();
-      }, info.remainingGapMs);
-
-      info.resumeTimer = resumeTimer;
-      this.intervals.set(id, resumeTimer);
+    for (const wrapper of this.audioEngine.soundSources.value) {
+      this.resumeSource(wrapper.instance);
     }
   }
 
-  /**
-   * Pause scheduling for a single sound source.
-   * Stores remaining delay and stops any pending loop.
-   * @param {SoundSource} source
-   */
+  /** Pause a single source */
   pauseSource(source) {
     const sched = source.state.schedule;
-    const { id } = sched;
-    let info = this.pauseInfo.get(id);
-
     if (!sched.enabled) return;
+    const id = sched.id;
+    const timer = this.timers.get(id);
+    let info = this.pauseInfo.get(id);
     if (!info) {
-      info = { remainingGapMs: 0, isPaused: false, resumeTimer: null, queuedLoop: sched.loopFn || null };
-      this.pauseInfo.set(id, info);
+      info = { remainingMs: 0, expectedTime: performance.now(), loop: null, isPaused: false };
     }
-
+    if (timer) {
+      clearTimeout(timer);
+      this.timers.delete(id);
+      info.remainingMs = Math.max(0, info.expectedTime - performance.now());
+    }
+    info.isPaused = true;
+    this.pauseInfo.set(id, info);
     if (sched.isPlaying) {
       source._audioElement.pause();
       sched.isPlaying = false;
     }
-
-    const timeoutId = this.intervals.get(id);
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-
-      const last = sched.lastPlayedAt ?? 0;
-      const elapsed = performance.now() - (last * 1000 + this.roomStartTime);
-      info.remainingGapMs = Math.max(0, info.remainingGapMs - elapsed);
-      info.isPaused = true;
-      this.intervals.delete(id);
-    }
-
-    sched.stopCurrentLoop = true;
     sched.paused = true;
   }
 
-  /**
-   * Resume scheduling for a single sound source that was paused.
-   * @param {SoundSource} source
-   */
+  /** Resume a single paused source */
   resumeSource(source) {
     const sched = source.state.schedule;
-    const { id } = sched;
-    const info = this.pauseInfo.get(id);
-
     if (!sched.enabled) return;
-
+    const id = sched.id;
+    const info = this.pauseInfo.get(id);
     if (!info) {
-      this._schedule(source);
+      this._schedule(source, 0);
       return;
     }
-
     if (!info.isPaused) return;
-
+    const timeoutId = setTimeout(info.loop || (() => this._schedule(source, 0)), info.remainingMs);
+    info.expectedTime = performance.now() + info.remainingMs;
     info.isPaused = false;
-    sched.stopCurrentLoop = false;
+    this.timers.set(id, timeoutId);
+    this.pauseInfo.set(id, info);
     sched.paused = false;
-
-    const resumeTimer = setTimeout(() => {
-      if (info.queuedLoop) {
-        info.queuedLoop();
-      } else {
-        this._schedule(source);
-      }
-    }, info.remainingGapMs);
-
-    info.resumeTimer = resumeTimer;
-    this.intervals.set(id, resumeTimer);
   }
 
-
-
-  /**
-   * Stops all active scheduling loops and clears their timers.
-   * This should be called when the room stops or pauses.
-   */
+  /** Completely stop scheduling */
   stop() {
     this.isPaused = true;
     this._stopped = true;
-    for (const id of this.intervals.values()) {
+    for (const id of this.timers.values()) {
       clearTimeout(id);
     }
-    this.intervals.clear();
+    this.timers.clear();
     this.pauseInfo.clear();
   }
 
-  /**
-   * Updates the schedule for a given source (e.g., after the user changes settings).
-   * Clears the old timeout and starts a fresh one with new settings.
-   * @param {SoundSource} source - the updated sound source
-   */
+  /** Update schedule settings for a sound */
   updateSchedule(source) {
-    const sched = source.state.schedule;
-    const forceRestart = sched.restart;
-
-
-    this.cancelSchedule(source); // stop any pending timers
-
-    if (!forceRestart && sched.isPlaying) {
-      // Defer restart until current audio finishes
-      if (!sched.pendingUpdate) {
-        sched.stopCurrentLoop = true;
-        sched.pendingUpdate = true;
-
-        const el = source._audioElement;
-        const onEnded = () => {
-          el.removeEventListener('ended', onEnded);
-          sched.pendingUpdate = false;
-          if (sched.enabled) {
-            this._schedule(source);
-          }
-        };
-
-        el.addEventListener('ended', onEnded);
-      }
-    } else if (sched.enabled) {
-      this._schedule(source); // restart or start with new config
+    this.cancelSchedule(source);
+    if (source.state.schedule?.enabled && !this._stopped) {
+      this._schedule(source, 0);
     }
   }
 
-  /**
-   * Cancels a specific sound's scheduling loop, if it exists.
-   * @param {SoundSource} source - the sound source to cancel
-   */
+  /** Cancel scheduling for a sound */
   cancelSchedule(source) {
     const sched = source.state.schedule;
-    const id = this.intervals.get(sched?.id);
-    if (id) {
-      clearTimeout(id);
-      this.intervals.delete(sched?.id);
+    const id = sched.id;
+    const timer = this.timers.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      this.timers.delete(id);
     }
-
-    const info = this.pauseInfo.get(sched?.id);
-    if (info?.resumeTimer) {
-      clearTimeout(info.resumeTimer);
-    }
-    // Reset any scheduling state so the sound can loop manually
-    sched.stopCurrentLoop = true;
+    this.pauseInfo.delete(id);
     sched.paused = false;
     sched.isPlaying = false;
-    sched.loopFn = null;
-    this.pauseInfo.delete(sched?.id);
   }
 }
 
-/**
- * Utility function: returns a random number between min and max (inclusive)
- * @param {number} min - minimum value
- * @param {number} max - maximum value
- */
 function randomInRange(min, max) {
   return Math.random() * (max - min) + min;
 }


### PR DESCRIPTION
## Summary
- rebuild `SoundScheduler` with a simpler timer-based design
- keep pause/resume API used by `AudioEngine`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687931e02150832f8cd6366ebccc167d