### PR TITLE
Simplify Stripe webhook plan reconciliation

### DIFF
--- a/api/_utils/stripePlans.js
+++ b/api/_utils/stripePlans.js
@@ -1,12 +1,25 @@
 const PLAN_PRICE_MAPPING = {
-  basic: process.env.STRIPE_BASIC_PRICE_ID,
-  pro: process.env.STRIPE_PRO_PRICE_ID,
+  basic: 'price_1SB0vsAMgU12pIQI2NT4UfnP',
+  pro: 'price_1SB0yNAMgU12pIQIOPDh0581',
+}
+
+const PLAN_PRODUCT_MAPPING = {
+  basic: 'prod_T7FQ16alcKlf3h',
+  pro: 'prod_T7FTCaAkapuxmX',
 }
 
 const PRICE_PLAN_MAPPING = Object.entries(PLAN_PRICE_MAPPING).reduce((acc, [plan, priceId]) => {
-  if (priceId) acc[priceId] = plan
+  acc[priceId] = plan
   return acc
 }, {})
+
+const PRODUCT_PLAN_MAPPING = Object.entries(PLAN_PRODUCT_MAPPING).reduce(
+  (acc, [plan, productId]) => {
+    acc[productId] = plan
+    return acc
+  },
+  {},
+)
 
 export function normalizePlanId(value) {
   if (!value) return null
@@ -20,6 +33,11 @@ export function normalizePlanId(value) {
 export function getPlanFromPriceId(priceId) {
   if (!priceId) return null
   return PRICE_PLAN_MAPPING[priceId] ?? null
+}
+
+export function getPlanFromProductId(productId) {
+  if (!productId) return null
+  return PRODUCT_PLAN_MAPPING[productId] ?? null
 }
 
 export function extractCustomerId(customer) {
@@ -39,59 +57,38 @@ export function normalizePlanFromSubscription(subscription) {
     return null
   }
 
-  const fromMetadata = normalizePlanId(subscription.metadata?.planId) ?? normalizePlanId(subscription.metadata?.tier)
+  const fromMetadata =
+    normalizePlanId(subscription.metadata?.planId) ?? normalizePlanId(subscription.metadata?.tier)
   if (fromMetadata) {
     return fromMetadata
   }
 
-  const priceMetadataTier =
-    normalizePlanId(subscription.items?.data?.[0]?.price?.metadata?.planId) ??
-    normalizePlanId(subscription.items?.data?.[0]?.price?.metadata?.tier)
-  if (priceMetadataTier) {
-    return priceMetadataTier
+  const item = subscription.items?.data?.[0]
+  const itemMetadataPlan =
+    normalizePlanId(item?.metadata?.planId) ?? normalizePlanId(item?.metadata?.tier)
+  if (itemMetadataPlan) {
+    return itemMetadataPlan
   }
 
-  const priceId = subscription.items?.data?.[0]?.price?.id
+  const priceMetadataPlan =
+    normalizePlanId(item?.price?.metadata?.planId) ?? normalizePlanId(item?.price?.metadata?.tier)
+  if (priceMetadataPlan) {
+    return priceMetadataPlan
+  }
+
+  const priceId = item?.price?.id ?? subscription.plan?.id
   const planFromPrice = getPlanFromPriceId(priceId)
   if (planFromPrice) {
     return planFromPrice
   }
 
+  const productId = item?.price?.product ?? subscription.plan?.product
+  const planFromProduct = getPlanFromProductId(productId)
+  if (planFromProduct) {
+    return planFromProduct
+  }
+
   return null
-}
-
-export async function resolveSubscription(subscription, stripeClient) {
-  if (!subscription) {
-    return null
-  }
-
-  if (typeof subscription !== 'string') {
-    if (subscription.items?.data?.length) {
-      return subscription
-    }
-
-    if (!stripeClient) {
-      return subscription
-    }
-
-    try {
-      return await stripeClient.subscriptions.retrieve(subscription.id, { expand: ['items'] })
-    } catch (error) {
-      console.warn('Failed to refresh subscription with items', error)
-      return subscription
-    }
-  }
-
-  if (!stripeClient) {
-    return null
-  }
-
-  try {
-    return await stripeClient.subscriptions.retrieve(subscription, { expand: ['items'] })
-  } catch (error) {
-    console.warn('Failed to retrieve subscription', error)
-    return null
-  }
 }
 
 function normalizePlanFromSessionMetadata(session) {
@@ -99,7 +96,8 @@ function normalizePlanFromSessionMetadata(session) {
     return null
   }
 
-  const fromMetadata = normalizePlanId(session.metadata?.planId) ?? normalizePlanId(session.metadata?.tier)
+  const fromMetadata =
+    normalizePlanId(session.metadata?.planId) ?? normalizePlanId(session.metadata?.tier)
   if (fromMetadata) {
     return fromMetadata
   }
@@ -114,24 +112,29 @@ function normalizePlanFromSessionMetadata(session) {
     return planFromPrice
   }
 
+  const planFromProduct = getPlanFromProductId(session.metadata?.productId)
+  if (planFromProduct) {
+    return planFromProduct
+  }
+
   return null
 }
 
-export async function resolvePlanFromCheckoutSession(session, stripeClient) {
+export function resolvePlanFromCheckoutSession(session) {
   if (!session) {
     return { plan: 'free', subscriptionId: null }
   }
 
-  const subscriptionIdFromSession = extractSubscriptionId(session.subscription)
+  const subscriptionId = extractSubscriptionId(session.subscription)
   const planFromSession = normalizePlanFromSessionMetadata(session)
 
   if (planFromSession) {
-    return { plan: planFromSession, subscriptionId: subscriptionIdFromSession }
+    return { plan: planFromSession, subscriptionId }
   }
 
-  const subscription = await resolveSubscription(session.subscription, stripeClient)
-  const subscriptionPlan = normalizePlanFromSubscription(subscription)
-  const subscriptionId = extractSubscriptionId(subscription) ?? subscriptionIdFromSession
+  const subscriptionPlan = normalizePlanFromSubscription(
+    typeof session.subscription === 'object' ? session.subscription : null,
+  )
 
   if (subscriptionPlan) {
     return { plan: subscriptionPlan, subscriptionId }
@@ -144,4 +147,4 @@ export async function resolvePlanFromCheckoutSession(session, stripeClient) {
   return { plan: undefined, subscriptionId }
 }
 
-export { PLAN_PRICE_MAPPING }
+export { PLAN_PRICE_MAPPING, PLAN_PRODUCT_MAPPING }

--- a/api/_utils/userPlan.js
+++ b/api/_utils/userPlan.js
@@ -53,47 +53,10 @@ export async function updateUserPlanTier({ userId, plan, customerId, subscriptio
   return normalizedPlan
 }
 
-export async function resolveUserForStripe({ userId, customerId, customerEmail }) {
-  if (!supabaseAdmin) {
-    throw new Error('Supabase admin client is not configured')
+export async function resolveUserForStripe({ userId }) {
+  if (!userId) {
+    return null
   }
 
-  if (userId) {
-    return userId
-  }
-
-  if (customerId) {
-    const { data, error } = await supabaseAdmin
-      .from('users')
-      .select('id')
-      .eq('stripe_customer_id', customerId)
-      .maybeSingle()
-
-    if (!error && data?.id) {
-      return data.id
-    }
-  }
-
-  if (customerEmail) {
-    try {
-      const { data } = await supabaseAdmin.auth.admin.getUserByEmail(customerEmail)
-      if (data?.user?.id) {
-        return data.user.id
-      }
-    } catch (error) {
-      console.warn('Failed to resolve user via Supabase auth email lookup', error)
-    }
-
-    const { data, error } = await supabaseAdmin
-      .from('users')
-      .select('id')
-      .eq('email', customerEmail)
-      .maybeSingle()
-
-    if (!error && data?.id) {
-      return data.id
-    }
-  }
-
-  return null
+  return userId
 }

--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -8,7 +8,6 @@ import {
   extractSubscriptionId,
   normalizePlanFromSubscription,
   resolvePlanFromCheckoutSession,
-  resolveSubscription,
 } from './_utils/stripePlans.js'
 import { resolveUserForStripe, updateUserPlanTier } from './_utils/userPlan.js'
 
@@ -79,13 +78,8 @@ async function handleCheckoutSessionCompleted(session) {
     return
   }
 
-  const customerEmail = session.customer_details?.email ?? session.customer_email ?? null
-  const referencedUserId = session.metadata?.userId ?? session.client_reference_id ?? null
-
   const userId = await resolveUserForStripe({
-    userId: referencedUserId,
-    customerId,
-    customerEmail,
+    userId: session.metadata?.userId ?? null,
   })
 
   if (!userId) {
@@ -93,7 +87,7 @@ async function handleCheckoutSessionCompleted(session) {
     return
   }
 
-  const { plan, subscriptionId } = await resolvePlanFromCheckoutSession(session, stripe)
+  const { plan, subscriptionId } = resolvePlanFromCheckoutSession(session)
 
   await updateUserPlanTier({
     userId,
@@ -112,13 +106,8 @@ async function handleSubscriptionUpdated(subscription) {
     return
   }
 
-  const customerEmail = subscription.customer_email ?? null
-  const referencedUserId = subscription.metadata?.userId ?? null
-
   const userId = await resolveUserForStripe({
-    userId: referencedUserId,
-    customerId,
-    customerEmail,
+    userId: subscription.metadata?.userId ?? null,
   })
 
   if (!userId) {
@@ -126,15 +115,17 @@ async function handleSubscriptionUpdated(subscription) {
     return
   }
 
-  const resolvedSubscription = (await resolveSubscription(subscription, stripe)) ?? subscription
-  const plan = normalizePlanFromSubscription(resolvedSubscription)
-  const subscriptionId = extractSubscriptionId(resolvedSubscription)
+  const subscriptionId = extractSubscriptionId(subscription)
+  const status = subscription.status
+  const isActiveStatus = ['trialing', 'active', 'past_due', 'unpaid'].includes(status)
+  const derivedPlan = isActiveStatus ? normalizePlanFromSubscription(subscription) : 'free'
+  const plan = derivedPlan ?? (isActiveStatus ? undefined : 'free')
 
   await updateUserPlanTier({
     userId,
     plan,
     customerId,
-    subscriptionId: plan === 'free' ? null : subscriptionId,
+    subscriptionId: !plan || plan === 'free' ? null : subscriptionId,
   })
 }
 
@@ -147,13 +138,8 @@ async function handleSubscriptionDeleted(subscription) {
     return
   }
 
-  const customerEmail = subscription.customer_email ?? null
-  const referencedUserId = subscription.metadata?.userId ?? null
-
   const userId = await resolveUserForStripe({
-    userId: referencedUserId,
-    customerId,
-    customerEmail,
+    userId: subscription.metadata?.userId ?? null,
   })
 
   if (!userId) {


### PR DESCRIPTION
## Summary
- hardcode Stripe price and product mappings for basic and pro plans
- resolve webhook users solely from Stripe metadata userId and derive plans from embedded subscription data
- keep webhook plan updates deterministic for inactive subscriptions by downgrading to the free tier

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901272c5288832fb961981f2e9d5212