### PR TITLE
feat: speed up YAMNet classification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/supabase-js": "^2.49.7",
         "@tailwindcss/vite": "^4.1.7",
         "@tensorflow/tfjs": "^4.22.0",
+        "@tensorflow/tfjs-backend-wasm": "^4.22.0",
         "@tensorflow/tfjs-converter": "^4.22.0",
         "@vercel/functions": "^2.2.2",
         "@vercel/speed-insights": "^1.2.0",
@@ -1217,6 +1218,19 @@
         "@tensorflow/tfjs-core": "4.22.0"
       }
     },
+    "node_modules/@tensorflow/tfjs-backend-wasm": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-wasm/-/tfjs-backend-wasm-4.22.0.tgz",
+      "integrity": "sha512-/IYhReRIp4jg/wYW0OwbbJZG8ON87mbz0PgkiP3CdcACRSvUN0h8rvC0O3YcDtkTQtFWF/tcXq/KlVDyV49wmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tensorflow/tfjs-backend-cpu": "4.22.0",
+        "@types/emscripten": "~0.0.34"
+      },
+      "peerDependencies": {
+        "@tensorflow/tfjs-core": "4.22.0"
+      }
+    },
     "node_modules/@tensorflow/tfjs-backend-webgl": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-4.22.0.tgz",
@@ -1316,6 +1330,12 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/emscripten": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-0.0.34.tgz",
+      "integrity": "sha512-QSb9ojDincskc+uKMI0KXp8e1NALFINCrMlp8VGKGcTSxeEyRTTKyjWw75NYrCZHUsVEEEpr1tYHpbtaC++/sQ==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@supabase/supabase-js": "^2.49.7",
     "@tailwindcss/vite": "^4.1.7",
     "@tensorflow/tfjs": "^4.22.0",
+    "@tensorflow/tfjs-backend-wasm": "^4.22.0",
     "@tensorflow/tfjs-converter": "^4.22.0",
     "@vercel/functions": "^2.2.2",
     "@vercel/speed-insights": "^1.2.0",

--- a/src/workers/audioTaggerWorker.js
+++ b/src/workers/audioTaggerWorker.js
@@ -1,4 +1,17 @@
 import * as tf from '@tensorflow/tfjs';
+import '@tensorflow/tfjs-backend-wasm';
+
+async function initBackend() {
+  const backends = ['webgl', 'wasm', 'cpu'];
+  for (const name of backends) {
+    if (tf.findBackend(name)) {
+      await tf.setBackend(name);
+      await tf.ready();
+      if (tf.getBackend() === name) return name;
+    }
+  }
+  return tf.getBackend();
+}
 
 let model = null;
 let labels = [];
@@ -8,16 +21,28 @@ async function loadModelAndLabels() {
   if (model) return;
   if (!loadingPromise) {
     loadingPromise = (async () => {
-      await tf.setBackend('cpu');
+      await initBackend();
       model = await tf.loadGraphModel('/models/yamnet-tfjs/model.json');
+
+      // Warm up and JIT compile the model
+      try {
+        const warmup = tf.zeros([16000], 'float32');
+        const res = model.predict(warmup);
+        await res.data();
+        warmup.dispose();
+        res.dispose();
+      } catch (e) {
+        console.warn('Warmup failed', e);
+      }
+
       const res = await fetch('/models/yamnet-tfjs/yamnet_class_map.csv');
       const text = await res.text();
-      
+
       labels = text
-      .split('\n')
-      .slice(1)
-      .map(line => line.split(',')[2]?.replace(/"/g, '').trim())
-      .filter(Boolean);
+        .split('\n')
+        .slice(1)
+        .map(line => line.split(',')[2]?.replace(/"/g, '').trim())
+        .filter(Boolean);
     })();
   }
   await loadingPromise;
@@ -33,20 +58,23 @@ self.onmessage = async (event) => {
       return;
     }
     const inputTensor = tf.tensor(monoBuffer, [monoBuffer.length], 'float32');
-    const prediction = model.predict(inputTensor);
 
-    // tf.GraphModel.predict may return either a tensor or an array of tensors
-    const scoresTensor = Array.isArray(prediction) ? prediction[0] : prediction;
-    const scores = scoresTensor.arraySync(); // shape [frames, 521]
-    const averaged = tf.tensor(scores).mean(0).arraySync(); // shape [521]
+    const [values, indices] = tf.tidy(() => {
+      const prediction = model.predict(inputTensor);
+      const scoresTensor = Array.isArray(prediction) ? prediction[0] : prediction;
+      const averaged = scoresTensor.mean(0);
+      return tf.topk(averaged, 5);
+    });
 
-    const topTags = Array.from(averaged)
-      .map((score, i) => ({ score, label: labels[i] }))
-      .filter(t => t.score > 0.07)
-      .sort((a, b) => b.score - a.score)
-      .slice(0, 5)
-      .map(t => t.label);
-    
+    const [vals, idxs] = await Promise.all([values.data(), indices.data()]);
+    values.dispose();
+    indices.dispose();
+    inputTensor.dispose();
+
+    const topTags = [];
+    for (let i = 0; i < idxs.length; i++) {
+      if (vals[i] > 0.07) topTags.push(labels[idxs[i]]);
+    }
 
     self.postMessage({ id, tags: topTags });
   } catch (err) {


### PR DESCRIPTION
## Summary
- choose best available TensorFlow.js backend and warm up the YAMNet model
- avoid synchronous tensor conversions by using `tf.topk`
- add WASM backend dependency for broader device support

## Testing
- `npm test` *(fails: downloadAudio and resetRoomState unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f9313932c832f94c75880365343f7