### PR TITLE
Add basic Playwright flow tests

### DIFF
--- a/e2e/auth.spec.js
+++ b/e2e/auth.spec.js
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test('shows login modal when visiting /login', async ({ page }) => {
+  await page.goto('/login');
+  await expect(page.getByRole('heading', { name: 'Sign In' })).toBeVisible();
+});
+
+test('shows sign up modal when visiting /signup', async ({ page }) => {
+  await page.goto('/signup');
+  await expect(page.getByRole('heading', { name: 'Sign Up' })).toBeVisible();
+});

--- a/e2e/static-pages.spec.js
+++ b/e2e/static-pages.spec.js
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test('terms of service page has heading', async ({ page }) => {
+  await page.goto('/terms');
+  await expect(page.getByRole('heading', { name: 'Terms of Service' })).toBeVisible();
+});
+
+test('privacy policy page has heading', async ({ page }) => {
+  await page.goto('/privacy');
+  await expect(page.getByRole('heading', { name: 'Privacy Policy' })).toBeVisible();
+});
+
+test('pricing page lists plans', async ({ page }) => {
+  await page.goto('/pricing');
+  await expect(page.getByRole('heading', { name: 'Choose Your Plan' })).toBeVisible();
+});
+
+test('logged out page shows message', async ({ page }) => {
+  await page.goto('/logged-out');
+  await expect(page.getByRole('heading', { name: "You've been signed out" })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add auth modal tests
- add static page tests for Terms, Privacy, Pricing and Logged Out views

## Testing
- `npm run test:unit`
- `npm run test:e2e` *(fails: browser binaries cannot download)*

------
https://chatgpt.com/codex/tasks/task_e_687ff0f05ea8832fa67f015be861b51f