### PR TITLE
Add undoable schedule edits

### DIFF
--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -49,7 +49,13 @@
 
       <!-- Scheduling Toggle -->
       <div class="w-full flex items-center space-x-2 text-left px-1">
-        <input type="checkbox" v-model="schedulingEnabled" class="accent-blue-500" />
+        <input
+          type="checkbox"
+          v-model="schedulingEnabled"
+          class="accent-blue-500"
+          @focus="beginScheduleEdit"
+          @change="commitScheduleEdit"
+        />
         <label class="text-sm">Enable Scheduling</label>
       </div>
 
@@ -59,7 +65,9 @@
         <div class="flex flex-col space-y-1">
           <label class="text-sm text-left">Schedule Mode</label>
           <select v-model="schedule.mode"
-            class="px-2 py-1 rounded border dark:bg-neutral-800 dark:border-neutral-700">
+            class="px-2 py-1 rounded border dark:bg-neutral-800 dark:border-neutral-700"
+            @focus="beginScheduleEdit"
+            @change="commitScheduleEdit">
             <option v-if="false" value="loop">Loop</option>
             <option value="interval">Interval</option>
             <option v-if="false" value="count">Count</option>
@@ -76,7 +84,8 @@
               type="number"
               :min="0"
               v-model.number="schedule.gapMin"
-              @blur="validateGap"
+              @focus="beginScheduleEdit"
+              @blur="() => { validateGap(); commitScheduleEdit(); }"
               class="px-2 py-1 rounded border dark:bg-neutral-800 dark:border-neutral-700"
             />
           </div>
@@ -87,7 +96,8 @@
               type="number"
               :min="schedule.gapMin"
               v-model.number="schedule.gapMax"
-              @blur="validateGap"
+              @focus="beginScheduleEdit"
+              @blur="() => { validateGap(); commitScheduleEdit(); }"
               class="px-2 py-1 rounded border dark:bg-neutral-800 dark:border-neutral-700"
             />
             <p v-if="schedule.gapMax < schedule.gapMin" class="text-red-500 text-xs">
@@ -104,7 +114,8 @@
             <input
               type="number"
               v-model.number="schedule.count"
-              @blur="validateCount"
+              @focus="beginScheduleEdit"
+              @blur="() => { validateCount(); commitScheduleEdit(); }"
               placeholder="Unlimited"
               class="px-2 py-1 rounded border dark:bg-neutral-800 dark:border-neutral-700"
             />
@@ -115,7 +126,8 @@
             <input
               type="number"
               v-model.number="schedule.activeStart"
-              @blur="validateTimeWindow"
+              @focus="beginScheduleEdit"
+              @blur="() => { validateTimeWindow(); commitScheduleEdit(); }"
               class="px-2 py-1 rounded border dark:bg-neutral-800 dark:border-neutral-700"
             />
           </div>
@@ -125,7 +137,8 @@
             <input
               type="number"
               v-model.number="schedule.activeEnd"
-              @blur="validateTimeWindow"
+              @focus="beginScheduleEdit"
+              @blur="() => { validateTimeWindow(); commitScheduleEdit(); }"
               class="px-2 py-1 rounded border dark:bg-neutral-800 dark:border-neutral-700"
             />
           </div>
@@ -190,6 +203,25 @@ const cleanSourceXY = computed(() => ({
   x: Math.round(state.value.x),
   y: Math.round(state.value.y)
 }));
+
+let schedulePayload = null;
+
+function beginScheduleEdit() {
+  if (!schedulePayload) {
+    schedulePayload = {
+      src: selectedSource.value,
+      from: JSON.parse(JSON.stringify(selectedSource.value.instance.state.schedule))
+    };
+  }
+}
+
+function commitScheduleEdit() {
+  if (schedulePayload) {
+    schedulePayload.to = JSON.parse(JSON.stringify(selectedSource.value.instance.state.schedule));
+    actionManager.value.doAction('update_sound_source_schedule', schedulePayload);
+    schedulePayload = null;
+  }
+}
 
 
 function validateGap() {

--- a/src/composables/useSoundRoomActions.js
+++ b/src/composables/useSoundRoomActions.js
@@ -28,7 +28,8 @@ export function unregisterSoundRoomActions() {
     'delete_canvas_sound_source',
     'move_canvas_sound_source',
     'delete_draggable_sound_source',
-    'add_draggable_sound_source'
+    'add_draggable_sound_source',
+    'update_sound_source_schedule'
   ])
   actionsRegistered = false
 }
@@ -87,6 +88,17 @@ function registerCanvasActions() {
   actionManager.value.registerActionHandlers('move_canvas_sound_source',
     payload => moveSoundSource(audioEngine.value.soundSources.value[payload.index], payload.to),
     payload => moveSoundSource(audioEngine.value.soundSources.value[payload.index], payload.from)
+  )
+
+  const setSchedule = (sched, data) => {
+    for (const key in data) {
+      sched[key] = data[key]
+    }
+  }
+
+  actionManager.value.registerActionHandlers('update_sound_source_schedule',
+    payload => setSchedule(payload.src.instance.state.schedule, payload.to),
+    payload => setSchedule(payload.src.instance.state.schedule, payload.from)
   )
 }
 


### PR DESCRIPTION
## Summary
- add `update_sound_source_schedule` action and unregister logic
- register new action in sound room actions
- expose schedule edit helpers in SelectedSourcePanel and hook them up to form inputs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687bed7c6d54832fb064522917085df6