### PR TITLE
Add schedule actions

### DIFF
--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -140,7 +140,7 @@
 </template>
 
 <script setup>
-import { computed, inject } from 'vue';
+import { computed, inject, watch } from 'vue';
 import VueSlider from 'vue-3-slider-component';
 import { useVolumeSlider } from '@/composables/useVolumeSlider';
 import { useActionManagerStore } from '@/stores/useActionManagerStore';
@@ -157,6 +157,36 @@ const audioEngineStore = useAudioEngineStore();
 
 const state = computed(() => selectedSource.value.instance.state);
 const schedule = computed(() => state.value.schedule);
+
+let suppressScheduleWatch = false;
+
+watch(
+  () => selectedSource.value?.instance.state.schedule.id,
+  () => {
+    suppressScheduleWatch = true;
+    queueMicrotask(() => { suppressScheduleWatch = false; });
+  }
+);
+
+function registerScheduleWatcher(getter, prop) {
+  watch(getter, (newVal, oldVal) => {
+    if (suppressScheduleWatch) return;
+    if (oldVal === undefined || newVal === oldVal) return;
+    actionManager.value.doAction('update_sound_source_schedule', {
+      index: selectedSource.value.index,
+      from: { [prop]: oldVal },
+      to: { [prop]: newVal }
+    });
+  });
+}
+
+registerScheduleWatcher(() => schedule.value.enabled, 'enabled');
+registerScheduleWatcher(() => schedule.value.mode, 'mode');
+registerScheduleWatcher(() => schedule.value.gapMin, 'gapMin');
+registerScheduleWatcher(() => schedule.value.gapMax, 'gapMax');
+registerScheduleWatcher(() => schedule.value.count, 'count');
+registerScheduleWatcher(() => schedule.value.activeStart, 'activeStart');
+registerScheduleWatcher(() => schedule.value.activeEnd, 'activeEnd');
 
 const schedulingEnabled = computed({
   get: () => schedule.value.enabled,

--- a/src/composables/useSoundRoomActions.js
+++ b/src/composables/useSoundRoomActions.js
@@ -14,6 +14,7 @@ export function registerSoundRoomActions() {
   if (actionsRegistered) return
   registerCanvasActions()
   registerDraggableActions()
+  registerScheduleActions()
   actionsRegistered = true
 }
 
@@ -28,7 +29,8 @@ export function unregisterSoundRoomActions() {
     'delete_canvas_sound_source',
     'move_canvas_sound_source',
     'delete_draggable_sound_source',
-    'add_draggable_sound_source'
+    'add_draggable_sound_source',
+    'update_sound_source_schedule'
   ])
   actionsRegistered = false
 }
@@ -202,6 +204,28 @@ function registerDraggableActions() {
   actionManager.value.registerActionHandlers('add_draggable_sound_source',
     async payload => await addDraggableSoundSource(payload),
     payload => deleteDraggableSoundSource(payload),
+  )
+}
+
+/**
+ * Setup undoable actions for schedule changes on sound sources.
+ */
+function registerScheduleActions() {
+  const { audioEngine } = storeToRefs(useAudioEngineStore())
+  const { actionManager } = storeToRefs(useActionManagerStore())
+
+  const applySchedule = (payload, values) => {
+    const src = audioEngine.value.soundSources.value[payload.index]
+    if (!src) return
+    Object.entries(values).forEach(([k, v]) => {
+      src.instance.state.schedule[k] = v
+    })
+  }
+
+  actionManager.value.registerActionHandlers(
+    'update_sound_source_schedule',
+    payload => applySchedule(payload, payload.to),
+    payload => applySchedule(payload, payload.from)
   )
 }
 


### PR DESCRIPTION
## Summary
- register schedule changes with ActionManager
- add schedule watchers for undoable schedule edits

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687bed7c6d54832fb064522917085df6