### PR TITLE
Add Playwright E2E test setup

### DIFF
--- a/e2e/basic.spec.js
+++ b/e2e/basic.spec.js
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('should display SoundRoom header', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'SoundRoom' })).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.7",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'e2e',
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## Summary
- set up Playwright with web server and testDir `e2e`
- add a basic test checking for the `SoundRoom` header
- expose `test:e2e` script in `package.json`

## Testing
- `npm run test:e2e` *(fails: browser not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687fe5cb84cc832f8201971cb39b9540