### PR TITLE
Implement Stripe webhooks and plan management

### DIFF
--- a/api/_utils/http.js
+++ b/api/_utils/http.js
@@ -1,0 +1,19 @@
+export const ALLOWED_ORIGIN = process.env.NODE_ENV === 'production' ? 'https://soundroom.live' : '*'
+
+export const corsHeaders = {
+  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Stripe-Signature, Authorization',
+  'Access-Control-Allow-Credentials': 'true',
+}
+
+export function jsonResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...corsHeaders,
+      ...(init.headers || {}),
+    },
+  })
+}

--- a/api/_utils/serverClients.js
+++ b/api/_utils/serverClients.js
@@ -1,0 +1,30 @@
+import Stripe from 'stripe'
+import { createClient } from '@supabase/supabase-js'
+
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY
+
+if (!stripeSecretKey) {
+  console.warn('Missing STRIPE_SECRET_KEY environment variable. Stripe functionality is disabled.')
+}
+
+export const stripe = stripeSecretKey ? new Stripe(stripeSecretKey) : null
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl) {
+  console.warn('Missing SUPABASE_URL environment variable. Supabase admin client cannot be created.')
+}
+
+if (!supabaseServiceKey) {
+  console.warn('Missing SUPABASE_SERVICE_ROLE_KEY environment variable. Supabase admin client cannot be created.')
+}
+
+export const supabaseAdmin =
+  supabaseUrl && supabaseServiceKey
+    ? createClient(supabaseUrl, supabaseServiceKey, {
+        auth: {
+          persistSession: false,
+        },
+      })
+    : null

--- a/api/_utils/stripePlans.js
+++ b/api/_utils/stripePlans.js
@@ -1,0 +1,25 @@
+const PLAN_PRICE_MAPPING = {
+  basic: process.env.STRIPE_BASIC_PRICE_ID,
+  pro: process.env.STRIPE_PRO_PRICE_ID,
+}
+
+const PRICE_PLAN_MAPPING = Object.entries(PLAN_PRICE_MAPPING).reduce((acc, [plan, priceId]) => {
+  if (priceId) acc[priceId] = plan
+  return acc
+}, {})
+
+export function normalizePlanId(value) {
+  if (!value) return null
+  const normalized = String(value).toLowerCase()
+  if (normalized === 'free' || normalized === 'basic' || normalized === 'pro') {
+    return normalized
+  }
+  return null
+}
+
+export function getPlanFromPriceId(priceId) {
+  if (!priceId) return null
+  return PRICE_PLAN_MAPPING[priceId] ?? null
+}
+
+export { PLAN_PRICE_MAPPING }

