### PR TITLE
Add upload signing endpoint

### DIFF
--- a/api/get-upload-url.js
+++ b/api/get-upload-url.js
@@ -1,0 +1,88 @@
+import { AwsClient } from "aws4fetch";
+
+/**
+ * API endpoint that signs a temporary upload URL for the R2 bucket.
+ *
+ * @param {Request} request - incoming HTTP request
+ * @returns {Promise<Response>} signed upload URL response
+ */
+export async function GET(request) {
+  const ALLOWED_ORIGIN =
+    process.env.NODE_ENV === 'production'
+      ? 'https://soundroom.live'
+      : '*';
+
+  const {
+    R2_ACCESS_KEY_ID,
+    R2_SECRET_ACCESS_KEY,
+    R2_BUCKET_NAME,
+    R2_ACCOUNT_ID
+  } = process.env;
+
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Credentials': 'true',
+  };
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: corsHeaders,
+    });
+  }
+
+  try {
+    const client = new AwsClient({
+      accessKeyId: R2_ACCESS_KEY_ID,
+      secretAccessKey: R2_SECRET_ACCESS_KEY,
+    });
+
+    const { searchParams } = new URL(request.url);
+    const userId = searchParams.get('userId');
+    const filename = searchParams.get('filename');
+
+    if (!userId || !filename) {
+      return new Response(
+        JSON.stringify({ error: "Missing 'userId' or 'filename' query param" }),
+        {
+          status: 400,
+          headers: {
+            ...corsHeaders,
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+    }
+
+    const key = `users/${userId}/${filename}`;
+    const url = new URL(`https://${R2_BUCKET_NAME}.${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${key}`);
+    url.searchParams.set('X-Amz-Expires', '120');
+
+    const signed = await client.sign(
+      new Request(url, { method: 'PUT' }),
+      { aws: { signQuery: true } }
+    );
+
+    return new Response(JSON.stringify({ signedUrl: signed.url, key }), {
+      status: 200,
+      headers: {
+        ...corsHeaders,
+        'Content-Type': 'application/json',
+      },
+    });
+  } catch (err) {
+    console.error('💥 SIGNING ERROR:', err);
+    return new Response(
+      JSON.stringify({ error: 'Internal Server Error', message: err.message }),
+      {
+        status: 500,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  }
+}

--- a/src/utils/uploadAudio.js
+++ b/src/utils/uploadAudio.js
@@ -1,0 +1,38 @@
+/**
+ * Fetch a signed URL for uploading a file to the R2 bucket.
+ *
+ * @param {string} userId - Supabase user ID
+ * @param {string} filename - original file name
+ * @returns {Promise<{signedUrl: string, key: string}>}
+ */
+async function getSignedUploadUrl(userId, filename) {
+  const params = new URLSearchParams({ userId, filename });
+  const res = await fetch(`/api/get-upload-url?${params.toString()}`);
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => ({ error: 'Invalid JSON response' }));
+    throw new Error(errorData.error || 'Failed to get signed upload URL');
+  }
+  return await res.json();
+}
+
+/**
+ * Upload an audio file to the R2 bucket for the given user.
+ *
+ * @param {File|Blob} file - file to upload
+ * @param {string} userId - Supabase user ID
+ * @returns {Promise<string>} key of the uploaded file
+ */
+export default async function uploadAudio(file, userId) {
+  const { signedUrl, key } = await getSignedUploadUrl(userId, file.name);
+  const uploadRes = await fetch(signedUrl, {
+    method: 'PUT',
+    body: file,
+    headers: {
+      'Content-Type': file.type,
+    },
+  });
+  if (!uploadRes.ok) {
+    throw new Error('Failed to upload file to R2');
+  }
+  return key;
+}


### PR DESCRIPTION
## Summary
- add Vercel function to sign upload URLs for R2
- support uploading via new helper utility

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_688273324760832f9f92e0c44d45cc8d