### PR TITLE
Fix plan tier resolution when subscription metadata is outdated

### DIFF
--- a/api/_utils/stripePlans.js
+++ b/api/_utils/stripePlans.js
@@ -57,38 +57,48 @@ export function normalizePlanFromSubscription(subscription) {
     return null
   }
 
-  const fromMetadata =
-    normalizePlanId(subscription.metadata?.planId) ?? normalizePlanId(subscription.metadata?.tier)
-  if (fromMetadata) {
-    return fromMetadata
-  }
-
   const item = subscription.items?.data?.[0]
+
+  const metadataPlan =
+    normalizePlanId(subscription.metadata?.planId) ?? normalizePlanId(subscription.metadata?.tier)
   const itemMetadataPlan =
     normalizePlanId(item?.metadata?.planId) ?? normalizePlanId(item?.metadata?.tier)
-  if (itemMetadataPlan) {
-    return itemMetadataPlan
-  }
-
   const priceMetadataPlan =
-    normalizePlanId(item?.price?.metadata?.planId) ?? normalizePlanId(item?.price?.metadata?.tier)
-  if (priceMetadataPlan) {
-    return priceMetadataPlan
-  }
+    normalizePlanId(item?.price?.metadata?.planId) ??
+    normalizePlanId(item?.price?.metadata?.tier)
+
+  const metadataCandidates = [metadataPlan, itemMetadataPlan, priceMetadataPlan].filter(
+    Boolean,
+  )
 
   const priceId = item?.price?.id ?? subscription.plan?.id
   const planFromPrice = getPlanFromPriceId(priceId)
+
+  const productId = item?.price?.product ?? subscription.plan?.product
+  const planFromProduct = getPlanFromProductId(productId)
+
+  for (const candidate of metadataCandidates) {
+    if (
+      !planFromPrice &&
+      !planFromProduct
+    ) {
+      return candidate
+    }
+
+    if (candidate === planFromPrice || candidate === planFromProduct) {
+      return candidate
+    }
+  }
+
   if (planFromPrice) {
     return planFromPrice
   }
 
-  const productId = item?.price?.product ?? subscription.plan?.product
-  const planFromProduct = getPlanFromProductId(productId)
   if (planFromProduct) {
     return planFromProduct
   }
 
-  return null
+  return metadataCandidates[0] ?? null
 }
 
 function normalizePlanFromSessionMetadata(session) {

--- a/api/_utils/userPlan.js
+++ b/api/_utils/userPlan.js
@@ -53,10 +53,25 @@ export async function updateUserPlanTier({ userId, plan, customerId, subscriptio
   return normalizedPlan
 }
 
-export async function resolveUserForStripe({ userId }) {
-  if (!userId) {
+export async function resolveUserForStripe({ userId, customerId }) {
+  if (userId) {
+    return userId
+  }
+
+  if (!customerId || !supabaseAdmin) {
     return null
   }
 
-  return userId
+  const { data, error } = await supabaseAdmin
+    .from('users')
+    .select('id')
+    .eq('stripe_customer_id', customerId)
+    .maybeSingle()
+
+  if (error) {
+    console.error('Unable to resolve user from Stripe customer id', error)
+    return null
+  }
+
+  return data?.id ?? null
 }

--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -80,6 +80,7 @@ async function handleCheckoutSessionCompleted(session) {
 
   const userId = await resolveUserForStripe({
     userId: session.metadata?.userId ?? null,
+    customerId,
   })
 
   if (!userId) {
@@ -108,6 +109,7 @@ async function handleSubscriptionUpdated(subscription) {
 
   const userId = await resolveUserForStripe({
     userId: subscription.metadata?.userId ?? null,
+    customerId,
   })
 
   if (!userId) {
@@ -140,6 +142,7 @@ async function handleSubscriptionDeleted(subscription) {
 
   const userId = await resolveUserForStripe({
     userId: subscription.metadata?.userId ?? null,
+    customerId,
   })
 
   if (!userId) {


### PR DESCRIPTION
## Summary
- adjust Stripe subscription plan normalization to reconcile metadata with current price/product ids
- ensure plan tier updates favor the active price mapping when metadata lags behind plan changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901521bfbe8832f8d0c07d8622aa62c