### PR TITLE
Refine room interaction audio

### DIFF
--- a/src/lib/SoundSource.js
+++ b/src/lib/SoundSource.js
@@ -70,11 +70,17 @@ export default class SoundSource {
     for (let i = 0; i < 2; i++) {
       const delay = this._audioContext.createDelay();
       delay.delayTime.value = 0.005 + i * 0.003; // short slapback
+
       const gain = this._audioContext.createGain();
       gain.gain.value = 0.2;
 
-      this._gainNode.connect(delay).connect(gain).connect(masterGain); // or stereo panner
-      this.earlyReflections.push({ delay, gain });
+      const pan = this._audioContext.createStereoPanner();
+      pan.pan.value = 0;
+
+      // chain: dry gain -> delay -> reflection gain -> pan -> master
+      this._gainNode.connect(delay).connect(gain).connect(pan).connect(masterGain);
+
+      this.earlyReflections.push({ delay, gain, pan });
     }
 
 
@@ -237,46 +243,48 @@ export default class SoundSource {
    * @param {import('./Room').default} room
    */
   updateRoomInteraction(room) {
-  if (!room) return;
+    if (!room) return;
 
-  const { x, y } = this.state;
-  const roomWidth = room.width;
-  const roomHeight = room.height;
+    const { x, y } = this.state;
+    const roomWidth = room.width;
+    const roomHeight = room.height;
 
-  const distLeft = x;
-  const distRight = roomWidth - x;
-  const distTop = y;
-  const distBottom = roomHeight - y;
-  const minWallDist = Math.min(distLeft, distRight, distTop, distBottom);
+    const distLeft = x;
+    const distRight = roomWidth - x;
+    const distTop = y;
+    const distBottom = roomHeight - y;
+    const minWallDist = Math.min(distLeft, distRight, distTop, distBottom);
 
-  const distTopLeft = Math.hypot(x, y);
-  const distTopRight = Math.hypot(roomWidth - x, y);
-  const distBottomLeft = Math.hypot(x, roomHeight - y);
-  const distBottomRight = Math.hypot(roomWidth - x, roomHeight - y);
-  const minCornerDist = Math.min(distTopLeft, distTopRight, distBottomLeft, distBottomRight);
+    const distTopLeft = Math.hypot(x, y);
+    const distTopRight = Math.hypot(roomWidth - x, y);
+    const distBottomLeft = Math.hypot(x, roomHeight - y);
+    const distBottomRight = Math.hypot(roomWidth - x, roomHeight - y);
+    const minCornerDist = Math.min(distTopLeft, distTopRight, distBottomLeft, distBottomRight);
 
-  const normWall = Math.min(minWallDist / 100, 1);
-  const normCorner = Math.min(minCornerDist / 150, 1);
+    const normWall = Math.min(minWallDist / 100, 1);
+    const normCorner = Math.min(minCornerDist / 150, 1);
 
-  const wallGain = 1 - normWall;
-  const cornerGain = 1 - normCorner;
+    const wallGain = 1 - normWall;
+    const cornerGain = 1 - normCorner;
 
-  // ↓ Simulate dry gain drop near corners/walls (further from listener, muffled)
-  const dryGain = 0.6 * normWall * normCorner;
-  this._gainNode.gain.setValueAtTime(dryGain, this._audioContext.currentTime);
+    // dry gain scales down near boundaries but reaches 1.0 when unobstructed
+    const dryGain = 0.2 + 0.8 * normWall * normCorner;
+    this._gainNode.gain.setValueAtTime(dryGain, this._audioContext.currentTime);
 
-  // ↓ IR send level: blend more into IR in corners, but don't exaggerate
-  this.reverbSend.gain.setValueAtTime(0.3 + 0.4 * cornerGain, this._audioContext.currentTime);
+    // reverb send increases slightly near corners
+    this.reverbSend.gain.setValueAtTime(0.3 + 0.5 * cornerGain, this._audioContext.currentTime);
 
-  // ↓ Still useful for lowpass muffling (e.g. corner boxiness)
-  const muffledFreq = 800 + 12000 * normCorner;
-  this.cornerFilter.frequency.setValueAtTime(muffledFreq, this._audioContext.currentTime);
+    // lowpass filter transitions back to the full 18 kHz when far from corners
+    const muffledFreq = 800 + (18000 - 800) * normCorner;
+    this.cornerFilter.frequency.setTargetAtTime(muffledFreq, this._audioContext.currentTime, 0.01);
 
-  // Optional: early reflections on wall proximity (can be subtle)
-  this.earlyReflections.forEach(ref => {
-    ref.gain.gain.setValueAtTime(0.05 + 0.2 * wallGain, this._audioContext.currentTime);
-  });
-}
+    // early reflections subtle gain & pan toward nearest wall
+    const horizPan = distLeft < distRight ? -wallGain : wallGain;
+    this.earlyReflections.forEach(ref => {
+      ref.gain.gain.setValueAtTime(0.05 + 0.2 * wallGain, this._audioContext.currentTime);
+      ref.pan.pan.setValueAtTime(horizPan, this._audioContext.currentTime);
+    });
+  }
 
 
 

--- a/test/unit/SoundSource.test.js
+++ b/test/unit/SoundSource.test.js
@@ -30,8 +30,9 @@ beforeEach(() => {
       return { connect: vi.fn(function(){ return this }), gain: { setValueAtTime: vi.fn(), value: 1 } }
     }),
     createPanner: vi.fn(() => panner),
+    createStereoPanner: vi.fn(() => ({ connect: vi.fn(function(){ return this }), pan: { value: 0, setValueAtTime: vi.fn() } })),
     createDelay: vi.fn(() => ({ connect: vi.fn(function(){ return this }), delayTime: { value: 0 } })),
-    createBiquadFilter: vi.fn(() => ({ connect: vi.fn(function(){ return this }), frequency: { value: 0, setValueAtTime: vi.fn() } })),
+    createBiquadFilter: vi.fn(() => ({ connect: vi.fn(function(){ return this }), frequency: { value: 0, setValueAtTime: vi.fn(), setTargetAtTime: vi.fn() } })),
     createDynamicsCompressor: vi.fn(() => ({
       connect: vi.fn(function(){ return this }),
       threshold: { value: 0 },


### PR DESCRIPTION
## Summary
- pan early reflections using StereoPanner
- smooth corner muffling and dry level logic in `updateRoomInteraction`
- adjust unit test stubs for new nodes

## Testing
- `npm run test:unit`
- `npm test` *(fails: No existing credentials found for Vercel CLI)*

------
https://chatgpt.com/codex/tasks/task_e_68813e116f18832fb320c7e5efd67dd8