### PR TITLE
Fix schedule actions for undo

### DIFF
--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -235,13 +235,16 @@ function commitScheduleEdit() {
 
   if (changedKeys.length > 0) {
     const changedParameters = {}
+    const originalParameters = {}
     for (const key of changedKeys) {
       changedParameters[key] = schedule.value[key]
+      originalParameters[key] = scheduleSnapshot[key]
     }
 
     actionManager.value.doAction('update_sound_source_schedule', {
       src: selectedSource.value,
-      changedParameters: structuredClone(changedParameters)
+      from: structuredClone(originalParameters),
+      to: structuredClone(changedParameters)
     })
   }
 

--- a/src/composables/useSoundRoomActions.js
+++ b/src/composables/useSoundRoomActions.js
@@ -217,17 +217,15 @@ function registerSchedulingActions() {
    *
    * @param {Object} payload
    */
-  const updateSchedule = (payload) => {
-      const src = payload.src
-      //Object.assign(src.instance.schedule, payload.changedParameters)
-      for (const key in payload.changedParameters) {
-        src.instance.schedule[key] = payload.changedParameters[key]
-      }
+  const updateSchedule = (src, params) => {
+    for (const key in params) {
+      src.instance.schedule[key] = params[key]
+    }
   }
 
   actionManager.value.registerActionHandlers('update_sound_source_schedule',
-    payload => updateSchedule(payload),
-    payload => updateSchedule(payload)
+    payload => updateSchedule(payload.src, payload.to),
+    payload => updateSchedule(payload.src, payload.from)
   )
   
 }


### PR DESCRIPTION
## Summary
- track previous scheduling parameters when editing sound sources
- update scheduling action handlers to apply `from`/`to` params so undo works

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c2d42f64c832fbd05a7eb93243f07