### PR TITLE
Fix playback state restoration

### DIFF
--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -175,16 +175,17 @@ export default class AudioEngine {
     const sched = instance.state.schedule
     const enabledUnwatch = watch(
       () => sched.enabled,
-      (_enabled) => {
-        this.#scheduler.updateSchedule(instance)
-      },
-      { immediate: true }
+      () => {
+        if (!sched.paused) {
+          this.#scheduler.updateSchedule(instance)
+        }
+      }
     )
 
     const paramsUnwatch = watch(
       () => [sched.gapMin, sched.gapMax, sched.activeStart, sched.activeEnd, sched.count, sched.mode],
       () => {
-        if (sched.enabled) {
+        if (sched.enabled && !sched.paused) {
           this.#scheduler.updateSchedule(instance)
         }
       }

--- a/src/lib/SoundScheduler.js
+++ b/src/lib/SoundScheduler.js
@@ -32,9 +32,13 @@ export default class SoundScheduler {
     for (const wrapper of this.audioEngine.soundSources.value) {
       const src = wrapper.instance;
       src.state.schedule.timesPlayed = 0; // reset play count
-      src.state.schedule.paused = false;
-      this._schedule(src);
-      
+      if (src.state.schedule.isPlaying) {
+        src.state.schedule.paused = false;
+        this._schedule(src);
+      } else {
+        src.state.schedule.paused = true;
+      }
+
     }
   }
 


### PR DESCRIPTION
## Summary
- respect stored playback state when recreating scheduler
- only reschedule when source isn't paused

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879ba571980832fb08fcfa01a258fe5