### PR TITLE
Add tests for Listener and improve navigator setup

### DIFF
--- a/test/AudioEngine.test.js
+++ b/test/AudioEngine.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import AudioEngine from '../src/lib/AudioEngine.js'
+
+const sampleJson = {
+  soundSources: [
+    {
+      libraryId: 'lib1',
+      name: 'test',
+      audioPath: 'a',
+      index: 0,
+      instance: { state: { x:0, y:0, angle:0, coneInner:30, coneOuter:60, schedule:{} } },
+      state: { angle:0, coneInner:30, coneOuter:60 }
+    }
+  ],
+  masterVolume: 0.8
+}
+
+describe('AudioEngine.fromJSON', () => {
+  it('creates an engine with provided master volume', () => {
+    const engine = AudioEngine.fromJSON(sampleJson)
+    expect(engine.masterVolume.value).toBe(0.8)
+  })
+
+  it('throws on invalid json', () => {
+    expect(() => AudioEngine.fromJSON({ foo: 'bar' })).toThrow()
+  })
+})

--- a/test/Listener.test.js
+++ b/test/Listener.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import Listener from '../src/lib/Listener.js'
+
+const createCtx = () => ({
+  listener: {
+    setPosition: vi.fn(),
+    setOrientation: vi.fn()
+  }
+})
+
+describe('Listener', () => {
+  it('serializes and deserializes', () => {
+    const l = new Listener(100, 50, 270)
+    const json = l.toJSON()
+    expect(json).toEqual({ x: 100, y: 50, angle: 270 })
+
+    const from = Listener.fromJSON(json)
+    expect(from.x).toBe(100)
+    expect(from.y).toBe(50)
+    expect(from.angle).toBe(270)
+  })
+
+  it('updates audio position and orientation', () => {
+    const ctx = createCtx()
+    const l = new Listener()
+    l.setAudioContext(ctx)
+    l.updateAudio()
+    expect(ctx.listener.setPosition).toHaveBeenCalledWith(3, 2, 0)
+    const [x, y] = ctx.listener.setOrientation.mock.calls[0]
+    expect(x).toBeCloseTo(0)
+    expect(y).toBeCloseTo(1)
+  })
+
+  it('updateAngle changes orientation', () => {
+    const ctx = createCtx()
+    const l = new Listener()
+    l.setAudioContext(ctx)
+    l.updateAngle(90)
+    const lastCall = ctx.listener.setOrientation.mock.calls.at(-1)
+    expect(l.angle).toBe(90)
+    expect(lastCall[1]).toBeCloseTo(0)
+  })
+
+  it('setCanvasContext stores the context', () => {
+    const ref = { value: { foo: 'bar' } }
+    const l = new Listener()
+    l.setCanvasContext(ref)
+    expect(l._canvasContext).toBe(ref.value)
+  })
+})

--- a/test/Room.test.js
+++ b/test/Room.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import Room from '../src/lib/Room.js'
+
+describe('Room', () => {
+  it('clamps values correctly', () => {
+    const room = new Room()
+    expect(room.clamp(150, 0, 100)).toBe(100)
+    expect(room.clamp(-5, 0, 100)).toBe(0)
+    expect(room.clamp(50, 0, 100)).toBe(50)
+  })
+
+  it('serializes and deserializes', () => {
+    const original = new Room(800, 600, 'My Room', 'id1')
+    const json = original.toJSON()
+    expect(json).toEqual({ width: 800, height: 600, name: 'My Room' })
+
+    const from = Room.fromJSON({ width: 800, height: 600, name: 'My Room', id: 'id1' })
+    expect(from.width).toBe(800)
+    expect(from.height).toBe(600)
+    expect(from.name.value).toBe('My Room')
+    expect(from.id).toBe('id1')
+  })
+
+  it('throws on invalid JSON', () => {
+    expect(() => Room.fromJSON({ foo: 'bar' })).toThrow()
+  })
+})

