### PR TITLE
Add tests for composables

### DIFF
--- a/test/Listener.test.js
+++ b/test/Listener.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import Listener from '../src/lib/Listener.js'
+
+const createCtx = () => ({
+  listener: {
+    setPosition: vi.fn(),
+    setOrientation: vi.fn()
+  }
+})
+
+describe('Listener', () => {
+  it('serializes and deserializes', () => {
+    const l = new Listener(100, 50, 270)
+    const json = l.toJSON()
+    expect(json).toEqual({ x: 100, y: 50, angle: 270 })
+
+    const from = Listener.fromJSON(json)
+    expect(from.x).toBe(100)
+    expect(from.y).toBe(50)
+    expect(from.angle).toBe(270)
+  })
+
+  it('updates audio position and orientation', () => {
+    const ctx = createCtx()
+    const l = new Listener()
+    l.setAudioContext(ctx)
+    l.updateAudio()
+    expect(ctx.listener.setPosition).toHaveBeenCalledWith(3, 2, 0)
+    const [x, y] = ctx.listener.setOrientation.mock.calls[0]
+    expect(x).toBeCloseTo(0)
+    expect(y).toBeCloseTo(1)
+  })
+
+  it('updateAngle changes orientation', () => {
+    const ctx = createCtx()
+    const l = new Listener()
+    l.setAudioContext(ctx)
+    l.updateAngle(90)
+    const lastCall = ctx.listener.setOrientation.mock.calls.at(-1)
+    expect(l.angle).toBe(90)
+    expect(lastCall[1]).toBeCloseTo(0)
+  })
+
+  it('setCanvasContext stores the context', () => {
+    const ref = { value: { foo: 'bar' } }
+    const l = new Listener()
+    l.setCanvasContext(ref)
+    expect(l._canvasContext).toBe(ref.value)
+  })
+})

--- a/test/Room.test.js
+++ b/test/Room.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import Room from '../src/lib/Room.js'
+
+describe('Room', () => {
+  it('clamps values correctly', () => {
+    const room = new Room()
+    expect(room.clamp(150, 0, 100)).toBe(100)
+    expect(room.clamp(-5, 0, 100)).toBe(0)
+    expect(room.clamp(50, 0, 100)).toBe(50)
+  })
+
+  it('serializes and deserializes', () => {
+    const original = new Room(800, 600, 'My Room', 'id1')
+    const json = original.toJSON()
+    expect(json).toEqual({ width: 800, height: 600, name: 'My Room' })
+
+    const from = Room.fromJSON({ width: 800, height: 600, name: 'My Room', id: 'id1' })
+    expect(from.width).toBe(800)
+    expect(from.height).toBe(600)
+    expect(from.name.value).toBe('My Room')
+    expect(from.id).toBe('id1')
+  })
+
+  it('throws on invalid JSON', () => {
+    expect(() => Room.fromJSON({ foo: 'bar' })).toThrow()
+  })
+})

--- a/test/device.test.js
+++ b/test/device.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { isMobileBrowser } from '../src/utils/device.js'
+
+beforeEach(() => {
+  Object.defineProperty(global, 'navigator', {
+    value: { userAgent: '', vendor: '' },
+    configurable: true,
+  })
+})
+
+describe('isMobileBrowser', () => {
+  it('detects a mobile user agent', () => {
+    navigator.userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1'
+    expect(isMobileBrowser()).toBe(true)
+  })
+
+  it('returns false for desktop user agents', () => {
+    navigator.userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+    expect(isMobileBrowser()).toBe(false)
+  })
+})

--- a/test/downloadAudio.test.js
+++ b/test/downloadAudio.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import downloadAudio, { downloadMultipleAudio } from '../src/utils/downloadAudio.js'
+
+let store
+
+vi.mock('../src/stores/useAudioCacheStore.js', () => ({
+  useAudioCacheStore: () => store
+}))
+
+beforeEach(() => {
+  store = {
+    audioCacheManager: {
+      getAudioURL: vi.fn(async (id, fetchFn) => 'blob:' + id)
+    }
+  }
+  global.Audio = vi.fn(function (url) {
+    this.url = url
+    this.preload = ''
+    this.addEventListener = vi.fn()
+  })
+})
+
+describe('downloadAudio', () => {
+  it('downloads and returns an Audio element', async () => {
+    const stop = vi.fn()
+    const result = await downloadAudio('bucket', 'path', true, stop)
+    expect(store.audioCacheManager.getAudioURL).toHaveBeenCalledWith('bucket/path', expect.any(Function))
+    expect(global.Audio).toHaveBeenCalledWith('blob:bucket/path')
+    const handler = result.audio.addEventListener.mock.calls[0][1]
+    handler()
+    expect(stop).toHaveBeenCalled()
+    expect(result.blobUrl).toBe('blob:bucket/path')
+    expect(result.audio).not.toBeNull()
+  })
+
+  it('skips creating Audio when populateAudio is false', async () => {
+    const result = await downloadAudio('b', 'p', false)
+    expect(result.audio).toBeNull()
+  })
+})
+
+describe('downloadMultipleAudio', () => {
+  it('returns audio paths for each source', async () => {
+    const list = [
+      { id: '1', bucket: 'b1', path: 'p1' },
+      { id: '2', bucket: 'b2', path: 'p2' }
+    ]
+    const results = await downloadMultipleAudio(list, false)
+    expect(results).toEqual([
+      { id: '1', audioPath: 'blob:1' },
+      { id: '2', audioPath: 'blob:2' }
+    ])
+  })
+})

