### PR TITLE
Fix plan management navigation and tier syncing

### DIFF
--- a/src/composables/useAuth.js
+++ b/src/composables/useAuth.js
@@ -24,6 +24,17 @@ const tier = ref('free')
 const TIER_CACHE_KEY = 'userTier'
 const CACHE_DURATION_MS = 1000 * 60 * 30 // 30 minutes
 
+function writeTierToCache(newTier) {
+  const normalized = (newTier || 'free').toLowerCase()
+
+  localStorage.setItem(TIER_CACHE_KEY, JSON.stringify({
+    value: normalized,
+    updatedAt: Date.now()
+  }))
+
+  return normalized
+}
+
 /**
  * Get the user's current tier from cache or database.
  *
@@ -54,12 +65,7 @@ export async function getUserTier(userId, forceRefresh = false) {
 
   const newTier = data?.plan_tier ?? 'free'
 
-  localStorage.setItem(TIER_CACHE_KEY, JSON.stringify({
-    value: newTier,
-    updatedAt: Date.now()
-  }))
-
-  return newTier
+  return writeTierToCache(newTier)
 }
 
 /**
@@ -75,6 +81,15 @@ export async function refreshTier(force = false) {
   }
 
   tier.value = await getUserTier(user.value.id, force)
+}
+
+/**
+ * Immediately updates the reactive tier state and cache.
+ *
+ * @param {string} value
+ */
+function primeTier(value) {
+  tier.value = writeTierToCache(value)
 }
 
 // Initial session check
@@ -115,6 +130,7 @@ export function useAuth() {
     tier: readonly(tier),
     getTier: getUserTier,
     refreshTier,
+    primeTier,
     clearUser: () => {
       user.value = null
       tier.value = 'free'

--- a/src/views/ManagePlan.vue
+++ b/src/views/ManagePlan.vue
@@ -123,7 +123,7 @@ import { supabase } from '@/utils/supabase'
 
 const SUPPORT_EMAIL = 'support@soundroom.app'
 
-const { tier, refreshTier } = useAuth()
+const { tier, refreshTier, primeTier } = useAuth()
 const router = useRouter()
 const route = useRoute()
 
@@ -182,6 +182,7 @@ async function downgradeToFree() {
     }
 
     const payload = await response.json()
+    primeTier(payload.plan)
     const planName = PLAN_DISPLAY_NAME[payload.plan] || 'Free'
     checkoutStatusMessage.value = `Your ${planName} plan is now active.`
     await refreshTier(true)
@@ -222,6 +223,7 @@ async function syncCheckoutIfNeeded() {
       }
 
       const payload = await response.json()
+      primeTier(payload.plan)
       const planName = PLAN_DISPLAY_NAME[payload.plan] || 'Free'
       checkoutStatusMessage.value = `Your ${planName} plan is now active.`
     } else {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -12,7 +12,7 @@
           <div class="flex items-center gap-3 rounded-full border border-neutral-200 dark:border-neutral-800 px-4 py-2 bg-white/70 dark:bg-neutral-900/70">
             <span class="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">Plan</span>
             <span class="text-sm font-medium">{{ planLabel }}</span>
-            <RouterLink :to="tier.value === 'free' ? '/upgrade' : 'https://billing.stripe.com/p/login/7sY9AScjvcjKayEfItbsc00'" class="ml-2">
+            <RouterLink :to="planButtonTarget" class="ml-2">
               <BaseButton type="button">
                 {{ tier.value === 'free' ? 'Upgrade Plan' : 'Manage Plan' }}
               </BaseButton>
@@ -206,6 +206,7 @@ import { supabase } from '@/utils/supabase'
 
 const router = useRouter()
 const { user, sessionLoaded, tier } = useAuth()
+const planButtonTarget = computed(() => (tier.value === 'free' ? '/upgrade' : '/manage-plan'))
 
 const profileForm = reactive({
   displayName: '',


### PR DESCRIPTION
## Summary
- update the settings plan button to route paying members to the in-app manage plan page
- expose a helper to immediately prime the tier cache after plan changes
- refresh the tier state right after checkout or downgrade responses

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_69001ae0927c832f9ad76f311157e527