### PR TITLE
Ensure Stripe plan normalization uses active price details

### DIFF
--- a/api/_utils/stripePlans.js
+++ b/api/_utils/stripePlans.js
@@ -39,22 +39,24 @@ export function normalizePlanFromSubscription(subscription) {
     return null
   }
 
-  const fromMetadata = normalizePlanId(subscription.metadata?.planId) ?? normalizePlanId(subscription.metadata?.tier)
-  if (fromMetadata) {
-    return fromMetadata
+  const priceItem = subscription.items?.data?.[0] ?? null
+  const price = priceItem?.price ?? null
+
+  const planFromPriceMetadata =
+    normalizePlanId(price?.metadata?.planId) ?? normalizePlanId(price?.metadata?.tier)
+  if (planFromPriceMetadata) {
+    return planFromPriceMetadata
   }
 
-  const priceMetadataTier =
-    normalizePlanId(subscription.items?.data?.[0]?.price?.metadata?.planId) ??
-    normalizePlanId(subscription.items?.data?.[0]?.price?.metadata?.tier)
-  if (priceMetadataTier) {
-    return priceMetadataTier
+  const planFromPriceId = getPlanFromPriceId(price?.id)
+  if (planFromPriceId) {
+    return planFromPriceId
   }
 
-  const priceId = subscription.items?.data?.[0]?.price?.id
-  const planFromPrice = getPlanFromPriceId(priceId)
-  if (planFromPrice) {
-    return planFromPrice
+  const planFromSubscriptionMetadata =
+    normalizePlanId(subscription.metadata?.planId) ?? normalizePlanId(subscription.metadata?.tier)
+  if (planFromSubscriptionMetadata) {
+    return planFromSubscriptionMetadata
   }
 
   return null


### PR DESCRIPTION
## Summary
- prefer active Stripe price metadata and price IDs when normalizing subscription plans
- fall back to stored subscription metadata only when price information is unavailable, preventing stale plan updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69011a5206f4832faa5b068acd44b145