### PR TITLE
Add user sound library modal

### DIFF
--- a/api/delete-file.js
+++ b/api/delete-file.js
@@ -1,0 +1,78 @@
+import { AwsClient } from "aws4fetch";
+
+export async function DELETE(request) {
+  const ALLOWED_ORIGIN =
+    process.env.NODE_ENV === 'production'
+      ? 'https://soundroom.live'
+      : '*';
+
+  const {
+    R2_ACCESS_KEY_ID,
+    R2_SECRET_ACCESS_KEY,
+    R2_BUCKET_NAME,
+    R2_ACCOUNT_ID,
+  } = process.env;
+
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
+    'Access-Control-Allow-Methods': 'DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Credentials': 'true',
+  };
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: corsHeaders,
+    });
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const bucket = searchParams.get('bucket');
+    const path = searchParams.get('path');
+
+    if (!bucket || !path) {
+      return new Response(
+        JSON.stringify({ error: "Missing 'bucket' or 'path' query param" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    const client = new AwsClient({
+      accessKeyId: R2_ACCESS_KEY_ID,
+      secretAccessKey: R2_SECRET_ACCESS_KEY,
+    });
+
+    const url = `https://${R2_BUCKET_NAME}.${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${bucket}/${path}`;
+    const signed = await client.sign(
+      new Request(url, { method: 'DELETE' }),
+      { aws: { signQuery: true } }
+    );
+
+    const res = await fetch(signed);
+    if (!res.ok) {
+      return new Response(
+        JSON.stringify({ error: 'Failed to delete file' }),
+        { status: res.status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('💥 DELETE ERROR:', err);
+    return new Response(
+      JSON.stringify({ error: 'Internal Server Error', message: err.message }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      }
+    );
+  }
+}

--- a/src/components/ui/modals/UserSoundLibrary/UserSoundGridItem.vue
+++ b/src/components/ui/modals/UserSoundLibrary/UserSoundGridItem.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="relative aspect-square flex flex-col items-center justify-between p-4 rounded-xl bg-neutral-100 dark:bg-neutral-800 shadow border border-neutral-300 dark:border-neutral-700">
+    <button
+      class="absolute top-1 right-1 text-neutral-400 hover:text-red-500"
+      @click="$emit('delete', sound)"
+    >
+      <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 16 16">
+        <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z" />
+      </svg>
+    </button>
+    <MarqueeTitle :text="getSourceName(sound.name)" />
+    <SoundPreviewCircle
+      :soundData="sound"
+      :currentlyPlayingId="currentlyPlayingId"
+      @updateCurrent="$emit('updateCurrent', $event)"
+    />
+  </div>
+</template>
+
+<script setup>
+import MarqueeTitle from '@/components/ui/text/MarqueeTitle.vue'
+import SoundPreviewCircle from '@/components/ui/modals/SoundLibrary/SoundPreviewCircle.vue'
+import { getSourceName } from '@/composables/useSelectedSource'
+
+const props = defineProps({
+  sound: Object,
+  currentlyPlayingId: String
+})
+
+defineEmits(['delete', 'updateCurrent'])
+</script>

--- a/src/components/ui/modals/UserSoundLibrary/UserSoundLibrary.vue
+++ b/src/components/ui/modals/UserSoundLibrary/UserSoundLibrary.vue
@@ -1,0 +1,68 @@
+<template>
+  <div @click.self="router.push('/')" class="modal-backdrop">
+    <div class="modal-panel flex">
+      <div class="flex-1 relative overflow-hidden">
+        <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-white/50 dark:bg-neutral-950/50 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800">
+          <h2 class="text-2xl font-bold">Your Sounds</h2>
+          <BaseButton class="text-sm" @click="router.push('/')">Close</BaseButton>
+        </div>
+        <div ref="gridScroll" class="mt-5 place-content-start p-6 pt-20 overflow-y-auto h-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          <UserSoundGridItem
+            v-for="sound in sounds"
+            :key="sound.id"
+            :sound="sound"
+            :currentlyPlayingId="currentlyPlayingId"
+            @delete="handleDelete(sound)"
+            @updateCurrent="currentlyPlayingId = $event"
+          />
+          <template v-if="!loading && sounds.length === 0">
+            <div class="col-span-full text-center text-neutral-400 mt-32">
+              <div class="text-xl font-semibold mb-2">No sounds uploaded</div>
+            </div>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { supabase } from '@/utils/supabase'
+import { useAuth } from '@/composables/useAuth'
+import BaseButton from '@/components/ui/input/BaseButton.vue'
+import UserSoundGridItem from './UserSoundGridItem.vue'
+
+const router = useRouter()
+const { user } = useAuth()
+
+const sounds = ref([])
+const loading = ref(true)
+const currentlyPlayingId = ref(null)
+
+onMounted(async () => {
+  if (!user.value) return
+  const { data, error } = await supabase
+    .from('sound_files')
+    .select()
+    .eq('owner_id', user.value.id)
+
+  if (!error) {
+    sounds.value = data.map(({ id, ...rest }) => ({ id, libraryId: id, ...rest }))
+  } else {
+    console.error('Failed to list user sounds:', error)
+  }
+  loading.value = false
+})
+
+async function handleDelete(sound) {
+  const { error } = await supabase.from('sound_files').delete().eq('id', sound.id)
+  if (error) {
+    console.error('Failed to remove record:', error)
+    return
+  }
+  await fetch(`/api/delete-file?bucket=${sound.bucket}&path=${encodeURIComponent(sound.path)}`, { method: 'DELETE' })
+  sounds.value = sounds.value.filter(s => s.id !== sound.id)
+}
+</script>

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -38,6 +38,11 @@ const router = createRouter({
           props: { component: () => import('@/components/ui/modals/RoomManager/RoomManager.vue') },
           meta: { requiresAuth: true }
         },
+        { path: '/your-sounds',
+          component: () => import('@/components/ui/modals/ModalWrapper.vue'),
+          props: { component: () => import('@/components/ui/modals/UserSoundLibrary/UserSoundLibrary.vue') },
+          meta: { requiresAuth: true }
+        },
       ]
     },
     { path: '/terms', component: () => import('@/views/TermsOfService.vue') },


### PR DESCRIPTION
## Summary
- create API endpoint `delete-file.js` for removing uploaded files from Cloudflare R2
- add `UserSoundLibrary` modal with a grid of user sounds
- include `UserSoundGridItem` with an `X` delete button
- register new `/your-sounds` route

## Testing
- `npm test` *(fails: downloadAudio tests and resetRoomState tests)*

------
https://chatgpt.com/codex/tasks/task_e_688d0a524960832f83da1dd1b474a4db