### PR TITLE
Ensure checkout sync updates Supabase plan tier

### DIFF
--- a/api/_utils/stripePlans.js
+++ b/api/_utils/stripePlans.js
@@ -22,4 +22,126 @@ export function getPlanFromPriceId(priceId) {
   return PRICE_PLAN_MAPPING[priceId] ?? null
 }
 
+export function extractCustomerId(customer) {
+  if (!customer) return null
+  if (typeof customer === 'string') return customer
+  return customer.id ?? null
+}
+
+export function extractSubscriptionId(subscription) {
+  if (!subscription) return null
+  if (typeof subscription === 'string') return subscription
+  return subscription.id ?? null
+}
+
+export function normalizePlanFromSubscription(subscription) {
+  if (!subscription) {
+    return null
+  }
+
+  const fromMetadata = normalizePlanId(subscription.metadata?.planId) ?? normalizePlanId(subscription.metadata?.tier)
+  if (fromMetadata) {
+    return fromMetadata
+  }
+
+  const priceMetadataTier =
+    normalizePlanId(subscription.items?.data?.[0]?.price?.metadata?.planId) ??
+    normalizePlanId(subscription.items?.data?.[0]?.price?.metadata?.tier)
+  if (priceMetadataTier) {
+    return priceMetadataTier
+  }
+
+  const priceId = subscription.items?.data?.[0]?.price?.id
+  const planFromPrice = getPlanFromPriceId(priceId)
+  if (planFromPrice) {
+    return planFromPrice
+  }
+
+  return null
+}
+
+export async function resolveSubscription(subscription, stripeClient) {
+  if (!subscription) {
+    return null
+  }
+
+  if (typeof subscription !== 'string') {
+    if (subscription.items?.data?.length) {
+      return subscription
+    }
+
+    if (!stripeClient) {
+      return subscription
+    }
+
+    try {
+      return await stripeClient.subscriptions.retrieve(subscription.id, { expand: ['items'] })
+    } catch (error) {
+      console.warn('Failed to refresh subscription with items', error)
+      return subscription
+    }
+  }
+
+  if (!stripeClient) {
+    return null
+  }
+
+  try {
+    return await stripeClient.subscriptions.retrieve(subscription, { expand: ['items'] })
+  } catch (error) {
+    console.warn('Failed to retrieve subscription', error)
+    return null
+  }
+}
+
+function normalizePlanFromSessionMetadata(session) {
+  if (!session) {
+    return null
+  }
+
+  const fromMetadata = normalizePlanId(session.metadata?.planId) ?? normalizePlanId(session.metadata?.tier)
+  if (fromMetadata) {
+    return fromMetadata
+  }
+
+  const priceMetadataTier = normalizePlanId(session.metadata?.priceTier)
+  if (priceMetadataTier) {
+    return priceMetadataTier
+  }
+
+  const planFromPrice = getPlanFromPriceId(session.metadata?.priceId)
+  if (planFromPrice) {
+    return planFromPrice
+  }
+
+  return null
+}
+
+export async function resolvePlanFromCheckoutSession(session, stripeClient) {
+  if (!session) {
+    return { plan: 'free', subscriptionId: null }
+  }
+
+  const subscriptionIdFromSession = extractSubscriptionId(session.subscription)
+  const planFromSession = normalizePlanFromSessionMetadata(session)
+
+  if (planFromSession) {
+    return { plan: planFromSession, subscriptionId: subscriptionIdFromSession }
+  }
+
+  const subscription = await resolveSubscription(session.subscription, stripeClient)
+  const subscriptionPlan = normalizePlanFromSubscription(subscription)
+  const subscriptionId = extractSubscriptionId(subscription) ?? subscriptionIdFromSession
+
+  if (subscriptionPlan) {
+    return { plan: subscriptionPlan, subscriptionId }
+  }
+
+  if (!subscriptionId) {
+    return { plan: 'free', subscriptionId: null }
+  }
+
+  return { plan: undefined, subscriptionId }
+}
+
 export { PLAN_PRICE_MAPPING }

