### PR TITLE
Add Stripe checkout integration for pricing plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,22 @@ Planned next-phase upgrades:
    npm install
    ```
 
-3. **Create `.env` for Supabase**
+3. **Create `.env` for Supabase & Stripe**
    ```env
    # .env.example
    VITE_SUPABASE_URL=https://your-project-id.supabase.co
    VITE_SUPABASE_KEY=your-anon-key
 
+   # Stripe publishable key (browser)
+   VITE_STRIPE_PUBLISHABLE_KEY=pk_test_...
+
+   # Stripe server-side secrets (set in Vercel/hosting environment)
+   STRIPE_SECRET_KEY=sk_test_...
+   STRIPE_BASIC_PRICE_ID=price_basic_...
+   STRIPE_PRO_PRICE_ID=price_pro_...
+
+   # Base URL used for checkout success/cancel fallbacks
+   PUBLIC_APP_URL=http://localhost:5173
    ```
 
 4. **Run locally**

--- a/api/create-checkout-session.js
+++ b/api/create-checkout-session.js
@@ -1,0 +1,97 @@
+import Stripe from 'stripe'
+
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY
+
+if (!stripeSecretKey) {
+  console.warn('Missing STRIPE_SECRET_KEY environment variable. Stripe checkout API will not function.')
+}
+
+const stripe = stripeSecretKey
+  ? new Stripe(stripeSecretKey, {
+      apiVersion: '2024-09-30.acacia',
+    })
+  : null
+
+const ALLOWED_ORIGIN = process.env.NODE_ENV === 'production' ? 'https://soundroom.live' : '*'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Access-Control-Allow-Credentials': 'true',
+}
+
+const PLAN_PRICE_MAPPING = {
+  basic: process.env.STRIPE_BASIC_PRICE_ID,
+  pro: process.env.STRIPE_PRO_PRICE_ID,
+}
+
+function jsonResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...corsHeaders,
+      ...(init.headers || {}),
+    },
+  })
+}
+
+export function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders,
+  })
+}
+
+export async function POST(request) {
+  if (!stripe) {
+    return jsonResponse({ error: 'Stripe is not configured' }, { status: 500 })
+  }
+
+  try {
+    const payload = await request.json()
+    const planId = String(payload.planId || '').toLowerCase()
+    const successUrl = payload.successUrl
+    const cancelUrl = payload.cancelUrl
+    const customerEmail = payload.customerEmail ? String(payload.customerEmail) : undefined
+    const clientReferenceId = payload.clientReferenceId ? String(payload.clientReferenceId) : undefined
+
+    if (!planId) {
+      return jsonResponse({ error: 'Missing planId' }, { status: 400 })
+    }
+
+    const priceId = PLAN_PRICE_MAPPING[planId]
+
+    if (!priceId) {
+      return jsonResponse({ error: 'Unsupported plan selected' }, { status: 400 })
+    }
+
+    const baseUrl = process.env.PUBLIC_APP_URL || 'https://soundroom.live'
+
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      line_items: [
+        {
+          price: priceId,
+          quantity: 1,
+        },
+      ],
+      allow_promotion_codes: true,
+      automatic_tax: { enabled: true },
+      billing_address_collection: 'auto',
+      customer_email: customerEmail,
+      client_reference_id: clientReferenceId,
+      success_url: successUrl || `${baseUrl}/manage-plan?checkout=success`,
+      cancel_url: cancelUrl || `${baseUrl}/upgrade?checkout=cancel`,
+      metadata: {
+        planId,
+      },
+    })
+
+    return jsonResponse({ sessionId: session.id })
+  } catch (error) {
+    console.error('Error creating Stripe checkout session', error)
+    return jsonResponse({ error: 'Unable to start checkout' }, { status: 500 })
+  }
+}

--- a/api/create-checkout-session.js
+++ b/api/create-checkout-session.js
@@ -7,9 +7,7 @@ if (!stripeSecretKey) {
 }
 
 const stripe = stripeSecretKey
-  ? new Stripe(stripeSecretKey, {
-      apiVersion: '2024-09-30.acacia',
-    })
+  ? new Stripe(stripeSecretKey)
   : null
 
 const ALLOWED_ORIGIN = process.env.NODE_ENV === 'production' ? 'https://soundroom.live' : '*'
@@ -46,28 +44,27 @@ export function OPTIONS() {
 
 export async function POST(request) {
   if (!stripe) {
-    return jsonResponse({ error: 'Stripe is not configured' }, { status: 500 })
+    return jsonResponse({ error: 'Stripe is not configured' }, { status: 500 });
   }
 
   try {
-    const payload = await request.json()
-    const planId = String(payload.planId || '').toLowerCase()
-    const successUrl = payload.successUrl
-    const cancelUrl = payload.cancelUrl
-    const customerEmail = payload.customerEmail ? String(payload.customerEmail) : undefined
-    const clientReferenceId = payload.clientReferenceId ? String(payload.clientReferenceId) : undefined
+    const payload = await request.json();
+    const planId = String(payload.planId || '').toLowerCase();
+    const successUrl = payload.successUrl;
+    const cancelUrl = payload.cancelUrl;
+    const customerEmail = payload.customerEmail ? String(payload.customerEmail) : undefined;
+    const clientReferenceId = payload.clientReferenceId ? String(payload.clientReferenceId) : undefined;
 
     if (!planId) {
-      return jsonResponse({ error: 'Missing planId' }, { status: 400 })
+      return jsonResponse({ error: 'Missing planId' }, { status: 400 });
     }
 
-    const priceId = PLAN_PRICE_MAPPING[planId]
-
+    const priceId = PLAN_PRICE_MAPPING[planId];
     if (!priceId) {
-      return jsonResponse({ error: 'Unsupported plan selected' }, { status: 400 })
+      return jsonResponse({ error: 'Unsupported plan selected' }, { status: 400 });
     }
 
-    const baseUrl = process.env.PUBLIC_APP_URL || 'https://soundroom.live'
+    const baseUrl = process.env.PUBLIC_APP_URL || 'https://soundroom.live';
 
     const session = await stripe.checkout.sessions.create({
       mode: 'subscription',
@@ -78,20 +75,18 @@ export async function POST(request) {
         },
       ],
       allow_promotion_codes: true,
-      automatic_tax: { enabled: true },
       billing_address_collection: 'auto',
       customer_email: customerEmail,
       client_reference_id: clientReferenceId,
       success_url: successUrl || `${baseUrl}/manage-plan?checkout=success`,
       cancel_url: cancelUrl || `${baseUrl}/upgrade?checkout=cancel`,
-      metadata: {
-        planId,
-      },
-    })
+      metadata: { planId },
+    });
 
-    return jsonResponse({ sessionId: session.id })
+    return jsonResponse({ sessionUrl: session.url });
   } catch (error) {
-    console.error('Error creating Stripe checkout session', error)
-    return jsonResponse({ error: 'Unable to start checkout' }, { status: 500 })
+    console.error('Error creating Stripe checkout session', error);
+    return jsonResponse({ error: 'Unable to start checkout' }, { status: 500 });
   }
 }
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@sentry/vite-plugin": "^4.3.0",
         "@sentry/vue": "^10.15.0",
+        "@stripe/stripe-js": "^8.1.0",
         "@supabase/supabase-js": "^2.49.7",
         "@tailwindcss/vite": "^4.1.7",
         "@tensorflow/tfjs": "^4.22.0",
@@ -25,6 +26,7 @@
         "p-limit": "^6.2.0",
         "pinia": "^3.0.3",
         "portal-vue": "^3.0.0-beta.0",
+        "stripe": "^19.1.0",
         "tailwindcss": "^4.1.7",
         "vite-svg-loader": "^5.1.0",
         "vue": "^3.5.14",
@@ -1342,6 +1344,15 @@
         }
       }
     },
+    "node_modules/@stripe/stripe-js": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-8.1.0.tgz",
+      "integrity": "sha512-bhhi0iSHDFRa2pPVv3WOHC6x/iGEu5AZqIiAvXsT8VOucsEre9gzgsK0jFzbzfGW2eeubF+mCdTTYwNAQCMJKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.69.1",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.69.1.tgz",
@@ -2442,6 +2453,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3833,6 +3860,18 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/p-limit": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
@@ -4094,6 +4133,21 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -4213,6 +4267,78 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -4304,6 +4430,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-19.1.0.tgz",
+      "integrity": "sha512-FjgIiE98dMMTNssfdjMvFdD4eZyEzdWAOwPYqzhPRNZeg9ggFWlPXmX1iJKD5pPIwZBaPlC3SayQQkwsPo6/YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@types/node": ">=16"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/superjson": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@sentry/vite-plugin": "^4.3.0",
     "@sentry/vue": "^10.15.0",
+    "@stripe/stripe-js": "^8.1.0",
     "@supabase/supabase-js": "^2.49.7",
     "@tailwindcss/vite": "^4.1.7",
     "@tensorflow/tfjs": "^4.22.0",
@@ -29,6 +30,7 @@
     "p-limit": "^6.2.0",
     "pinia": "^3.0.3",
     "portal-vue": "^3.0.0-beta.0",
+    "stripe": "^19.1.0",
     "tailwindcss": "^4.1.7",
     "vite-svg-loader": "^5.1.0",
     "vue": "^3.5.14",

--- a/src/utils/stripe.js
+++ b/src/utils/stripe.js
@@ -53,20 +53,19 @@ export async function redirectToCheckout(options) {
     }),
   })
 
+  console.log(response)
+
   if (!response.ok) {
     const errorPayload = await response.json().catch(() => ({ error: 'Unknown error' }))
     throw new Error(errorPayload.error || 'Unable to start checkout')
   }
 
-  const { sessionId } = await response.json()
+  const { sessionUrl } = await response.json()
 
-  if (!sessionId) {
-    throw new Error('Stripe session was not returned')
+  if (!sessionUrl) {
+    throw new Error('Stripe session URL was not returned')
   }
 
-  const { error } = await stripe.redirectToCheckout({ sessionId })
-
-  if (error) {
-    throw error
-  }
+  window.location.href = sessionUrl; // navigate to Stripe directly
+  
 }

--- a/src/utils/stripe.js
+++ b/src/utils/stripe.js
@@ -1,0 +1,72 @@
+import { loadStripe } from '@stripe/stripe-js'
+
+let stripePromise
+
+/**
+ * Lazily load the Stripe.js instance using the publishable key.
+ *
+ * @returns {Promise<import('@stripe/stripe-js').Stripe | null>}
+ */
+export function getStripe() {
+  if (!stripePromise) {
+    const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
+    if (!publishableKey) {
+      console.warn('Stripe publishable key is not defined. Checkout is disabled.')
+      return Promise.resolve(null)
+    }
+
+    stripePromise = loadStripe(publishableKey)
+  }
+
+  return stripePromise
+}
+
+/**
+ * Create a checkout session for the selected plan and redirect the user.
+ *
+ * @param {{
+ *   planId: string,
+ *   customerEmail?: string,
+ *   successUrl?: string,
+ *   cancelUrl?: string,
+ *   clientReferenceId?: string,
+ * }} options
+ */
+export async function redirectToCheckout(options) {
+  const stripe = await getStripe()
+
+  if (!stripe) {
+    throw new Error('Stripe failed to load')
+  }
+
+  const response = await fetch('/api/create-checkout-session', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      planId: options.planId,
+      customerEmail: options.customerEmail,
+      successUrl: options.successUrl,
+      cancelUrl: options.cancelUrl,
+      clientReferenceId: options.clientReferenceId,
+    }),
+  })
+
+  if (!response.ok) {
+    const errorPayload = await response.json().catch(() => ({ error: 'Unknown error' }))
+    throw new Error(errorPayload.error || 'Unable to start checkout')
+  }
+
+  const { sessionId } = await response.json()
+
+  if (!sessionId) {
+    throw new Error('Stripe session was not returned')
+  }
+
+  const { error } = await stripe.redirectToCheckout({ sessionId })
+
+  if (error) {
+    throw error
+  }
+}

--- a/src/views/Pricing/Pricing.vue
+++ b/src/views/Pricing/Pricing.vue
@@ -12,7 +12,7 @@
           </p>
           <div class="grid gap-6 mx-auto max-w-6xl justify-items-center md:grid-cols-2 xl:grid-cols-3">
             <PricingCard
-              v-for="plan in displayPlans"
+              v-for="plan in plansWithCheckoutState"
               class="w-full max-w-sm"
               :key="plan.id"
               :title="plan.name"
@@ -23,8 +23,16 @@
               :cta-label="plan.ctaLabel"
               :cta-disabled="plan.ctaDisabled"
               :plan-id="plan.id"
+              :cta-busy="plan.ctaBusy"
+              @select-plan="() => handlePlanSelect(plan)"
             />
           </div>
+          <p
+            v-if="checkoutError"
+            class="text-sm text-red-600 dark:text-red-400 text-center"
+          >
+            {{ checkoutError }}
+          </p>
           <div class="max-w-5xl mx-auto rounded-md border border-neutral-200 bg-white p-4 text-left shadow-sm dark:border-neutral-800 dark:bg-neutral-950" data-testid="pricing-feature-comparison">
             <div class="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Full feature comparison</div>
             <PlanComparisonTable class="mt-4" :plans="basePlans" :features="FEATURE_DEFINITIONS" />
@@ -36,15 +44,16 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import BaseButton from '@/components/ui/input/BaseButton.vue'
 import PricingCard from '@/views/Pricing/PricingCard.vue'
 import PlanComparisonTable from '@/views/Pricing/PlanComparisonTable.vue'
 import { useAuth } from '@/composables/useAuth'
+import { redirectToCheckout } from '@/utils/stripe'
 
 const router = useRouter()
-const { tier } = useAuth()
+const { tier, isAuthenticated, user } = useAuth()
 
 const closeModal = () => {
   router.push('/')
@@ -215,6 +224,54 @@ const displayPlans = computed(() => {
     }
   })
 })
+
+const activeCheckoutPlan = ref(null)
+const checkoutError = ref('')
+
+const plansWithCheckoutState = computed(() =>
+  displayPlans.value.map(plan => ({
+    ...plan,
+    ctaBusy: activeCheckoutPlan.value === plan.id,
+  }))
+)
+
+const isDowngrade = (planId) => {
+  const userIndex = PLAN_ORDER.indexOf(currentTier.value)
+  const planIndex = PLAN_ORDER.indexOf(planId)
+  return userIndex !== -1 && planIndex !== -1 && planIndex < userIndex
+}
+
+const handlePlanSelect = async (plan) => {
+  checkoutError.value = ''
+
+  if (isDowngrade(plan.id)) {
+    router.push('/manage-plan')
+    return
+  }
+
+  if (!isAuthenticated.value) {
+    router.push({ path: '/signup', query: { redirect: '/upgrade', plan: plan.id } })
+    return
+  }
+
+  const origin = typeof window !== 'undefined' ? window.location.origin : undefined
+
+  try {
+    activeCheckoutPlan.value = plan.id
+    await redirectToCheckout({
+      planId: plan.id,
+      customerEmail: user.value?.email ?? undefined,
+      clientReferenceId: user.value?.id ?? undefined,
+      successUrl: origin ? `${origin}/manage-plan?checkout=success` : undefined,
+      cancelUrl: origin ? `${origin}/upgrade?checkout=cancel` : undefined,
+    })
+  } catch (error) {
+    console.error('Stripe checkout failed', error)
+    checkoutError.value = error?.message || 'Unable to start checkout. Please try again.'
+  } finally {
+    activeCheckoutPlan.value = null
+  }
+}
 </script>
 
 <style scoped>

--- a/src/views/Pricing/PricingCard.vue
+++ b/src/views/Pricing/PricingCard.vue
@@ -22,10 +22,11 @@
     
     <button
       :class="ctaClasses"
-      :disabled="ctaDisabled"
+      :disabled="ctaDisabled || ctaBusy"
       type="button"
+      @click="$emit('select-plan')"
     >
-      {{ ctaLabel }}
+      {{ ctaText }}
     </button>
   </div>
 </template>
@@ -48,6 +49,8 @@ const STATUS_STYLES = {
     dot: 'bg-neutral-400 dark:bg-neutral-500'
   }
 }
+
+defineEmits(['select-plan'])
 
 const props = defineProps({
   title: String,
@@ -72,6 +75,10 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
+  ctaBusy: {
+    type: Boolean,
+    default: false
+  },
   planId: {
     type: String,
     default: 'free'
@@ -93,6 +100,8 @@ const ctaClasses = computed(() => [
   BASE_CTA_CLASS,
   planTheme.value.cta
 ])
+
+const ctaText = computed(() => (props.ctaBusy ? 'Redirecting…' : props.ctaLabel))
 
 const normalizeFeature = feature => {
   if (typeof feature === 'string') {


### PR DESCRIPTION
## Summary
- add Stripe client and server dependencies along with an API endpoint to create checkout sessions
- hook the pricing modal up to Stripe checkout with loading states, auth guarding, and downgrade routing
- document the required Stripe environment variables for local and hosted configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fe83a13488832fadab9376c50002e4