### PR TITLE
feat: enable deleting user sounds

### DIFF
--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -13,6 +13,7 @@
         v-bind="{ waiting, soundLibrarySources, currentlyPlayingId }"
         @toggle="$emit('toggleSound', $event)"
         @updateCurrent="$emit('updateCurrent', $event)"
+        @delete="$emit('delete', $event)"
       />
       <template v-if="userTier === 'pro' && activeCategory === 'your-sounds' && sounds.length === 0">
           <div class="col-span-full text-center text-neutral-400 mt-32">
@@ -51,7 +52,7 @@ const props = defineProps({
 })
 
 const { isAuthenticated, tier: userTier } = useAuth()
-const emit = defineEmits(['close', 'toggleSound', 'updateCurrent', 'upload'])
+const emit = defineEmits(['close', 'toggleSound', 'updateCurrent', 'upload', 'delete'])
 
 const gridScroll = ref(null)
 function scrollTop() {

--- a/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
@@ -16,8 +16,12 @@
     >
       {{ soundLibrarySources.find((s) => s.libraryId == sound.libraryId) ? 'Remove' : 'Load' }}
     </BaseButton>
-    <BaseButton v-if="userSound" class="hover:underline !bg-transparent !border-none hover:text-red-500 !text-xs">
-    Delete
+    <BaseButton
+      v-if="userSound"
+      class="hover:underline !bg-transparent !border-none hover:text-red-500 !text-xs"
+      @click="$emit('delete', sound)"
+    >
+      Delete
     </BaseButton>
   </div>
 </template>
@@ -37,7 +41,7 @@ const props = defineProps({
   userSound: Boolean
 })
 
-defineEmits(['toggle', 'updateCurrent'])
+defineEmits(['toggle', 'updateCurrent', 'delete'])
 </script>
 <style>
 .close-button {

--- a/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
@@ -21,13 +21,23 @@
         @toggleSound="toggleAddSource"
         @updateCurrent="currentlyPlayingId = $event"
         @upload="showUploadPanel = true"
+        @delete="promptDeleteSound"
       />
-     
+
     </div>
-  
+
+    <YesNoModal
+      v-if="deleteSoundModalVisible"
+      :yesFunction="doDeleteSound"
+      :noFunction="cancelDeleteSound"
+      message="Are you sure you want to delete this sound?"
+      title="Delete Sound"
+      @close="cancelDeleteSound"
+    />
+
   </div>
-  
-  
+
+
 </template>
 
 <script setup>
@@ -37,12 +47,14 @@ import { supabase } from '@/utils/supabase'
 
 import CategoryList from '@/components/ui/modals/SoundLibrary/CategoryList.vue'
 import SoundGrid from '@/components/ui/modals/SoundLibrary/SoundGrid.vue'
+import YesNoModal from '@/components/ui/modals/YesNoModal.vue'
 import { useRouter } from 'vue-router'
 
 import { useAudioCacheStore } from '@/stores/useAudioCacheStore'
 import { useActionManagerStore } from '@/stores/useActionManagerStore'
 import { useAuth } from '@/composables/useAuth'
 import { storeToRefs } from 'pinia'
+import deleteAudio from '@/utils/deleteAudio'
 
 
 
@@ -54,6 +66,8 @@ const actionStore = useActionManagerStore()
 const { waiting } = storeToRefs(actionStore)
 const { soundLibrarySources } = storeToRefs(cacheStore)
 const showUploadPanel = ref(false)
+const deleteSoundModalVisible = ref(false)
+const soundToDelete = ref(null)
 
 
 const categories = [
@@ -121,6 +135,32 @@ const refreshUserSounds = async () => {
       ...rest,
     }))
   }
+}
+
+function promptDeleteSound(sound) {
+  soundToDelete.value = sound
+  deleteSoundModalVisible.value = true
+}
+
+function cancelDeleteSound() {
+  deleteSoundModalVisible.value = false
+  soundToDelete.value = null
+}
+
+async function doDeleteSound() {
+  if (!soundToDelete.value) return
+  const s = soundToDelete.value
+  try {
+    if (soundLibrarySources.value.find(sound => sound.libraryId == s.libraryId)) {
+      await actionStore.deleteLibrarySoundSource(s)
+    }
+    await deleteAudio(s.bucket, s.path, s.plan_tier ?? 'users')
+    await supabase.from('sound_files').delete().eq('id', s.libraryId)
+    await refreshUserSounds()
+  } catch (error) {
+    console.error('Failed to delete user sound:', error)
+  }
+  cancelDeleteSound()
 }
 
 /**

--- a/src/utils/deleteAudio.js
+++ b/src/utils/deleteAudio.js
@@ -1,0 +1,17 @@
+/**
+ * Delete an audio file from the R2 bucket.
+ *
+ * @param {string} bucket - storage bucket name
+ * @param {string} path - path of the file within the bucket
+ * @param {string} base - base directory for the R2 bucket
+ * @returns {Promise<void>}
+ */
+export default async function deleteAudio(bucket, path, base) {
+  const params = new URLSearchParams({ bucket, path, base })
+  const res = await fetch(`/api/delete-file?${params.toString()}`, { method: 'DELETE' })
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => ({ error: 'Invalid JSON response' }))
+    throw new Error(errorData.error || 'Failed to delete file')
+  }
+  await res.json()
+}


### PR DESCRIPTION
## Summary
- allow deleting sounds from the user library
- confirm deletions with a minimal yes/no modal
- add utility to remove audio files from storage

## Testing
- `npm test` *(fails: expected spy to be called with arguments, Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_689153abfcfc832fbf067aa98606e51b