### PR TITLE
Add Playwright e2e tests

### DIFF
--- a/test/e2e/auth/login.spec.js
+++ b/test/e2e/auth/login.spec.js
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('open login modal', async ({ page }) => {
+  await page.goto('/login');
+  await expect(page.getByRole('heading', { name: /sign in/i })).toBeVisible();
+});

--- a/test/e2e/auth/logout.spec.js
+++ b/test/e2e/auth/logout.spec.js
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('logged out screen links back to login', async ({ page }) => {
+  await page.goto('/logged-out');
+  await page.getByRole('button', { name: /sign in again/i }).click();
+  await expect(page).toHaveURL(/\/login$/);
+});

--- a/test/e2e/auth/reset-password.spec.js
+++ b/test/e2e/auth/reset-password.spec.js
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('open password reset view', async ({ page }) => {
+  await page.goto('/reset');
+  await expect(page.getByRole('heading', { name: /reset password/i })).toBeVisible();
+});

--- a/test/e2e/sound-library/add-sound.spec.js
+++ b/test/e2e/sound-library/add-sound.spec.js
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+import { mockSoundRoutes, mockSound } from './mockRoutes';
+
+test.beforeEach(async ({ page }) => {
+  await mockSoundRoutes(page);
+});
+
+test('load sound from library', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: /add source/i }).click();
+  await page.getByRole('button', { name: 'Load' }).click();
+  await expect(page.getByRole('listitem', { name: mockSound.name })).toBeVisible();
+});

--- a/test/e2e/sound-library/drag-to-canvas.spec.js
+++ b/test/e2e/sound-library/drag-to-canvas.spec.js
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import { mockSoundRoutes, mockSound } from './mockRoutes';
+
+test.beforeEach(async ({ page }) => {
+  await mockSoundRoutes(page);
+});
+
+test('drag loaded sound onto canvas', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: /add source/i }).click();
+  await page.getByRole('button', { name: 'Load' }).click();
+  const item = page.getByRole('listitem', { name: mockSound.name });
+  const canvas = page.getByRole('application');
+  await item.dragTo(canvas);
+  await expect(page.getByText(mockSound.name)).toBeVisible();
+});

--- a/test/e2e/sound-library/mockRoutes.js
+++ b/test/e2e/sound-library/mockRoutes.js
@@ -1,0 +1,28 @@
+export const mockSound = {
+  id: '1',
+  name: 'Bird Chirp',
+  bucket: 'nature',
+  path: 'bird.mp3'
+};
+
+export async function mockSoundRoutes(page) {
+  await page.route('**/sound_files*', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([mockSound])
+    });
+  });
+
+  await page.route('**/api/get-signed-url**', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ signedUrl: 'mock.mp3' })
+    });
+  });
+
+  await page.route('**/mock.mp3', route => {
+    route.fulfill({ status: 200, contentType: 'audio/mpeg', body: '' });
+  });
+}

--- a/test/e2e/sound-library/playback.spec.js
+++ b/test/e2e/sound-library/playback.spec.js
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+import { mockSoundRoutes, mockSound } from './mockRoutes';
+
+test.beforeEach(async ({ page }) => {
+  await mockSoundRoutes(page);
+});
+
+test('toggle play and pause for all sounds', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: /add source/i }).click();
+  await page.getByRole('button', { name: 'Load' }).click();
+  const item = page.getByRole('listitem', { name: mockSound.name });
+  const canvas = page.getByRole('application');
+  await item.dragTo(canvas);
+  const playButton = page.getByRole('button', { name: /play all/i });
+  await playButton.click();
+  await expect(page.getByRole('button', { name: /pause all/i })).toBeVisible();
+  await page.getByRole('button', { name: /pause all/i }).click();
+  await expect(page.getByRole('button', { name: /play all/i })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- split the end-to-end tests into organized folders
- create helper for mocking sound library routes
- add individual tests for login, logout, password reset, and sound interactions

## Testing
- `npm run test:e2e` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1179/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_687ff2b1b560832f922cdfb92c961458