### PR TITLE
Add undoable schedule edits

### DIFF
--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -140,7 +140,7 @@
 </template>
 
 <script setup>
-import { computed, inject } from 'vue';
+import { computed, inject, watch } from 'vue';
 import VueSlider from 'vue-3-slider-component';
 import { useVolumeSlider } from '@/composables/useVolumeSlider';
 import { useActionManagerStore } from '@/stores/useActionManagerStore';
@@ -152,7 +152,7 @@ const props = defineProps({
 });
 
 const selectedSource = inject('selectedSource');
-const { actionManager } = storeToRefs(useActionManagerStore());
+const { actionManager, waiting } = storeToRefs(useActionManagerStore());
 const audioEngineStore = useAudioEngineStore();
 
 const state = computed(() => selectedSource.value.instance.state);
@@ -160,8 +160,43 @@ const schedule = computed(() => state.value.schedule);
 
 const schedulingEnabled = computed({
   get: () => schedule.value.enabled,
-  set: (val) => schedule.value.enabled = val
+  set: (val) => {
+    const prev = schedule.value.enabled;
+    schedule.value.enabled = val;
+    if (prev !== val) {
+      actionManager.value.doAction('update_sound_source_schedule', {
+        index: selectedSource.value.index,
+        from: { enabled: prev },
+        to: { enabled: val }
+      });
+    }
+  }
 });
+
+let watchIndex = selectedSource.value?.index;
+watch(selectedSource, () => {
+  watchIndex = selectedSource.value?.index;
+});
+
+function trackScheduleChange(field, newVal, oldVal) {
+  if (waiting.value || watchIndex !== selectedSource.value.index) {
+    watchIndex = selectedSource.value.index;
+    return;
+  }
+  if (newVal === oldVal) return;
+  actionManager.value.doAction('update_sound_source_schedule', {
+    index: selectedSource.value.index,
+    from: { [field]: oldVal },
+    to: { [field]: newVal }
+  });
+}
+
+watch(() => schedule.value.gapMin, (n, o) => trackScheduleChange('gapMin', n, o));
+watch(() => schedule.value.gapMax, (n, o) => trackScheduleChange('gapMax', n, o));
+watch(() => schedule.value.mode, (n, o) => trackScheduleChange('mode', n, o));
+watch(() => schedule.value.count, (n, o) => trackScheduleChange('count', n, o));
+watch(() => schedule.value.activeStart, (n, o) => trackScheduleChange('activeStart', n, o));
+watch(() => schedule.value.activeEnd, (n, o) => trackScheduleChange('activeEnd', n, o));
 
 
 const { onStart, onChange, onEnd } = useVolumeSlider(selectedSource, actionManager);

--- a/src/composables/useSoundRoomActions.js
+++ b/src/composables/useSoundRoomActions.js
@@ -14,6 +14,7 @@ export function registerSoundRoomActions() {
   if (actionsRegistered) return
   registerCanvasActions()
   registerDraggableActions()
+  registerScheduleActions()
   actionsRegistered = true
 }
 
@@ -28,7 +29,8 @@ export function unregisterSoundRoomActions() {
     'delete_canvas_sound_source',
     'move_canvas_sound_source',
     'delete_draggable_sound_source',
-    'add_draggable_sound_source'
+    'add_draggable_sound_source',
+    'update_sound_source_schedule'
   ])
   actionsRegistered = false
 }
@@ -202,6 +204,28 @@ function registerDraggableActions() {
   actionManager.value.registerActionHandlers('add_draggable_sound_source',
     async payload => await addDraggableSoundSource(payload),
     payload => deleteDraggableSoundSource(payload),
+  )
+}
+
+/**
+ * Setup undoable actions for modifying a sound source's scheduling data.
+ */
+function registerScheduleActions() {
+  const { audioEngine } = storeToRefs(useAudioEngineStore())
+  const { actionManager } = storeToRefs(useActionManagerStore())
+
+  const applySchedule = (payload, type) => {
+    const wrapper = audioEngine.value.soundSources.value[payload.index]
+    if (!wrapper) return
+    const sched = wrapper.instance.state.schedule
+    const updates = type === 'do' ? payload.to : payload.from
+    Object.assign(sched, updates)
+  }
+
+  actionManager.value.registerActionHandlers(
+    'update_sound_source_schedule',
+    payload => applySchedule(payload, 'do'),
+    payload => applySchedule(payload, 'undo')
   )
 }
 


### PR DESCRIPTION
## Summary
- register new action for updating sound source scheduling
- watch schedule fields in SelectedSourcePanel and dispatch `update_sound_source_schedule`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687bed7c6d54832fb064522917085df6