--- a/api/_utils/userPlan.js
+++ b/api/_utils/userPlan.js
@@ -43,3 +43,48 @@ export async function updateUserPlanTier({ userId, plan, customerId, subscriptio
 
   return normalizedPlan
 }
+
+export async function resolveUserForStripe({ userId, customerId, customerEmail }) {
+  if (!supabaseAdmin) {
+    throw new Error('Supabase admin client is not configured')
+  }
+
+  if (userId) {
+    return userId
+  }
+
+  if (customerId) {
+    const { data, error } = await supabaseAdmin
+      .from('users')
+      .select('id')
+      .eq('stripe_customer_id', customerId)
+      .maybeSingle()
+
+    if (!error && data?.id) {
+      return data.id
+    }
+  }
+
+  if (customerEmail) {
+    try {
+      const { data } = await supabaseAdmin.auth.admin.getUserByEmail(customerEmail)
+      if (data?.user?.id) {
+        return data.user.id
+      }
+    } catch (error) {
+      console.warn('Failed to resolve user via Supabase auth email lookup', error)
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from('users')
+      .select('id')
+      .eq('email', customerEmail)
+      .maybeSingle()
+
+    if (!error && data?.id) {
+      return data.id
+    }
+  }
+
+  return null
+}

--- a/api/_utils/userPlan.js
+++ b/api/_utils/userPlan.js
@@ -1,0 +1,45 @@
+import { supabaseAdmin } from './serverClients.js'
+import { normalizePlanId } from './stripePlans.js'
+
+const DEFAULT_PLAN = 'free'
+
+export async function updateUserPlanTier({ userId, plan, customerId, subscriptionId }) {
+  if (!supabaseAdmin) {
+    throw new Error('Supabase admin client is not configured')
+  }
+
+  if (!userId) {
+    throw new Error('Missing user reference for plan update')
+  }
+
+  const normalizedPlan = normalizePlanId(plan) ?? DEFAULT_PLAN
+
+  const updatePayload = { plan_tier: normalizedPlan }
+
+  if (customerId !== undefined) {
+    updatePayload.stripe_customer_id = customerId
+  }
+
+  if (subscriptionId !== undefined) {
+    updatePayload.stripe_subscription_id = subscriptionId
+  }
+
+  const { error } = await supabaseAdmin.from('users').update(updatePayload).eq('id', userId)
+
+  if (error) {
+    if (error.code === '42703') {
+      const { error: fallbackError } = await supabaseAdmin
+        .from('users')
+        .update({ plan_tier: normalizedPlan })
+        .eq('id', userId)
+
+      if (fallbackError) {
+        throw new Error(`Supabase plan update failed: ${fallbackError.message}`)
+      }
+    } else {
+      throw new Error(`Supabase plan update failed: ${error.message}`)
+    }
+  }
+
+  return normalizedPlan
+}

--- a/api/create-checkout-session.js
+++ b/api/create-checkout-session.js
@@ -1,39 +1,6 @@
-import Stripe from 'stripe'
-
-const stripeSecretKey = process.env.STRIPE_SECRET_KEY
-
-if (!stripeSecretKey) {
-  console.warn('Missing STRIPE_SECRET_KEY environment variable. Stripe checkout API will not function.')
-}
-
-const stripe = stripeSecretKey
-  ? new Stripe(stripeSecretKey)
-  : null
-
-const ALLOWED_ORIGIN = process.env.NODE_ENV === 'production' ? 'https://soundroom.live' : '*'
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type',
-  'Access-Control-Allow-Credentials': 'true',
-}
-
-const PLAN_PRICE_MAPPING = {
-  basic: process.env.STRIPE_BASIC_PRICE_ID,
-  pro: process.env.STRIPE_PRO_PRICE_ID,
-}
-
-function jsonResponse(body, init = {}) {
-  return new Response(JSON.stringify(body), {
-    ...init,
-    headers: {
-      'Content-Type': 'application/json',
-      ...corsHeaders,
-      ...(init.headers || {}),
-    },
-  })
-}
+import { corsHeaders, jsonResponse } from './_utils/http.js'
+import { stripe } from './_utils/serverClients.js'
+import { PLAN_PRICE_MAPPING } from './_utils/stripePlans.js'
 
 export function OPTIONS() {
   return new Response(null, {
@@ -64,7 +31,21 @@ export async function POST(request) {
       return jsonResponse({ error: 'Unsupported plan selected' }, { status: 400 });
     }
 
+    if (!clientReferenceId) {
+      return jsonResponse({ error: 'Missing user reference for checkout' }, { status: 400 });
+    }
+
     const baseUrl = process.env.PUBLIC_APP_URL || 'https://soundroom.live';
+
+    const metadata = { planId };
+    if (clientReferenceId) metadata.userId = clientReferenceId;
+
+    const subscriptionMetadata = { planId };
+    if (clientReferenceId) subscriptionMetadata.userId = clientReferenceId;
+
+    const successUrlWithSession = successUrl
+      || `${baseUrl}/manage-plan?checkout=success&session_id={CHECKOUT_SESSION_ID}`;
+    const cancelUrlWithSession = cancelUrl || `${baseUrl}/upgrade?checkout=cancel`;
 
     const session = await stripe.checkout.sessions.create({
       mode: 'subscription',
@@ -78,9 +59,12 @@ export async function POST(request) {
       billing_address_collection: 'auto',
       customer_email: customerEmail,
       client_reference_id: clientReferenceId,
-      success_url: successUrl || `${baseUrl}/manage-plan?checkout=success`,
-      cancel_url: cancelUrl || `${baseUrl}/upgrade?checkout=cancel`,
-      metadata: { planId },
+      success_url: successUrlWithSession,
+      cancel_url: cancelUrlWithSession,
+      metadata,
+      subscription_data: {
+        metadata: subscriptionMetadata,
+      },
     });
 
     return jsonResponse({ sessionUrl: session.url });

--- a/api/manage-plan.js
+++ b/api/manage-plan.js
@@ -1,0 +1,105 @@
+import { corsHeaders, jsonResponse } from './_utils/http.js'
+import { stripe, supabaseAdmin } from './_utils/serverClients.js'
+import { updateUserPlanTier } from './_utils/userPlan.js'
+
+async function authenticateRequest(request) {
+  if (!supabaseAdmin) {
+    throw new Error('Supabase admin client is not configured')
+  }
+
+  const authHeader = request.headers.get('authorization') || request.headers.get('Authorization') || ''
+  const token = authHeader.startsWith('Bearer ') ? authHeader.slice('Bearer '.length).trim() : ''
+
+  if (!token) {
+    throw new Error('Missing access token')
+  }
+
+  const { data, error } = await supabaseAdmin.auth.getUser(token)
+
+  if (error || !data?.user) {
+    throw new Error('Invalid or expired access token')
+  }
+
+  return data.user
+}
+
+async function cancelSubscriptionIfNeeded(subscriptionId) {
+  if (!subscriptionId) {
+    return
+  }
+
+  if (!stripe) {
+    throw new Error('Stripe is not configured for subscription management')
+  }
+
+  try {
+    await stripe.subscriptions.cancel(subscriptionId)
+  } catch (error) {
+    if (error?.statusCode === 404) {
+      return
+    }
+
+    throw error
+  }
+}
+
+export function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders,
+  })
+}
+
+export async function POST(request) {
+  let payload
+
+  try {
+    payload = await request.json()
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON payload' }, { status: 400 })
+  }
+
+  const action = typeof payload.action === 'string' ? payload.action.toLowerCase() : ''
+
+  if (action !== 'downgrade') {
+    return jsonResponse({ error: 'Unsupported action' }, { status: 400 })
+  }
+
+  let user
+
+  try {
+    user = await authenticateRequest(request)
+  } catch (error) {
+    return jsonResponse({ error: error.message }, { status: 401 })
+  }
+
+  try {
+    const { data: profile, error: profileError } = await supabaseAdmin
+      .from('users')
+      .select('stripe_subscription_id, stripe_customer_id')
+      .eq('id', user.id)
+      .single()
+
+    if (profileError) {
+      throw new Error(profileError.message)
+    }
+
+    const subscriptionId = profile?.stripe_subscription_id || null
+
+    if (subscriptionId) {
+      await cancelSubscriptionIfNeeded(subscriptionId)
+    }
+
+    const normalizedPlan = await updateUserPlanTier({
+      userId: user.id,
+      plan: 'free',
+      subscriptionId: null,
+      customerId: profile?.stripe_customer_id ?? undefined,
+    })
+
+    return jsonResponse({ status: 'ok', plan: normalizedPlan })
+  } catch (error) {
+    console.error('Failed to update plan', error)
+    return jsonResponse({ error: error.message || 'Unable to update plan' }, { status: 500 })
+  }
+}

--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -1,0 +1,122 @@
+import { Buffer } from 'node:buffer'
+import { corsHeaders, jsonResponse } from './_utils/http.js'
+import { stripe } from './_utils/serverClients.js'
+import { getPlanFromPriceId, normalizePlanId } from './_utils/stripePlans.js'
+import { updateUserPlanTier } from './_utils/userPlan.js'
+
+const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
+
+if (!webhookSecret) {
+  console.warn('Missing STRIPE_WEBHOOK_SECRET environment variable. Stripe webhooks will not be verified.')
+}
+
+export function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders,
+  })
+}
+
+export async function POST(request) {
+  if (!stripe || !webhookSecret) {
+    return jsonResponse({ error: 'Stripe webhook is not configured' }, { status: 500 })
+  }
+
+  const signature = request.headers.get('stripe-signature')
+
+  if (!signature) {
+    return jsonResponse({ error: 'Missing Stripe signature' }, { status: 400 })
+  }
+
+  let event
+
+  try {
+    const bodyBuffer = Buffer.from(await request.arrayBuffer())
+    event = stripe.webhooks.constructEvent(bodyBuffer, signature, webhookSecret)
+  } catch (error) {
+    console.error('Stripe webhook signature verification failed', error)
+    return jsonResponse({ error: `Webhook Error: ${error.message}` }, { status: 400 })
+  }
+
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed':
+        await handleCheckoutSessionCompleted(event.data.object)
+        break
+      case 'customer.subscription.created':
+      case 'customer.subscription.updated':
+      case 'customer.subscription.deleted':
+        await handleSubscriptionEvent(event.data.object)
+        break
+      default:
+        break
+    }
+
+    return jsonResponse({ received: true })
+  } catch (error) {
+    console.error('Error handling Stripe webhook', error)
+    return jsonResponse({ error: 'Failed to process webhook' }, { status: 500 })
+  }
+}
+
+async function handleCheckoutSessionCompleted(session) {
+  if (!session) return
+  if (session.payment_status && session.payment_status !== 'paid') return
+
+  const userId = session.client_reference_id || session.metadata?.userId
+  if (!userId) return
+
+  let plan = normalizePlanId(session.metadata?.planId)
+
+  let subscriptionId = null
+  let subscription = null
+
+  if (typeof session.subscription === 'string') {
+    subscriptionId = session.subscription
+  } else if (session.subscription) {
+    subscriptionId = session.subscription.id
+    subscription = session.subscription
+  }
+
+  if (!plan && subscriptionId) {
+    subscription = subscription || (await stripe.subscriptions.retrieve(subscriptionId, { expand: ['items'] }))
+    const priceId = subscription?.items?.data?.[0]?.price?.id
+    plan = getPlanFromPriceId(priceId)
+  }
+
+  const customerId = typeof session.customer === 'string' ? session.customer : session.customer?.id
+
+  await updateUserPlanTier({
+    userId,
+    plan,
+    customerId,
+    subscriptionId,
+  })
+}
+
+async function handleSubscriptionEvent(subscription) {
+  if (!subscription) return
+
+  const userId = subscription.metadata?.userId
+  if (!userId) return
+
+  const status = subscription.status
+  let plan = null
+
+  if (status === 'active' || status === 'trialing') {
+    const priceId = subscription.items?.data?.[0]?.price?.id
+    plan = getPlanFromPriceId(priceId) || normalizePlanId(subscription.metadata?.planId)
+  } else {
+    plan = 'free'
+  }
+
+  const customerId = typeof subscription.customer === 'string' ? subscription.customer : subscription.customer?.id
+  const subscriptionIdValue = plan === 'free' ? null : subscription.id
+
+  await updateUserPlanTier({
+    userId,
+    plan,
+    customerId,
+    subscriptionId: subscriptionIdValue,
+  })
+}

