### PR TITLE
Fix file upload handler in SoundLibrary

### DIFF
--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -30,8 +30,9 @@
             <input
               type="file"
               accept="audio/*"
+              multiple
               class="hidden"
-              @change="emit('upload')"
+              @change="emit('upload', $event)"
             />
           </label>
         </div>


### PR DESCRIPTION
## Summary
- pass the change event up from `SoundGrid` so uploads work
- allow selecting multiple files at once

## Testing
- `npm test` *(fails: Process from config.webServer was not able to start)*

------
https://chatgpt.com/codex/tasks/task_e_6882cfde87a4832f8d3638f7bb069b01