### PR TITLE
Handle all loops via scheduler

### DIFF
--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -160,7 +160,7 @@ export default class AudioEngine {
       masterGain: this.#masterGain,
       file: src.audioPath,
       state: src.state,
-      loop: !src.state.schedule?.enabled,
+      loop: false,
     })
     // Route the new source through the reverb chain
     this.connectToReverb(instance)
@@ -172,7 +172,7 @@ export default class AudioEngine {
       this.#audioContext.resume()
     }
     if (!src.instance.state.schedule?.enabled && instance.isPlaying) {
-      instance.play()
+      this.#scheduler.updateSchedule(instance, { force: true })
     }
     
     // Watch schedule changes to hook into the scheduler
@@ -180,15 +180,14 @@ export default class AudioEngine {
     const enabledUnwatch = watch(
       () => sched.enabled,
       (enabled) => {
+        this.#scheduler.cancelSchedule(instance)
+        instance.stop()
+        instance._audioElement.currentTime = 0
+
         if (enabled) {
-          instance._audioElement.loop = false // disable looping for scheduled sounds
           this.#scheduler.updateSchedule(instance)
         } else {
-          instance._audioElement.loop = true
-          instance.stop() // stop immediately if scheduling is disabled
-          instance._audioElement.currentTime = 0 // reset time
-          this.#scheduler.cancelSchedule(instance)
-          instance.play()
+          this.#scheduler.updateSchedule(instance, { force: true })
         }
       },
       { immediate: true }
@@ -199,6 +198,8 @@ export default class AudioEngine {
       () => {
         if (sched.enabled) {
           this.#scheduler.updateSchedule(instance)
+        } else {
+          this.#scheduler.updateSchedule(instance, { force: true })
         }
       }
     )
@@ -296,10 +297,8 @@ export default class AudioEngine {
         } else {
           this.#scheduler.updateSchedule(src.instance);
         }
-        src.instance._audioElement.loop = false
       } else {
-        src.instance._audioElement.loop = true
-        src.instance?.play?.()
+        this.#scheduler.updateSchedule(src.instance, { force: true });
       }
   }
 
@@ -308,10 +307,7 @@ export default class AudioEngine {
       console.warn("Tried to pause sound source but it was not valid:", src)
       return
     }
-    const sched = src.instance.state.schedule;
-    if (sched?.enabled) {
-      this.#scheduler.pauseSource(src.instance);
-    }
+    this.#scheduler.pauseSource(src.instance);
     src.instance.stop();
   }
 

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -31,10 +31,14 @@ export default class SoundScheduler {
 
     for (const wrapper of this.audioEngine.soundSources.value) {
       const src = wrapper.instance;
-      if (src.state.schedule?.enabled) {
-        src.state.schedule.timesPlayed = 0; // reset play count
-        src.state.schedule.paused = false;
+      const sched = src.state.schedule;
+
+      if (sched.enabled) {
+        sched.timesPlayed = 0; // reset play count
+        sched.paused = false;
         this._schedule(src);
+      } else if (src.state.isPlaying) {
+        this._schedule(src, true);
       }
     }
   }
@@ -45,7 +49,7 @@ export default class SoundScheduler {
    * Plays the sound if within the allowed time window, then re-schedules itself.
    * @param {SoundSource} source - the sound source with a scheduling config
    */
-  _schedule(source) {
+  _schedule(source, force = false) {
     const sched = source.state.schedule;
     const { id: scheduleId } = sched;
 
@@ -88,7 +92,7 @@ export default class SoundScheduler {
     };
 
       const loop = async () => {
-        if (!sched.enabled) return;
+        if (!sched.enabled && !force) return;
 
         await playAndWait();
         sched.isPlaying = false;
@@ -101,9 +105,9 @@ export default class SoundScheduler {
         sched.lastPlayedAt = now;
       sched.timesPlayed = (sched.timesPlayed || 0) + 1;
 
-      if (sched.enabled) {
-        const min = sched.mode == "loop" ? 0 : sched.gapMin;
-        const max = sched.mode == "loop" ? 0 : sched.gapMax;
+      if (sched.enabled || force) {
+        const min = (sched.mode == "loop" || force) ? 0 : sched.gapMin;
+        const max = (sched.mode == "loop" || force) ? 0 : sched.gapMax;
         const nextGap = randomInRange(min, max) * 1000;
 
         const timeoutId = setTimeout(loop, nextGap);
@@ -135,7 +139,7 @@ export default class SoundScheduler {
       const { id } = sched;
       let info = this.pauseInfo.get(id);
 
-      if (!sched.enabled) continue;
+      if (!sched.enabled && !this.intervals.has(id)) continue;
       if (!info) {
         info = { remainingGapMs: 0, isPaused: false, resumeTimer: null, queuedLoop: sched.loopFn || null };
         this.pauseInfo.set(id, info);
@@ -169,7 +173,7 @@ export default class SoundScheduler {
       const { id } = sched;
       const info = this.pauseInfo.get(id);
 
-      if (!sched.enabled || !info || !info.isPaused) continue;
+      if (!info || !info.isPaused) continue;
 
       info.isPaused = false;
       sched.paused = false;
@@ -194,7 +198,7 @@ export default class SoundScheduler {
     const { id } = sched;
     let info = this.pauseInfo.get(id);
 
-    if (!sched.enabled) return;
+    if (!sched.enabled && !this.intervals.has(id)) return;
     if (!info) {
       info = { remainingGapMs: 0, isPaused: false, resumeTimer: null, queuedLoop: sched.loopFn || null };
       this.pauseInfo.set(id, info);
@@ -229,10 +233,8 @@ export default class SoundScheduler {
     const { id } = sched;
     const info = this.pauseInfo.get(id);
 
-    if (!sched.enabled) return;
-
     if (!info) {
-      this._schedule(source);
+      this._schedule(source, !sched.enabled);
       return;
     }
 
@@ -246,7 +248,7 @@ export default class SoundScheduler {
       if (info.queuedLoop) {
         info.queuedLoop();
       } else {
-        this._schedule(source);
+        this._schedule(source, !sched.enabled);
       }
     }, info.remainingGapMs);
 
@@ -272,7 +274,7 @@ export default class SoundScheduler {
    * Clears the old timeout and starts a fresh one with new settings.
    * @param {SoundSource} source - the updated sound source
    */
-  updateSchedule(source) {
+  updateSchedule(source, { force = false } = {}) {
     const sched = source.state.schedule;
     const forceRestart = sched.restart;
 
@@ -288,15 +290,15 @@ export default class SoundScheduler {
         const onEnded = () => {
           el.removeEventListener('ended', onEnded);
           sched.pendingUpdate = false;
-          if (sched.enabled) {
-            this._schedule(source);
+          if (sched.enabled || force) {
+            this._schedule(source, force);
           }
         };
 
         el.addEventListener('ended', onEnded);
       }
-    } else if (sched.enabled) {
-      this._schedule(source); // restart or start with new config
+    } else if (sched.enabled || force) {
+      this._schedule(source, force); // restart or start with new config
     }
   }
 


### PR DESCRIPTION
## Summary
- extend SoundScheduler to run loops even when scheduling is disabled
- let AudioEngine use SoundScheduler for every sound source

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687997c9c484832f8026a0bdcc5c8ceb