### PR TITLE
Show scheduled sounds playing during gaps

### DIFF
--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -33,6 +33,7 @@ export default class SoundScheduler {
       const src = wrapper.instance;
       if (src.state.schedule?.enabled) {
         src.state.schedule.timesPlayed = 0; // reset play count
+        src.state.schedule.paused = false;
         this._schedule(src);
       }
     }
@@ -49,6 +50,7 @@ export default class SoundScheduler {
     const { id: scheduleId } = sched;
 
     sched.loopFn = null;
+    sched.paused = false;
 
     // Ensure pause info exists so pausing before the first loop works
     this.pauseInfo.set(scheduleId, {
@@ -139,6 +141,8 @@ export default class SoundScheduler {
         this.pauseInfo.set(id, info);
       }
 
+      sched.paused = true;
+
       // Pause audio if it's currently playing
       if (sched.isPlaying) {
         source.instance._audioElement.pause();
@@ -168,6 +172,7 @@ export default class SoundScheduler {
       if (!sched.enabled || !info || !info.isPaused) continue;
 
       info.isPaused = false;
+      sched.paused = false;
 
       // Resume loop after the remaining delay
       const resumeTimer = setTimeout(() => {
@@ -194,6 +199,8 @@ export default class SoundScheduler {
       info = { remainingGapMs: 0, isPaused: false, resumeTimer: null, queuedLoop: sched.loopFn || null };
       this.pauseInfo.set(id, info);
     }
+
+    sched.paused = true;
 
     if (sched.isPlaying) {
       source._audioElement.pause();
@@ -232,6 +239,7 @@ export default class SoundScheduler {
     if (!info.isPaused) return;
 
     info.isPaused = false;
+    sched.paused = false;
     sched.stopCurrentLoop = false;
 
     const resumeTimer = setTimeout(() => {
@@ -312,6 +320,7 @@ export default class SoundScheduler {
     }
 
     sched.stopCurrentLoop = true;
+    sched.paused = true;
   }
 }
 

--- a/src/lib/SoundSource.js
+++ b/src/lib/SoundSource.js
@@ -49,6 +49,7 @@ export default class SoundSource {
       timesPlayed: 0,
       isPlaying: false, // whether the sound is currently playing
       lastPlayedAt: null,
+      paused: true, // whether scheduling is currently paused
     };
 
 
@@ -150,8 +151,12 @@ export default class SoundSource {
   /**
    * Whether the sound is currently playing.
    * @returns {boolean}
-   */
+  */
   get playing() {
+    const sched = this.state.schedule;
+    if (sched?.enabled) {
+      return !sched.paused;
+    }
     return this._playing.value;
   }
 


### PR DESCRIPTION
## Summary
- track `paused` state in each sound schedule
- treat scheduled sounds as playing whenever their schedule isn't paused
- maintain `paused` state when starting, pausing or resuming schedules

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68795d64ded0832f98aa5cde84ab7e74