--- a/test/useContextMenuLogic.test.js
+++ b/test/useContextMenuLogic.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ref } from 'vue'
+import { useContextMenuLogic, SOUND_NODE_PART_NAME } from '../src/composables/useContextMenuLogic.js'
+
+vi.mock('../src/stores/useActionManagerStore.js', () => ({
+  useActionManagerStore: () => ({ actionManager: { doAction: vi.fn() } })
+}))
+
+let show
+vi.mock('../src/stores/useCanvasStore.js', () => ({
+  useCanvasStore: () => ({ stageDivRef: { contextMenuRef: { show: (...args) => show(...args) } } })
+}))
+vi.mock('../src/stores/useAudioEngineStore.js', () => ({
+  useAudioEngineStore: () => ({ playSoundSource: vi.fn(), pauseSoundSource: vi.fn() })
+}))
+
+describe('useContextMenuLogic', () => {
+  it('shows context menu for sound node part', () => {
+    show = vi.fn()
+    const { showContextMenu } = useContextMenuLogic(ref(null))
+    const prevent = vi.fn()
+    const stop = vi.fn()
+    const evt = { preventDefault: prevent, stopPropagation: stop, clientX: 5, clientY: 6 }
+    const target = { getAttr: vi.fn(() => SOUND_NODE_PART_NAME) }
+    showContextMenu({ evt, target })
+    expect(prevent).toHaveBeenCalled()
+    expect(stop).toHaveBeenCalled()
+    expect(show).toHaveBeenCalledWith({ x: 5, y: 6 })
+  })
+})

--- a/test/useDragDropAudio.test.js
+++ b/test/useDragDropAudio.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { useDragDropAudio } from '../src/composables/useDragDropAudio.js'
+
+let actionManagerRef, canvasStore
+
+vi.mock('../src/stores/useActionManagerStore.js', () => ({
+  useActionManagerStore: () => ({ actionManager: actionManagerRef })
+}))
+vi.mock('../src/stores/useCanvasStore.js', () => ({
+  useCanvasStore: () => canvasStore
+}))
+
+beforeEach(() => {
+  actionManagerRef = ref({ doAction: vi.fn() })
+  canvasStore = { stageDivRef: { getBoundingClientRect: () => ({ left: 10, top: 20 }) } }
+})
+
+describe('useDragDropAudio', () => {
+  it('captures dragged source and drops at coordinates', () => {
+    const draggedSource = ref(null)
+    const { handleDragStart, handleDrop } = useDragDropAudio({ draggedSource })
+    const src = { audioPath: 'a.mp3', name: 'A', libraryId: '1' }
+    handleDragStart(null, src)
+    expect(draggedSource.value).toEqual(src)
+
+    handleDrop({ clientX: 30, clientY: 50 })
+    expect(actionManagerRef.value.doAction).toHaveBeenCalledWith('add_canvas_sound_source', expect.objectContaining({ src: expect.any(Object) }))
+    const payload = actionManagerRef.value.doAction.mock.calls[0][1]
+    expect(payload.src.state.x).toBe(20)
+    expect(payload.src.state.y).toBe(30)
+  })
+})

--- a/test/useSelectedSource.test.js
+++ b/test/useSelectedSource.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+import { useSelectedSource, getSourceName } from '../src/composables/useSelectedSource.js'
+
+let sources
+let engine
+
+vi.mock('../src/stores/useAudioEngineStore.js', () => ({
+  useAudioEngineStore: () => engine
+}))
+
+beforeEach(() => {
+  sources = []
+  engine = { audioEngine: ref({ soundSources: { get value() { return sources } } }) }
+})
+
+describe('getSourceName', () => {
+  it('strips extension from file path', () => {
+    expect(getSourceName('sounds/foo/bar.mp3')).toBe('bar')
+  })
+})
+
+describe('useSelectedSource', () => {
+  it('returns null when index is invalid', () => {
+    const idx = ref(null)
+    const { selectedSource } = useSelectedSource(idx)
+    expect(selectedSource.value).toBeNull()
+  })
+
+  it('exposes selected source with volume', () => {
+    sources.push({ instance: { getVolume: () => 0.4 }, state: {} })
+    const idx = ref(0)
+    const { selectedSource } = useSelectedSource(idx)
+    expect(selectedSource.value.volume).toBe(0.4)
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for useContextMenuLogic, useDragDropAudio, and useSelectedSource composables
- cover context menu actions, drag/drop handling, and source selection helpers

## Testing
- `CI=1 npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687fc88321e0832fb9c2268cf366ac55