### PR TITLE
Integrate Stripe billing portal session handling

### DIFF
--- a/api/create-portal-session.js
+++ b/api/create-portal-session.js
@@ -1,0 +1,110 @@
+import { corsHeaders, jsonResponse } from './_utils/http.js'
+import { stripe, supabaseAdmin } from './_utils/serverClients.js'
+
+async function authenticateRequest(request) {
+  if (!supabaseAdmin) {
+    throw new Error('Supabase admin client is not configured')
+  }
+
+  const authHeader = request.headers.get('authorization') || request.headers.get('Authorization') || ''
+  const token = authHeader.startsWith('Bearer ') ? authHeader.slice('Bearer '.length).trim() : ''
+
+  if (!token) {
+    throw new Error('Missing access token')
+  }
+
+  const { data, error } = await supabaseAdmin.auth.getUser(token)
+
+  if (error || !data?.user) {
+    throw new Error('Invalid or expired access token')
+  }
+
+  return data.user
+}
+
+function isValidReturnUrl(url) {
+  if (typeof url !== 'string' || !url) {
+    return false
+  }
+
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:'
+  } catch {
+    return false
+  }
+}
+
+export function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders,
+  })
+}
+
+export async function POST(request) {
+  if (!stripe) {
+    return jsonResponse({ error: 'Stripe is not configured' }, { status: 500 })
+  }
+
+  if (!supabaseAdmin) {
+    return jsonResponse({ error: 'Supabase admin client is not configured' }, { status: 500 })
+  }
+
+  let payload = {}
+  try {
+    payload = await request.json()
+  } catch {
+    payload = {}
+  }
+
+  let returnUrl = typeof payload.returnUrl === 'string' ? payload.returnUrl : undefined
+  if (!isValidReturnUrl(returnUrl)) {
+    returnUrl = undefined
+  }
+
+  let user
+  try {
+    user = await authenticateRequest(request)
+  } catch (error) {
+    return jsonResponse({ error: error.message }, { status: 401 })
+  }
+
+  try {
+    const { data: profile, error: profileError } = await supabaseAdmin
+      .from('users')
+      .select('stripe_customer_id')
+      .eq('id', user.id)
+      .single()
+
+    if (profileError) {
+      throw new Error(profileError.message)
+    }
+
+    const customerId = profile?.stripe_customer_id
+
+    if (!customerId) {
+      return jsonResponse({ error: 'No billing account is associated with your profile.' }, { status: 400 })
+    }
+
+    const baseUrl = process.env.PUBLIC_APP_URL || 'https://soundroom.live'
+    const fallbackReturnUrl = `${baseUrl.replace(/\/$/, '')}/manage-plan`
+
+    const sessionParams = {
+      customer: customerId,
+      return_url: returnUrl || fallbackReturnUrl,
+    }
+
+    const configuredPortalId = process.env.STRIPE_BILLING_PORTAL_CONFIGURATION_ID
+    if (configuredPortalId) {
+      sessionParams.configuration = configuredPortalId
+    }
+
+    const session = await stripe.billingPortal.sessions.create(sessionParams)
+
+    return jsonResponse({ url: session.url })
+  } catch (error) {
+    console.error('Failed to create Stripe billing portal session', error)
+    return jsonResponse({ error: error.message || 'Unable to open billing portal' }, { status: 500 })
+  }
+}

--- a/src/utils/billingPortal.js
+++ b/src/utils/billingPortal.js
@@ -1,0 +1,46 @@
+import { supabase } from '@/utils/supabase'
+
+/**
+ * Create a Stripe Billing Portal session and return the redirect URL.
+ *
+ * @param {string | undefined} returnUrl - Optional URL that Stripe should
+ *   redirect back to when the customer exits the portal.
+ * @returns {Promise<string>} - Resolves with the portal session URL.
+ */
+export async function createBillingPortalSession(returnUrl) {
+  const { data: sessionData, error: sessionError } = await supabase.auth.getSession()
+  if (sessionError) {
+    throw new Error(sessionError.message)
+  }
+
+  const accessToken = sessionData?.session?.access_token
+  if (!accessToken) {
+    throw new Error('You must be signed in to manage your subscription.')
+  }
+
+  const response = await fetch('/api/create-portal-session', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ returnUrl }),
+  })
+
+  let payload = {}
+  try {
+    payload = await response.json()
+  } catch {
+    payload = {}
+  }
+
+  if (!response.ok) {
+    throw new Error(payload.error || 'Unable to open the billing portal. Please try again later.')
+  }
+
+  if (typeof payload.url !== 'string' || payload.url.length === 0) {
+    throw new Error('Billing portal is currently unavailable. Please contact support for assistance.')
+  }
+
+  return payload.url
+}