--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -1,14 +1,8 @@
 import { Buffer } from 'node:buffer'
 import { corsHeaders, jsonResponse } from './_utils/http.js'
-import { stripe } from './_utils/serverClients.js'
-import { getPlanFromPriceId, normalizePlanId } from './_utils/stripePlans.js'
-import { resolveUserForStripe, updateUserPlanTier } from './_utils/userPlan.js'
+import { stripe, supabaseAdmin } from './_utils/serverClients.js'
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
-
-if (!webhookSecret) {
-  console.warn('Missing STRIPE_WEBHOOK_SECRET environment variable. Stripe webhooks will not be verified.')
-}
 
 export function OPTIONS() {
   return new Response(null, {
@@ -18,12 +12,12 @@ export function OPTIONS() {
 }
 
 export async function POST(request) {
-  if (!stripe || !webhookSecret) {
+  if (!stripe || !supabaseAdmin || !webhookSecret) {
+    console.error('Stripe webhook invoked without required configuration')
     return jsonResponse({ error: 'Stripe webhook is not configured' }, { status: 500 })
   }
 
   const signature = request.headers.get('stripe-signature')
-
   if (!signature) {
     return jsonResponse({ error: 'Missing Stripe signature' }, { status: 400 })
   }
@@ -31,151 +25,149 @@ export async function POST(request) {
   let event
 
   try {
-    const bodyBuffer = Buffer.from(await request.arrayBuffer())
-    event = stripe.webhooks.constructEvent(bodyBuffer, signature, webhookSecret)
+    const payload = Buffer.from(await request.arrayBuffer())
+    event = stripe.webhooks.constructEvent(payload, signature, webhookSecret)
   } catch (error) {
-    console.error('Stripe webhook signature verification failed', error)
-    return jsonResponse({ error: `Webhook Error: ${error.message}` }, { status: 400 })
+    console.error('Invalid Stripe webhook signature', error)
+    return jsonResponse({ error: 'Invalid signature' }, { status: 400 })
   }
 
   try {
     switch (event.type) {
-      case 'checkout.session.completed':
-        await handleCheckoutSessionCompleted(event.data.object)
+      case 'checkout.session.completed': {
+        const session = event.data.object
+        await handleCheckoutSessionCompleted(session)
         break
-      case 'customer.subscription.created':
-      case 'customer.subscription.updated':
-      case 'customer.subscription.deleted':
-        await handleSubscriptionEvent(event.data.object)
+      }
+      case 'customer.subscription.updated': {
+        const subscription = event.data.object
+        await handleSubscriptionUpdated(subscription)
         break
+      }
+      case 'customer.subscription.deleted': {
+        const subscription = event.data.object
+        await handleSubscriptionDeleted(subscription)
+        break
+      }
       default:
         break
     }
 
     return jsonResponse({ received: true })
   } catch (error) {
-    console.error('Error handling Stripe webhook', error)
+    console.error('Error handling Stripe webhook event', error)
     return jsonResponse({ error: 'Failed to process webhook' }, { status: 500 })
   }
 }
 
 async function handleCheckoutSessionCompleted(session) {
   if (!session) return
-  if (session.payment_status && session.payment_status !== 'paid') return
 
-  const customerId = typeof session.customer === 'string' ? session.customer : session.customer?.id
-  const customerEmail =
-    session.customer_details?.email ||
-    session.customer_email ||
-    (typeof session.customer === 'object' ? session.customer?.email : null)
-
-  const resolvedUserId = await resolveUserForStripe({
-    userId: session.client_reference_id || session.metadata?.userId,
-    customerId,
-    customerEmail,
-  })
-
-  if (!resolvedUserId) {
-    console.warn('Unable to resolve user for checkout session', session.id)
+  const customerId = extractCustomerId(session.customer)
+  if (!customerId) {
+    console.warn('Checkout session missing customer reference', session.id)
     return
   }
 
-  let plan = normalizePlanId(session.metadata?.planId)
-
-  let subscriptionId = null
-  let subscription = null
-
-  if (typeof session.subscription === 'string') {
-    subscriptionId = session.subscription
-  } else if (session.subscription) {
-    subscriptionId = session.subscription.id
-    subscription = session.subscription
+  const user = await findUserByStripeCustomerId(customerId)
+  if (!user) {
+    console.warn('No Supabase user found for Stripe customer', customerId)
+    return
   }
 
-  if (!plan && subscriptionId) {
-    subscription = subscription || (await stripe.subscriptions.retrieve(subscriptionId, { expand: ['items'] }))
-    const priceId = subscription?.items?.data?.[0]?.price?.id
-    plan = await resolvePlanFromPrice(priceId)
-  }
+  const tier = normalizeTier(session.metadata?.tier) ?? 'basic'
+  const subscriptionId = typeof session.subscription === 'string' ? session.subscription : session.subscription?.id
 
-  if (!plan && Array.isArray(session.display_items) && session.display_items.length > 0) {
-    const priceId = session.display_items[0]?.price?.id
-    plan = await resolvePlanFromPrice(priceId)
-  }
-
-  await updateUserPlanTier({
-    userId: resolvedUserId,
-    plan,
-    customerId,
-    subscriptionId,
+  await updateUser(user.id, {
+    stripe_subscription_id: subscriptionId ?? null,
+    tier,
   })
 }
 
-async function handleSubscriptionEvent(subscription) {
+async function handleSubscriptionUpdated(subscription) {
   if (!subscription) return
 
-  const status = subscription.status
-  let plan = null
-
-  if (status === 'active' || status === 'trialing') {
-    const priceId = subscription.items?.data?.[0]?.price?.id
-    plan = (await resolvePlanFromPrice(priceId)) || normalizePlanId(subscription.metadata?.planId)
-  } else {
-    plan = 'free'
-  }
-
-  const customerId = typeof subscription.customer === 'string' ? subscription.customer : subscription.customer?.id
-  let customerEmail =
-    subscription.customer_email ||
-    (typeof subscription.customer === 'object' ? subscription.customer?.email : null)
-
-  if (!customerEmail && customerId) {
-    try {
-      const customer = await stripe.customers.retrieve(customerId)
-      customerEmail = customer?.email ?? null
-    } catch (error) {
-      console.warn('Failed to retrieve Stripe customer for email resolution', error)
-    }
-  }
-
-  const resolvedUserId = await resolveUserForStripe({
-    userId: subscription.metadata?.userId,
-    customerId,
-    customerEmail,
-  })
-
-  if (!resolvedUserId) {
-    console.warn('Unable to resolve user for subscription event', subscription.id)
+  const customerId = extractCustomerId(subscription.customer)
+  if (!customerId) {
+    console.warn('Subscription update missing customer reference', subscription.id)
     return
   }
 
-  const subscriptionIdValue = plan === 'free' ? null : subscription.id
+  const user = await findUserByStripeCustomerId(customerId)
+  if (!user) {
+    console.warn('No Supabase user found for Stripe customer', customerId)
+    return
+  }
 
-  await updateUserPlanTier({
-    userId: resolvedUserId,
-    plan,
-    customerId,
-    subscriptionId: subscriptionIdValue,
+  const tier =
+    normalizeTier(subscription.metadata?.tier) ??
+    normalizeTier(subscription.items?.data?.[0]?.price?.metadata?.tier) ??
+    'basic'
+
+  await updateUser(user.id, {
+    stripe_subscription_id: subscription.id,
+    tier,
   })
 }
 
-async function resolvePlanFromPrice(priceId) {
-  if (!priceId) return null
+async function handleSubscriptionDeleted(subscription) {
+  if (!subscription) return
 
-  const mapped = getPlanFromPriceId(priceId)
-  if (mapped) return mapped
+  const customerId = extractCustomerId(subscription.customer)
+  if (!customerId) {
+    console.warn('Subscription deletion missing customer reference', subscription.id)
+    return
+  }
 
-  if (!stripe) return null
+  const user = await findUserByStripeCustomerId(customerId)
+  if (!user) {
+    console.warn('No Supabase user found for Stripe customer', customerId)
+    return
+  }
 
-  try {
-    const price = await stripe.prices.retrieve(priceId, { expand: ['product'] })
-    return (
-      normalizePlanId(price?.metadata?.planId) ||
-      normalizePlanId(price?.product?.metadata?.planId) ||
-      null
-    )
-  } catch (error) {
-    console.warn('Failed to resolve plan from Stripe price metadata', error)
-    return null
+  await updateUser(user.id, {
+    stripe_subscription_id: null,
+    tier: 'free',
+  })
+}
+
+function extractCustomerId(customer) {
+  if (!customer) return null
+  if (typeof customer === 'string') return customer
+  return customer.id ?? null
+}
+
+async function findUserByStripeCustomerId(customerId) {
+  const { data, error } = await supabaseAdmin
+    .from('users')
+    .select('id')
+    .eq('stripe_customer_id', customerId)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  return data
+}
+
+async function updateUser(userId, updates) {
+  const { error } = await supabaseAdmin.from('users').update(updates).eq('id', userId)
+
+  if (error) {
+    throw error
+  }
+}
+
+function normalizeTier(tier) {
+  if (typeof tier !== 'string') return null
+
+  switch (tier.toLowerCase()) {
+    case 'pro':
+    case 'premium':
+    case 'basic':
+      return tier.toLowerCase()
+    default:
+      return null
   }
 }

--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -1,6 +1,8 @@
 import { Buffer } from 'node:buffer'
 import { corsHeaders, jsonResponse } from './_utils/http.js'
-import { stripe, supabaseAdmin } from './_utils/serverClients.js'
+import { stripe } from './_utils/serverClients.js'
+import { getPlanFromPriceId, normalizePlanId } from './_utils/stripePlans.js'
+import { resolveUserForStripe, updateUserPlanTier } from './_utils/userPlan.js'
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
 
@@ -12,7 +14,7 @@ export function OPTIONS() {
 }
 
 export async function POST(request) {
-  if (!stripe || !supabaseAdmin || !webhookSecret) {
+  if (!stripe || !webhookSecret) {
     console.error('Stripe webhook invoked without required configuration')
     return jsonResponse({ error: 'Stripe webhook is not configured' }, { status: 500 })
   }
@@ -69,18 +71,34 @@ async function handleCheckoutSessionCompleted(session) {
     return
   }
 
-  const user = await findUserByStripeCustomerId(customerId)
-  if (!user) {
-    console.warn('No Supabase user found for Stripe customer', customerId)
+  const customerEmail = session.customer_details?.email ?? session.customer_email ?? null
+  const referencedUserId = session.metadata?.userId ?? session.client_reference_id ?? null
+
+  const userId = await resolveUserForStripe({
+    userId: referencedUserId,
+    customerId,
+    customerEmail,
+  })
+
+  if (!userId) {
+    console.warn('Unable to resolve user for checkout session', session.id)
     return
   }
 
-  const tier = normalizeTier(session.metadata?.tier) ?? 'basic'
-  const subscriptionId = typeof session.subscription === 'string' ? session.subscription : session.subscription?.id
+  let plan = normalizePlanFromSession(session)
 
-  await updateUser(user.id, {
-    stripe_subscription_id: subscriptionId ?? null,
-    tier,
+  if (!plan) {
+    const subscription = await resolveSubscription(session.subscription)
+    plan = normalizePlanFromSubscription(subscription)
+  }
+
+  const subscriptionId = extractSubscriptionId(session.subscription)
+
+  await updateUserPlanTier({
+    userId,
+    plan,
+    customerId,
+    subscriptionId: plan === 'free' ? null : subscriptionId,
   })
 }
 
@@ -93,20 +111,27 @@ async function handleSubscriptionUpdated(subscription) {
     return
   }
 
-  const user = await findUserByStripeCustomerId(customerId)
-  if (!user) {
-    console.warn('No Supabase user found for Stripe customer', customerId)
+  const customerEmail = subscription.customer_email ?? null
+  const referencedUserId = subscription.metadata?.userId ?? null
+
+  const userId = await resolveUserForStripe({
+    userId: referencedUserId,
+    customerId,
+    customerEmail,
+  })
+
+  if (!userId) {
+    console.warn('Unable to resolve user for subscription update', subscription.id)
     return
   }
 
-  const tier =
-    normalizeTier(subscription.metadata?.tier) ??
-    normalizeTier(subscription.items?.data?.[0]?.price?.metadata?.tier) ??
-    'basic'
+  const plan = normalizePlanFromSubscription(subscription)
 
-  await updateUser(user.id, {
-    stripe_subscription_id: subscription.id,
-    tier,
+  await updateUserPlanTier({
+    userId,
+    plan,
+    customerId,
+    subscriptionId: plan === 'free' ? null : subscription.id,
   })
 }
 
@@ -119,15 +144,25 @@ async function handleSubscriptionDeleted(subscription) {
     return
   }
 
-  const user = await findUserByStripeCustomerId(customerId)
-  if (!user) {
-    console.warn('No Supabase user found for Stripe customer', customerId)
+  const customerEmail = subscription.customer_email ?? null
+  const referencedUserId = subscription.metadata?.userId ?? null
+
+  const userId = await resolveUserForStripe({
+    userId: referencedUserId,
+    customerId,
+    customerEmail,
+  })
+
+  if (!userId) {
+    console.warn('Unable to resolve user for subscription deletion', subscription.id)
     return
   }
 
-  await updateUser(user.id, {
-    stripe_subscription_id: null,
-    tier: 'free',
+  await updateUserPlanTier({
+    userId,
+    plan: 'free',
+    customerId,
+    subscriptionId: null,
   })
 }
 
@@ -137,37 +172,72 @@ function extractCustomerId(customer) {
   return customer.id ?? null
 }
 
-async function findUserByStripeCustomerId(customerId) {
-  const { data, error } = await supabaseAdmin
-    .from('users')
-    .select('id')
-    .eq('stripe_customer_id', customerId)
-    .maybeSingle()
-
-  if (error) {
-    throw error
-  }
-
-  return data
+function extractSubscriptionId(subscription) {
+  if (!subscription) return null
+  if (typeof subscription === 'string') return subscription
+  return subscription.id ?? null
 }
 
-async function updateUser(userId, updates) {
-  const { error } = await supabaseAdmin.from('users').update(updates).eq('id', userId)
+async function resolveSubscription(subscription) {
+  if (!subscription) {
+    return null
+  }
 
-  if (error) {
-    throw error
+  if (typeof subscription !== 'string') {
+    return subscription
+  }
+
+  if (!stripe) {
+    return null
+  }
+
+  try {
+    return await stripe.subscriptions.retrieve(subscription, {
+      expand: ['items'],
+    })
+  } catch (error) {
+    console.warn('Failed to retrieve subscription for checkout session', error)
+    return null
   }
 }
 
-function normalizeTier(tier) {
-  if (typeof tier !== 'string') return null
+function normalizePlanFromSession(session) {
+  if (!session) return null
 
-  switch (tier.toLowerCase()) {
-    case 'pro':
-    case 'premium':
-    case 'basic':
-      return tier.toLowerCase()
-    default:
-      return null
+  const fromMetadata = normalizePlanId(session.metadata?.planId) ?? normalizePlanId(session.metadata?.tier)
+  if (fromMetadata) {
+    return fromMetadata
   }
+
+  const planFromPrice = getPlanFromPriceId(session.metadata?.priceId)
+  if (planFromPrice) {
+    return planFromPrice
+  }
+
+  return null
+}
+
+function normalizePlanFromSubscription(subscription) {
+  if (!subscription) {
+    return 'free'
+  }
+
+  const fromMetadata = normalizePlanId(subscription.metadata?.planId) ?? normalizePlanId(subscription.metadata?.tier)
+  if (fromMetadata) {
+    return fromMetadata
+  }
+
+  const priceMetadataTier = normalizePlanId(subscription.items?.data?.[0]?.price?.metadata?.planId) ??
+    normalizePlanId(subscription.items?.data?.[0]?.price?.metadata?.tier)
+  if (priceMetadataTier) {
+    return priceMetadataTier
+  }
+
+  const priceId = subscription.items?.data?.[0]?.price?.id
+  const planFromPrice = getPlanFromPriceId(priceId)
+  if (planFromPrice) {
+    return planFromPrice
+  }
+
+  return 'free'
 }

--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -2,7 +2,7 @@ import { Buffer } from 'node:buffer'
 import { corsHeaders, jsonResponse } from './_utils/http.js'
 import { stripe } from './_utils/serverClients.js'
 import { getPlanFromPriceId, normalizePlanId } from './_utils/stripePlans.js'
-import { updateUserPlanTier } from './_utils/userPlan.js'
+import { resolveUserForStripe, updateUserPlanTier } from './_utils/userPlan.js'
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
 
@@ -63,8 +63,22 @@ async function handleCheckoutSessionCompleted(session) {
   if (!session) return
   if (session.payment_status && session.payment_status !== 'paid') return
 
-  const userId = session.client_reference_id || session.metadata?.userId
-  if (!userId) return
+  const customerId = typeof session.customer === 'string' ? session.customer : session.customer?.id
+  const customerEmail =
+    session.customer_details?.email ||
+    session.customer_email ||
+    (typeof session.customer === 'object' ? session.customer?.email : null)
+
+  const resolvedUserId = await resolveUserForStripe({
+    userId: session.client_reference_id || session.metadata?.userId,
+    customerId,
+    customerEmail,
+  })
+
+  if (!resolvedUserId) {
+    console.warn('Unable to resolve user for checkout session', session.id)
+    return
+  }
 
   let plan = normalizePlanId(session.metadata?.planId)
 
@@ -81,13 +95,16 @@ async function handleCheckoutSessionCompleted(session) {
   if (!plan && subscriptionId) {
     subscription = subscription || (await stripe.subscriptions.retrieve(subscriptionId, { expand: ['items'] }))
     const priceId = subscription?.items?.data?.[0]?.price?.id
-    plan = getPlanFromPriceId(priceId)
+    plan = await resolvePlanFromPrice(priceId)
   }
 
-  const customerId = typeof session.customer === 'string' ? session.customer : session.customer?.id
+  if (!plan && Array.isArray(session.display_items) && session.display_items.length > 0) {
+    const priceId = session.display_items[0]?.price?.id
+    plan = await resolvePlanFromPrice(priceId)
+  }
 
   await updateUserPlanTier({
-    userId,
+    userId: resolvedUserId,
     plan,
     customerId,
     subscriptionId,
@@ -97,26 +114,68 @@ async function handleCheckoutSessionCompleted(session) {
 async function handleSubscriptionEvent(subscription) {
   if (!subscription) return
 
-  const userId = subscription.metadata?.userId
-  if (!userId) return
-
   const status = subscription.status
   let plan = null
 
   if (status === 'active' || status === 'trialing') {
     const priceId = subscription.items?.data?.[0]?.price?.id
-    plan = getPlanFromPriceId(priceId) || normalizePlanId(subscription.metadata?.planId)
+    plan = (await resolvePlanFromPrice(priceId)) || normalizePlanId(subscription.metadata?.planId)
   } else {
     plan = 'free'
   }
 
   const customerId = typeof subscription.customer === 'string' ? subscription.customer : subscription.customer?.id
+  let customerEmail =
+    subscription.customer_email ||
+    (typeof subscription.customer === 'object' ? subscription.customer?.email : null)
+
+  if (!customerEmail && customerId) {
+    try {
+      const customer = await stripe.customers.retrieve(customerId)
+      customerEmail = customer?.email ?? null
+    } catch (error) {
+      console.warn('Failed to retrieve Stripe customer for email resolution', error)
+    }
+  }
+
+  const resolvedUserId = await resolveUserForStripe({
+    userId: subscription.metadata?.userId,
+    customerId,
+    customerEmail,
+  })
+
+  if (!resolvedUserId) {
+    console.warn('Unable to resolve user for subscription event', subscription.id)
+    return
+  }
+
   const subscriptionIdValue = plan === 'free' ? null : subscription.id
 
   await updateUserPlanTier({
-    userId,
+    userId: resolvedUserId,
     plan,
     customerId,
     subscriptionId: subscriptionIdValue,
   })
+}
+
+async function resolvePlanFromPrice(priceId) {
+  if (!priceId) return null
+
+  const mapped = getPlanFromPriceId(priceId)
+  if (mapped) return mapped
+
+  if (!stripe) return null
+
+  try {
+    const price = await stripe.prices.retrieve(priceId, { expand: ['product'] })
+    return (
+      normalizePlanId(price?.metadata?.planId) ||
+      normalizePlanId(price?.product?.metadata?.planId) ||
+      null
+    )
+  } catch (error) {
+    console.warn('Failed to resolve plan from Stripe price metadata', error)
+    return null
+  }
 }

--- a/api/sync-checkout-session.js
+++ b/api/sync-checkout-session.js
@@ -1,0 +1,85 @@
+import { corsHeaders, jsonResponse } from './_utils/http.js'
+import { stripe } from './_utils/serverClients.js'
+import { getPlanFromPriceId, normalizePlanId } from './_utils/stripePlans.js'
+import { updateUserPlanTier } from './_utils/userPlan.js'
+
+export function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders,
+  })
+}
+
+export async function POST(request) {
+  if (!stripe) {
+    return jsonResponse({ error: 'Stripe is not configured' }, { status: 500 })
+  }
+
+  let payload
+
+  try {
+    payload = await request.json()
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON payload' }, { status: 400 })
+  }
+
+  const sessionId = typeof payload.sessionId === 'string' ? payload.sessionId.trim() : ''
+
+  if (!sessionId) {
+    return jsonResponse({ error: 'Missing sessionId' }, { status: 400 })
+  }
+
+  try {
+    const session = await stripe.checkout.sessions.retrieve(sessionId, {
+      expand: ['subscription', 'subscription.items'],
+    })
+
+    if (session.payment_status !== 'paid') {
+      return jsonResponse({ status: 'pending' }, { status: 202 })
+    }
+
+    const userId = session.client_reference_id || session.metadata?.userId
+
+    if (!userId) {
+      return jsonResponse({ error: 'Checkout session is missing user reference' }, { status: 400 })
+    }
+
+    let plan = normalizePlanId(session.metadata?.planId)
+
+    if (!plan) {
+      let subscription = null
+
+      if (typeof session.subscription === 'string') {
+        subscription = await stripe.subscriptions.retrieve(session.subscription, {
+          expand: ['items'],
+        })
+      } else if (session.subscription) {
+        subscription = session.subscription
+      }
+
+      const priceId = subscription?.items?.data?.[0]?.price?.id
+      const planFromPrice = getPlanFromPriceId(priceId)
+      plan = planFromPrice ?? 'free'
+    }
+
+    const customerId = typeof session.customer === 'string'
+      ? session.customer
+      : session.customer?.id
+
+    const subscriptionId = typeof session.subscription === 'string'
+      ? session.subscription
+      : session.subscription?.id
+
+    const normalizedPlan = await updateUserPlanTier({
+      userId,
+      plan,
+      customerId,
+      subscriptionId: plan === 'free' ? null : subscriptionId,
+    })
+
+    return jsonResponse({ status: 'ok', plan: normalizedPlan })
+  } catch (error) {
+    console.error('Failed to sync checkout session', error)
+    return jsonResponse({ error: 'Failed to sync checkout session' }, { status: 500 })
+  }
+}

--- a/api/sync-checkout-session.js
+++ b/api/sync-checkout-session.js
@@ -1,7 +1,6 @@
 import { corsHeaders, jsonResponse } from './_utils/http.js'
 import { stripe } from './_utils/serverClients.js'
 import { getPlanFromPriceId, normalizePlanId } from './_utils/stripePlans.js'
-import { updateUserPlanTier } from './_utils/userPlan.js'
 
 export function OPTIONS() {
   return new Response(null, {
@@ -62,20 +61,7 @@ export async function POST(request) {
       plan = planFromPrice ?? 'free'
     }
 
-    const customerId = typeof session.customer === 'string'
-      ? session.customer
-      : session.customer?.id
-
-    const subscriptionId = typeof session.subscription === 'string'
-      ? session.subscription
-      : session.subscription?.id
-
-    const normalizedPlan = await updateUserPlanTier({
-      userId,
-      plan,
-      customerId,
-      subscriptionId: plan === 'free' ? null : subscriptionId,
-    })
+    const normalizedPlan = normalizePlanId(plan) ?? 'free'
 
     return jsonResponse({ status: 'ok', plan: normalizedPlan })
   } catch (error) {

--- a/src/components/SoundRoom/HeaderBar.vue
+++ b/src/components/SoundRoom/HeaderBar.vue
@@ -132,11 +132,6 @@ const headerButtons = computed(() => [
     shouldShow: isAuthenticated.value && tier.value === 'free'
   },
   {
-    label: 'Manage Account',
-    action: () => router.push('/settings'),
-    shouldShow: isAuthenticated.value
-  },
-  {
     label: 'Settings',
     action: () => router.push('/settings'),
     shouldShow: isAuthenticated.value

--- a/src/utils/stripe.js
+++ b/src/utils/stripe.js
@@ -53,8 +53,6 @@ export async function redirectToCheckout(options) {
     }),
   })
 
-  console.log(response)
-
   if (!response.ok) {
     const errorPayload = await response.json().catch(() => ({ error: 'Unknown error' }))
     throw new Error(errorPayload.error || 'Unable to start checkout')

--- a/src/views/ManagePlan.vue
+++ b/src/views/ManagePlan.vue
@@ -16,9 +16,9 @@
           <p v-else-if="checkoutErrorMessage" class="text-sm font-medium">{{ checkoutErrorMessage }}</p>
         </div>
         <div class="flex items-center justify-between gap-6 flex-wrap">
-          <div class="space-y-2">
+          <div class="space-y-2 w-full">
             <h1 class="text-3xl font-semibold tracking-tight">Manage Plan</h1>
-            <p class="text-sm text-neutral-600 dark:text-neutral-400 max-w-2xl">
+            <p class="text-sm text-neutral-600 dark:text-neutral-400 w-full">
               Review what is included in your subscription, explore upgrade options, or reach out for billing support.
             </p>
           </div>

--- a/src/views/ManagePlan.vue
+++ b/src/views/ManagePlan.vue
@@ -2,6 +2,19 @@
   <main class="flex-1 overflow-y-auto bg-neutral-100 dark:bg-neutral-950 text-neutral-900 dark:text-neutral-100">
     <div class="max-w-4xl mx-auto px-6 py-10 space-y-10">
       <section class="space-y-4">
+        <div
+          v-if="checkoutStatusMessage || checkoutErrorMessage || isProcessingCheckout"
+          class="rounded-xl border p-4"
+          :class="[
+            isProcessingCheckout ? 'border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900/60 dark:bg-blue-950/40 dark:text-blue-300' : '',
+            checkoutStatusMessage && !isProcessingCheckout ? 'border-green-200 bg-green-50 text-green-700 dark:border-green-900/60 dark:bg-green-950/40 dark:text-green-300' : '',
+            checkoutErrorMessage ? 'border-red-200 bg-red-50 text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300' : '',
+          ]"
+        >
+          <p v-if="isProcessingCheckout" class="text-sm font-medium">Processing your plan change…</p>
+          <p v-else-if="checkoutStatusMessage" class="text-sm font-medium">{{ checkoutStatusMessage }}</p>
+          <p v-else-if="checkoutErrorMessage" class="text-sm font-medium">{{ checkoutErrorMessage }}</p>
+        </div>
         <div class="flex items-center justify-between gap-6 flex-wrap">
           <div class="space-y-2">
             <h1 class="text-3xl font-semibold tracking-tight">Manage Plan</h1>
@@ -50,6 +63,7 @@
               v-if="currentPlan.manageAction"
               variant="naked"
               class="text-sm text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
+              :disabled="isDowngradeBusy"
               @click="currentPlan.manageAction.handler"
             >
               {{ currentPlan.manageAction.label }}
@@ -100,19 +114,142 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import BaseButton from '@/components/ui/input/BaseButton.vue'
 import { useAuth } from '@/composables/useAuth'
 import { getPlanTheme, getPlanBadgeClass } from '@/constants/planThemes'
+import { supabase } from '@/utils/supabase'
 
 const SUPPORT_EMAIL = 'support@soundroom.app'
 
-const { tier } = useAuth()
+const { tier, refreshTier } = useAuth()
 const router = useRouter()
 const route = useRoute()
 
 const normalizedTier = computed(() => (tier.value || 'free').toLowerCase())
+
+const checkoutStatusMessage = ref('')
+const checkoutErrorMessage = ref('')
+const isProcessingCheckout = ref(false)
+
+const PLAN_DISPLAY_NAME = {
+  free: 'Free',
+  basic: 'Basic',
+  pro: 'Pro',
+}
+
+const isDowngradeBusy = ref(false)
+
+async function downgradeToFree() {
+  if (isDowngradeBusy.value) return
+
+  if (normalizedTier.value === 'free') {
+    checkoutStatusMessage.value = 'You are already on the Free plan.'
+    checkoutErrorMessage.value = ''
+    return
+  }
+
+  checkoutStatusMessage.value = ''
+  checkoutErrorMessage.value = ''
+  isDowngradeBusy.value = true
+  isProcessingCheckout.value = true
+
+  try {
+    const { data: sessionData, error: sessionError } = await supabase.auth.getSession()
+    if (sessionError) {
+      throw new Error(sessionError.message)
+    }
+
+    const accessToken = sessionData?.session?.access_token
+
+    if (!accessToken) {
+      throw new Error('You must be signed in to manage your plan.')
+    }
+
+    const response = await fetch('/api/manage-plan', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ action: 'downgrade' }),
+    })
+
+    if (!response.ok) {
+      const errorPayload = await response.json().catch(() => ({ error: 'Unable to update plan' }))
+      throw new Error(errorPayload.error || 'Unable to update plan')
+    }
+
+    const payload = await response.json()
+    const planName = PLAN_DISPLAY_NAME[payload.plan] || 'Free'
+    checkoutStatusMessage.value = `Your ${planName} plan is now active.`
+    await refreshTier(true)
+  } catch (error) {
+    console.error('Failed to downgrade plan', error)
+    checkoutErrorMessage.value = error?.message || 'Unable to update your plan. Please try again.'
+  } finally {
+    isDowngradeBusy.value = false
+    isProcessingCheckout.value = false
+  }
+}
+
+async function syncCheckoutIfNeeded() {
+  if (route.query.checkout !== 'success') {
+    return
+  }
+
+  const sessionIdParam = route.query.session_id
+  const sessionId = Array.isArray(sessionIdParam) ? sessionIdParam[0] : sessionIdParam
+
+  checkoutStatusMessage.value = ''
+  checkoutErrorMessage.value = ''
+  isProcessingCheckout.value = true
+
+  try {
+    if (sessionId) {
+      const response = await fetch('/api/sync-checkout-session', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ sessionId }),
+      })
+
+      if (!response.ok) {
+        const errorPayload = await response.json().catch(() => ({ error: 'Unable to verify checkout' }))
+        throw new Error(errorPayload.error || 'Unable to verify checkout')
+      }
+
+      const payload = await response.json()
+      const planName = PLAN_DISPLAY_NAME[payload.plan] || 'Free'
+      checkoutStatusMessage.value = `Your ${planName} plan is now active.`
+    } else {
+      await refreshTier(true)
+      const planName = PLAN_DISPLAY_NAME[normalizedTier.value] || 'Free'
+      checkoutStatusMessage.value = `Your ${planName} plan is now active.`
+    }
+
+    await refreshTier(true)
+  } catch (error) {
+    console.error('Failed to process checkout sync', error)
+    checkoutErrorMessage.value = error?.message || 'Unable to confirm your plan. Please contact support if this persists.'
+  } finally {
+    isProcessingCheckout.value = false
+
+    const newQuery = { ...route.query }
+    delete newQuery.checkout
+    delete newQuery.session_id
+
+    router.replace({ query: newQuery })
+  }
+}
+
+onMounted(() => {
+  if (route.query.checkout === 'success') {
+    syncCheckoutIfNeeded()
+  }
+})
 
 const PLAN_MAP = {
   free: {
@@ -146,11 +283,8 @@ const PLAN_MAP = {
       to: '/upgrade'
     },
     manageAction: {
-      label: 'Request downgrade to Free',
-      handler: () => sendEmail({
-        subject: 'SoundRoom – Downgrade request',
-        body: `Hi SoundRoom team,%0D%0A%0D%0AI would like to move my plan to Free. My account email is ${route.query.email || '[your account email]'}.` 
-      })
+      label: 'Downgrade to Free',
+      handler: downgradeToFree
     }
   },
   pro: {
@@ -165,11 +299,8 @@ const PLAN_MAP = {
     ],
     nextCta: null,
     manageAction: {
-      label: 'Manage or cancel subscription',
-      handler: () => sendEmail({
-        subject: 'SoundRoom – Manage Pro subscription',
-        body: `Hi SoundRoom team,%0D%0A%0D%0AI need help managing my subscription. My account email is ${route.query.email || '[your account email]'}.`
-      })
+      label: 'Cancel subscription & downgrade to Free',
+      handler: downgradeToFree
     }
   }
 }

--- a/src/views/Pricing/Pricing.vue
+++ b/src/views/Pricing/Pricing.vue
@@ -262,7 +262,7 @@ const handlePlanSelect = async (plan) => {
       planId: plan.id,
       customerEmail: user.value?.email ?? undefined,
       clientReferenceId: user.value?.id ?? undefined,
-      successUrl: origin ? `${origin}/manage-plan?checkout=success` : undefined,
+      successUrl: origin ? `${origin}/manage-plan?checkout=success&session_id={CHECKOUT_SESSION_ID}` : undefined,
       cancelUrl: origin ? `${origin}/upgrade?checkout=cancel` : undefined,
     })
   } catch (error) {


### PR DESCRIPTION
## Summary
- add shared server utilities for Stripe and Supabase admin access and enrich checkout sessions with user metadata
- implement Stripe webhook, checkout sync, and authenticated plan management endpoints to keep Supabase plan_tier in sync and support downgrades
- refresh client pricing and manage plan flows to surface checkout status, trigger tier refreshes, and allow self-service downgrades to Free

## Testing
- npm run test:unit *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fec9249adc832f912bf30837b254e7