### PR TITLE
Fix scheduler initialization when loading room

### DIFF
--- a/src/composables/useSaveAndLoadRoom.js
+++ b/src/composables/useSaveAndLoadRoom.js
@@ -5,9 +5,6 @@ import { useAudioCacheStore } from "@/stores/useAudioCacheStore";
 import { useActionManagerStore } from "@/stores/useActionManagerStore";
 import { useCanvasStore } from "@/stores/useCanvasStore";
 import { storeToRefs } from "pinia";
-import Room from '@/lib/Room'
-import Listener from '@/lib/Listener'
-import AudioEngine from '@/lib/AudioEngine'
 
 import { supabase } from "@/utils/supabase";
 import { downloadMultipleAudio } from "@/utils/downloadAudio";
@@ -315,9 +312,9 @@ export function useSaveAndLoadRoom() {
       audioEngine.value.dispose();
       listener.value.dispose();
 
-      room.value = Room.fromJSON(roomData.room);
-      listener.value = Listener.fromJSON(roomData.listener);
-      audioEngine.value = AudioEngine.fromJSON(roomData.audioEngine);
+      roomStore.loadRoom(roomData.room);
+      listenerStore.loadListener(roomData.listener);
+      audioEngineStore.loadAudioEngine(roomData.audioEngine);
 
       audioEngineStore.setupAudioContext();
     }

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -501,9 +501,9 @@ export default class AudioEngine {
           index: src.index,
           src: {
             libraryId: src.libraryId,
-            name: src.name,  
-            state: src.instance.state,
-            audioPath: src.audioPath, 
+            name: src.name,
+            state: reactive({ ...src.instance.state }),
+            audioPath: src.audioPath,
           }
         }))
       engine = new AudioEngine(uninitializedSoundSources, json.masterVolume ?? 1)

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -73,13 +73,16 @@ export default class SoundScheduler {
   async _playAndWait(source) {
     return new Promise((resolve) => {
       const el = source._audioElement;
+      const sched = source.state.schedule;
       const cleanup = () => {
         el.removeEventListener('ended', onEnded);
         el.removeEventListener('pause', onPause);
+        sched.isPlaying = false;
         resolve();
       };
       const onEnded = () => cleanup();
       const onPause = () => cleanup();
+      sched.isPlaying = true;
       el.addEventListener('ended', onEnded);
       el.addEventListener('pause', onPause);
       source.forcePlayFromStart();


### PR DESCRIPTION
## Summary
- load room data using store helpers so the computed `audioEngine` ref updates correctly
- rehydrate `SoundScheduler` state reactively when loading a room

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68793ff19f90832f9e1b56427c009915