--- a/src/views/ManagePlan.vue
+++ b/src/views/ManagePlan.vue
@@ -60,13 +60,21 @@
               </BaseButton>
             </RouterLink>
             <BaseButton
-              v-if="currentPlan.manageAction"
+              v-if="currentPlan.portalAction"
+              :loading="isCreatingPortalSession"
+              :disabled="isCreatingPortalSession || isProcessingCheckout"
+              @click="currentPlan.portalAction.handler"
+            >
+              {{ currentPlan.portalAction.label }}
+            </BaseButton>
+            <BaseButton
+              v-if="currentPlan.cancelAction"
               variant="naked"
               class="text-sm text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
-              :disabled="isDowngradeBusy"
-              @click="currentPlan.manageAction.handler"
+              :disabled="isDowngradeBusy || isCreatingPortalSession"
+              @click="currentPlan.cancelAction.handler"
             >
-              {{ currentPlan.manageAction.label }}
+              {{ currentPlan.cancelAction.label }}
             </BaseButton>
           </div>
         </div>
@@ -76,7 +84,7 @@
         <header class="space-y-1">
           <h2 class="text-xl font-semibold">Billing & Receipts</h2>
           <p class="text-sm text-neutral-600 dark:text-neutral-400">
-            SoundRoom uses Stripe under the hood. A full self-service billing portal is coming soon — in the meantime, reach out and we will take care of any changes for you.
+            SoundRoom uses Stripe under the hood. Use the billing portal to view invoices, update payment details, or make changes to your plan anytime.
           </p>
         </header>
 
@@ -120,6 +128,7 @@ import BaseButton from '@/components/ui/input/BaseButton.vue'
 import { useAuth } from '@/composables/useAuth'
 import { getPlanTheme, getPlanBadgeClass } from '@/constants/planThemes'
 import { supabase } from '@/utils/supabase'
+import { createBillingPortalSession } from '@/utils/billingPortal'
 
 const SUPPORT_EMAIL = 'support@soundroom.app'
 
@@ -140,6 +149,7 @@ const PLAN_DISPLAY_NAME = {
 }
 
 const isDowngradeBusy = ref(false)
+const isCreatingPortalSession = ref(false)
 
 async function downgradeToFree() {
   if (isDowngradeBusy.value) return
@@ -192,6 +202,28 @@ async function downgradeToFree() {
   } finally {
     isDowngradeBusy.value = false
     isProcessingCheckout.value = false
+  }
+}
+
+async function openBillingPortal() {
+  if (isCreatingPortalSession.value) return
+
+  checkoutStatusMessage.value = ''
+  checkoutErrorMessage.value = ''
+  isCreatingPortalSession.value = true
+
+  try {
+    const returnUrl = typeof window !== 'undefined' ? `${window.location.origin}/manage-plan` : undefined
+    const portalUrl = await createBillingPortalSession(returnUrl)
+
+    if (typeof window !== 'undefined') {
+      window.location.href = portalUrl
+    }
+  } catch (error) {
+    console.error('Failed to open billing portal', error)
+    checkoutErrorMessage.value = error?.message || 'Unable to open billing portal. Please try again later.'
+  } finally {
+    isCreatingPortalSession.value = false
   }
 }
 
@@ -268,7 +300,8 @@ const PLAN_MAP = {
       label: 'Upgrade to Pro',
       to: '/upgrade'
     },