--- a/api/_utils/userPlan.js
+++ b/api/_utils/userPlan.js
@@ -12,9 +12,14 @@ export async function updateUserPlanTier({ userId, plan, customerId, subscriptio
     throw new Error('Missing user reference for plan update')
   }
 
-  const normalizedPlan = normalizePlanId(plan) ?? DEFAULT_PLAN
+  const updatePayload = {}
 
-  const updatePayload = { plan_tier: normalizedPlan }
+  let normalizedPlan
+
+  if (plan !== undefined) {
+    normalizedPlan = normalizePlanId(plan) ?? DEFAULT_PLAN
+    updatePayload.plan_tier = normalizedPlan
+  }
 
   if (customerId !== undefined) {
     updatePayload.stripe_customer_id = customerId
@@ -24,10 +29,14 @@ export async function updateUserPlanTier({ userId, plan, customerId, subscriptio
     updatePayload.stripe_subscription_id = subscriptionId
   }
 
+  if (Object.keys(updatePayload).length === 0) {
+    return normalizedPlan
+  }
+
   const { error } = await supabaseAdmin.from('users').update(updatePayload).eq('id', userId)
 
   if (error) {
-    if (error.code === '42703') {
+    if (error.code === '42703' && normalizedPlan) {
       const { error: fallbackError } = await supabaseAdmin
         .from('users')
         .update({ plan_tier: normalizedPlan })

--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -3,7 +3,13 @@ export const config = { runtime: 'nodejs' };
 import { Buffer } from 'node:buffer'
 import { corsHeaders, jsonResponse } from './_utils/http.js'
 import { stripe } from './_utils/serverClients.js'
-import { getPlanFromPriceId, normalizePlanId } from './_utils/stripePlans.js'
+import {
+  extractCustomerId,
+  extractSubscriptionId,
+  normalizePlanFromSubscription,
+  resolvePlanFromCheckoutSession,
+  resolveSubscription,
+} from './_utils/stripePlans.js'
 import { resolveUserForStripe, updateUserPlanTier } from './_utils/userPlan.js'
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET
@@ -87,20 +93,13 @@ async function handleCheckoutSessionCompleted(session) {
     return
   }
 
-  let plan = normalizePlanFromSession(session)
-
-  if (!plan) {
-    const subscription = await resolveSubscription(session.subscription)
-    plan = normalizePlanFromSubscription(subscription)
-  }
-
-  const subscriptionId = extractSubscriptionId(session.subscription)
+  const { plan, subscriptionId } = await resolvePlanFromCheckoutSession(session, stripe)
 
   await updateUserPlanTier({
     userId,
-    plan,
+    plan: plan ?? (subscriptionId ? undefined : 'free'),
     customerId,
-    subscriptionId: plan === 'free' ? null : subscriptionId,
+    subscriptionId: plan === 'free' ? null : subscriptionId ?? null,
   })
 }
 
@@ -127,13 +126,15 @@ async function handleSubscriptionUpdated(subscription) {
     return
   }
 
-  const plan = normalizePlanFromSubscription(subscription)
+  const resolvedSubscription = (await resolveSubscription(subscription, stripe)) ?? subscription
+  const plan = normalizePlanFromSubscription(resolvedSubscription)
+  const subscriptionId = extractSubscriptionId(resolvedSubscription)
 
   await updateUserPlanTier({
     userId,
     plan,
     customerId,
-    subscriptionId: plan === 'free' ? null : subscription.id,
+    subscriptionId: plan === 'free' ? null : subscriptionId,
   })
 }
 
@@ -166,80 +167,4 @@ async function handleSubscriptionDeleted(subscription) {
     customerId,
     subscriptionId: null,
   })
-}
-
-function extractCustomerId(customer) {
-  if (!customer) return null
-  if (typeof customer === 'string') return customer
-  return customer.id ?? null
-}
-
-function extractSubscriptionId(subscription) {
-  if (!subscription) return null
-  if (typeof subscription === 'string') return subscription
-  return subscription.id ?? null
-}
-
-async function resolveSubscription(subscription) {
-  if (!subscription) {
-    return null
-  }
-
-  if (typeof subscription !== 'string') {
-    return subscription
-  }
-
-  if (!stripe) {
-    return null
-  }
-
-  try {
-    return await stripe.subscriptions.retrieve(subscription, {
-      expand: ['items'],
-    })
-  } catch (error) {
-    console.warn('Failed to retrieve subscription for checkout session', error)
-    return null
-  }
-}
-
-function normalizePlanFromSession(session) {
-  if (!session) return null
-
-  const fromMetadata = normalizePlanId(session.metadata?.planId) ?? normalizePlanId(session.metadata?.tier)
-  if (fromMetadata) {
-    return fromMetadata
-  }
-
-  const planFromPrice = getPlanFromPriceId(session.metadata?.priceId)
-  if (planFromPrice) {
-    return planFromPrice
-  }
-
-  return null
-}
-
-function normalizePlanFromSubscription(subscription) {
-  if (!subscription) {
-    return 'free'
-  }
-
-  const fromMetadata = normalizePlanId(subscription.metadata?.planId) ?? normalizePlanId(subscription.metadata?.tier)
-  if (fromMetadata) {
-    return fromMetadata
-  }
-
-  const priceMetadataTier = normalizePlanId(subscription.items?.data?.[0]?.price?.metadata?.planId) ??
-    normalizePlanId(subscription.items?.data?.[0]?.price?.metadata?.tier)
-  if (priceMetadataTier) {
-    return priceMetadataTier
-  }
-
-  const priceId = subscription.items?.data?.[0]?.price?.id
-  const planFromPrice = getPlanFromPriceId(priceId)
-  if (planFromPrice) {
-    return planFromPrice
-  }
-
-  return 'free'
 }

--- a/api/sync-checkout-session.js
+++ b/api/sync-checkout-session.js
@@ -1,6 +1,7 @@
 import { corsHeaders, jsonResponse } from './_utils/http.js'
 import { stripe } from './_utils/serverClients.js'
 import { getPlanFromPriceId, normalizePlanId } from './_utils/stripePlans.js'
+import { updateUserPlanTier } from './_utils/userPlan.js'
 
 export function OPTIONS() {
   return new Response(null, {
@@ -45,17 +46,17 @@ export async function POST(request) {
 
     let plan = normalizePlanId(session.metadata?.planId)
 
+    let subscription = null
+
+    if (typeof session.subscription === 'string') {
+      subscription = await stripe.subscriptions.retrieve(session.subscription, {
+        expand: ['items'],
+      })
+    } else if (session.subscription) {
+      subscription = session.subscription
+    }
+
     if (!plan) {
-      let subscription = null
-
-      if (typeof session.subscription === 'string') {
-        subscription = await stripe.subscriptions.retrieve(session.subscription, {
-          expand: ['items'],
-        })
-      } else if (session.subscription) {
-        subscription = session.subscription
-      }
-
       const priceId = subscription?.items?.data?.[0]?.price?.id
       const planFromPrice = getPlanFromPriceId(priceId)
       plan = planFromPrice ?? 'free'
@@ -63,9 +64,36 @@ export async function POST(request) {
 
     const normalizedPlan = normalizePlanId(plan) ?? 'free'
 
+    const customerId = extractCustomerId(session.customer)
+    const subscriptionId = normalizedPlan === 'free' ? null : extractSubscriptionId(subscription)
+
+    try {
+      await updateUserPlanTier({
+        userId,
+        plan: normalizedPlan,
+        customerId,
+        subscriptionId,
+      })
+    } catch (error) {
+      console.error('Failed to persist user plan tier after checkout session sync', error)
+      return jsonResponse({ error: 'Failed to finalize plan' }, { status: 500 })
+    }
+
     return jsonResponse({ status: 'ok', plan: normalizedPlan })
   } catch (error) {
     console.error('Failed to sync checkout session', error)
     return jsonResponse({ error: 'Failed to sync checkout session' }, { status: 500 })
   }
+}
+
+function extractCustomerId(customer) {
+  if (!customer) return null
+  if (typeof customer === 'string') return customer
+  return customer.id ?? null
+}
+
+function extractSubscriptionId(subscription) {
+  if (!subscription) return null
+  if (typeof subscription === 'string') return subscription
+  return subscription.id ?? null
 }

--- a/api/sync-checkout-session.js
+++ b/api/sync-checkout-session.js
@@ -1,6 +1,6 @@
 import { corsHeaders, jsonResponse } from './_utils/http.js'
 import { stripe } from './_utils/serverClients.js'
-import { getPlanFromPriceId, normalizePlanId } from './_utils/stripePlans.js'
+import { extractCustomerId, resolvePlanFromCheckoutSession } from './_utils/stripePlans.js'
 import { updateUserPlanTier } from './_utils/userPlan.js'
 
 export function OPTIONS() {
@@ -44,56 +44,32 @@ export async function POST(request) {
       return jsonResponse({ error: 'Checkout session is missing user reference' }, { status: 400 })
     }
 
-    let plan = normalizePlanId(session.metadata?.planId)
-
-    let subscription = null
-
-    if (typeof session.subscription === 'string') {
-      subscription = await stripe.subscriptions.retrieve(session.subscription, {
-        expand: ['items'],
-      })
-    } else if (session.subscription) {
-      subscription = session.subscription
-    }
-
-    if (!plan) {
-      const priceId = subscription?.items?.data?.[0]?.price?.id
-      const planFromPrice = getPlanFromPriceId(priceId)
-      plan = planFromPrice ?? 'free'
-    }
-
-    const normalizedPlan = normalizePlanId(plan) ?? 'free'
+    const { plan: resolvedPlan, subscriptionId: resolvedSubscriptionId } =
+      await resolvePlanFromCheckoutSession(session, stripe)
 
     const customerId = extractCustomerId(session.customer)
-    const subscriptionId = normalizedPlan === 'free' ? null : extractSubscriptionId(subscription)
+    const planToPersist = resolvedPlan ?? (resolvedSubscriptionId ? undefined : 'free')
+    const subscriptionId = planToPersist === 'free' ? null : resolvedSubscriptionId ?? null
 
     try {
-      await updateUserPlanTier({
+      const persistedPlan = await updateUserPlanTier({
         userId,
-        plan: normalizedPlan,
+        plan: planToPersist,
         customerId,
         subscriptionId,
       })
+
+      if (planToPersist === undefined) {
+        return jsonResponse({ status: 'pending' }, { status: 202 })
+      }
+
+      return jsonResponse({ status: 'ok', plan: persistedPlan ?? planToPersist ?? 'free' })
     } catch (error) {
       console.error('Failed to persist user plan tier after checkout session sync', error)
       return jsonResponse({ error: 'Failed to finalize plan' }, { status: 500 })
     }
-
-    return jsonResponse({ status: 'ok', plan: normalizedPlan })
   } catch (error) {
     console.error('Failed to sync checkout session', error)
     return jsonResponse({ error: 'Failed to sync checkout session' }, { status: 500 })
   }
-}
-
-function extractCustomerId(customer) {
-  if (!customer) return null
-  if (typeof customer === 'string') return customer
-  return customer.id ?? null
-}
-
-function extractSubscriptionId(subscription) {
-  if (!subscription) return null
-  if (typeof subscription === 'string') return subscription
-  return subscription.id ?? null
 }


### PR DESCRIPTION
## Summary
- update the checkout-session sync handler to persist the user's plan tier in Supabase
- reuse subscription details to capture customer and subscription identifiers when updating
- surface an error if the Supabase update fails so the plan state stays consistent

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_690028641368832f80ff245a100145da