--- a/test/SoundSource.test.js
+++ b/test/SoundSource.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import SoundSource from '../src/lib/SoundSource.js'
+import Room from '../src/lib/Room.js'
+
+let ctx
+let panner
+let mainGain
+let reverbGain
+
+beforeEach(() => {
+  panner = {
+    connect: vi.fn(function(){ return this }),
+    positionX: { setValueAtTime: vi.fn() },
+    positionY: { setValueAtTime: vi.fn() },
+    positionZ: { setValueAtTime: vi.fn() },
+    orientationX: { setValueAtTime: vi.fn() },
+    orientationY: { setValueAtTime: vi.fn() },
+    orientationZ: { setValueAtTime: vi.fn() }
+  }
+  mainGain = { connect: vi.fn(function(){ return this }), gain: { setValueAtTime: vi.fn(), value: 1 } }
+  reverbGain = { connect: vi.fn(function(){ return this }), gain: { setValueAtTime: vi.fn(), value: 1 } }
+  let first = true
+  ctx = {
+    currentTime: 0,
+    createMediaElementSource: vi.fn(() => ({ connect: vi.fn(function(){ return this }) })),
+    createGain: vi.fn(() => {
+      if (first) { first = false; return mainGain }
+      return reverbGain
+    }),
+    createPanner: vi.fn(() => panner),
+    destination: {}
+  }
+  global.Audio = vi.fn(function(){
+    this.addEventListener = vi.fn()
+    this.pause = vi.fn()
+    this.play = vi.fn()
+    this.load = vi.fn()
+    this.volume = 1
+    this.loop = false
+    this.preload = ''
+  })
+})
+
+describe('SoundSource', () => {
+  const baseState = { x:0, y:0, angle:0, coneInner:30, coneOuter:60, volume:1, schedule:{} }
+
+  it('sets and gets volume', () => {
+    const src = new SoundSource({ audioContext: ctx, masterGain: {}, file: 'f', state: { ...baseState } })
+    src.setVolume(0.7)
+    expect(src.getVolume()).toBe(0.7)
+  })
+
+  it('updates audio position and orientation', () => {
+    const state = { ...baseState, x:100, y:200, angle:90 }
+    const src = new SoundSource({ audioContext: ctx, masterGain: {}, file: 'f', state })
+    src.updateAudio()
+    expect(panner.positionX.setValueAtTime).toHaveBeenCalledWith(1, 0)
+    expect(panner.positionY.setValueAtTime).toHaveBeenCalledWith(2, 0)
+    expect(panner.orientationX.setValueAtTime.mock.calls[0][0]).toBeCloseTo(0)
+    expect(panner.orientationY.setValueAtTime.mock.calls[0][0]).toBeCloseTo(1)
+  })
+
+  it('updates gain based on room interaction', () => {
+    const state = { ...baseState, x:10, y:10 }
+    const src = new SoundSource({ audioContext: ctx, masterGain: {}, file: 'f', state })
+    const room = new Room(200,200,'r')
+    src.updateRoomInteraction(room)
+    expect(mainGain.gain.setValueAtTime).toHaveBeenCalled()
+    expect(reverbGain.gain.setValueAtTime).toHaveBeenCalled()
+  })
+
+  it('reflects paused state through playing getter', () => {
+    const state = { ...baseState, schedule: { paused: false } }
+    const src = new SoundSource({ audioContext: ctx, masterGain: {}, file: 'f', state })
+    expect(src.playing).toBe(true)
+    src.state.schedule.paused = true
+    expect(src.playing).toBe(false)
+  })
+})

--- a/test/device.test.js
+++ b/test/device.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { isMobileBrowser } from '../src/utils/device.js'
+
+beforeEach(() => {
+  Object.defineProperty(global, 'navigator', {
+    value: { userAgent: '', vendor: '' },
+    configurable: true,
+  })
+})
+
+describe('isMobileBrowser', () => {
+  it('detects a mobile user agent', () => {
+    navigator.userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1'
+    expect(isMobileBrowser()).toBe(true)
+  })
+
+  it('returns false for desktop user agents', () => {
+    navigator.userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+    expect(isMobileBrowser()).toBe(false)
+  })
+})

--- a/test/downloadAudio.test.js
+++ b/test/downloadAudio.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import downloadAudio, { downloadMultipleAudio } from '../src/utils/downloadAudio.js'
+
+let store
+
+vi.mock('../src/stores/useAudioCacheStore.js', () => ({
+  useAudioCacheStore: () => store
+}))
+
+beforeEach(() => {
+  store = {
+    audioCacheManager: {
+      getAudioURL: vi.fn(async (id, fetchFn) => 'blob:' + id)
+    }
+  }
+  global.Audio = vi.fn(function (url) {
+    this.url = url
+    this.preload = ''
+    this.addEventListener = vi.fn()
+  })
+})
+
+describe('downloadAudio', () => {
+  it('downloads and returns an Audio element', async () => {
+    const stop = vi.fn()
+    const result = await downloadAudio('bucket', 'path', true, stop)
+    expect(store.audioCacheManager.getAudioURL).toHaveBeenCalledWith('bucket/path', expect.any(Function))
+    expect(global.Audio).toHaveBeenCalledWith('blob:bucket/path')
+    const handler = result.audio.addEventListener.mock.calls[0][1]
+    handler()
+    expect(stop).toHaveBeenCalled()
+    expect(result.blobUrl).toBe('blob:bucket/path')
+    expect(result.audio).not.toBeNull()
+  })
+
+  it('skips creating Audio when populateAudio is false', async () => {
+    const result = await downloadAudio('b', 'p', false)
+    expect(result.audio).toBeNull()
+  })
+})
+
+describe('downloadMultipleAudio', () => {
+  it('returns audio paths for each source', async () => {
+    const list = [
+      { id: '1', bucket: 'b1', path: 'p1' },
+      { id: '2', bucket: 'b2', path: 'p2' }
+    ]
+    const results = await downloadMultipleAudio(list, false)
+    expect(results).toEqual([
+      { id: '1', audioPath: 'blob:1' },
+      { id: '2', audioPath: 'blob:2' }
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for Listener class
- refine navigator mocking in device tests
- add coverage for SoundSource behavior and AudioEngine JSON parsing

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687fc88321e0832fb9c2268cf366ac55