-    manageAction: null
+    portalAction: null,
+    cancelAction: null
   },
   basic: {
     id: 'basic',
@@ -284,8 +317,12 @@ const PLAN_MAP = {
       label: 'Upgrade to Pro',
       to: '/upgrade'
     },
-    manageAction: {
-      label: 'Downgrade to Free',
+    portalAction: {
+      label: 'Manage billing in Stripe portal',
+      handler: openBillingPortal
+    },
+    cancelAction: {
+      label: 'Cancel subscription & downgrade to Free',
       handler: downgradeToFree
     }
   },
@@ -300,7 +337,11 @@ const PLAN_MAP = {
       'Unlimited saved rooms with snapshot history'
     ],
     nextCta: null,
-    manageAction: {
+    portalAction: {
+      label: 'Manage billing in Stripe portal',
+      handler: openBillingPortal
+    },
+    cancelAction: {
       label: 'Cancel subscription & downgrade to Free',
       handler: downgradeToFree
     }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -17,14 +17,23 @@
                 Upgrade Plan
               </BaseButton>
             </RouterLink>
-            <a v-else href="https://billing.stripe.com/p/login/7sY9AScjvcjKayEfItbsc00" target="_blank" rel="noopener" class="ml-2">
-              <BaseButton type="button">
-                Manage Plan
-              </BaseButton>
-            </a>
+            <BaseButton
+              v-else
+              type="button"
+              class="ml-2"
+              :loading="isOpeningBillingPortal"
+              :disabled="isOpeningBillingPortal"
+              @click="handleManagePlan"
+            >
+              Manage Plan
+            </BaseButton>
 
           </div>
         </div>
+
+        <p v-if="billingPortalError" class="text-sm text-red-500">
+          {{ billingPortalError }}
+        </p>
 
         <div class="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white/70 dark:bg-neutral-900/70 p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
           <div>
@@ -209,6 +218,7 @@ import BaseButton from '@/components/ui/input/BaseButton.vue'
 import BaseInput from '@/components/ui/input/BaseInput.vue'
 import { useAuth } from '@/composables/useAuth'
 import { supabase } from '@/utils/supabase'
+import { createBillingPortalSession } from '@/utils/billingPortal'
 
 const router = useRouter()
 const { user, sessionLoaded, tier } = useAuth()
@@ -249,6 +259,9 @@ const preferenceMessage = ref('')
 const securityMessage = ref('')
 const securityError = ref('')
 
+const isOpeningBillingPortal = ref(false)
+const billingPortalError = ref('')
+
 const LOCAL_PREF_KEY = 'soundroom.userPreferences'
 
 const userEmail = computed(() => user.value?.email ?? 'Unknown user')
@@ -260,6 +273,27 @@ const planLabel = computed(() => {
     ? 'Free'
     : value.charAt(0).toUpperCase() + value.slice(1)
 })
+
+async function handleManagePlan() {
+  if (isOpeningBillingPortal.value) return
+
+  billingPortalError.value = ''
+  isOpeningBillingPortal.value = true
+
+  try {
+    const returnUrl = typeof window !== 'undefined' ? `${window.location.origin}/manage-plan` : undefined
+    const portalUrl = await createBillingPortalSession(returnUrl)
+
+    if (typeof window !== 'undefined') {
+      window.location.href = portalUrl
+    }
+  } catch (error) {
+    console.error('Failed to open billing portal', error)
+    billingPortalError.value = error?.message || 'Unable to open billing portal. Please try again later.'
+  } finally {
+    isOpeningBillingPortal.value = false
+  }
+}
 
 const hasProfileChanges = computed(() => {
   const trimmedName = profileForm.displayName.trim()


### PR DESCRIPTION
## Summary
- add an API endpoint that creates Stripe Billing Portal sessions for authenticated customers
- introduce a shared billing portal utility and update the Manage Plan view to launch the portal or cancel subscriptions
- update Settings to open the billing portal directly and show inline errors instead of linking to Stripe

## Testing
- npm run build *(fails: missing @sentry/vite-plugin in the local environment)*

------
https://chatgpt.com/codex/tasks/task_e_690116b24a34832f8c411f6be64b6276