### PR TITLE
Fix login route 404 by adding Vercel SPA rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,8 @@
 {
   "rewrites": [
     { "source": "/@vite/(.*)", "destination": "/@vite/$1" },
-    { "source": "/src/(.*)", "destination": "/src/$1" }
+    { "source": "/src/(.*)", "destination": "/src/$1" },
+    { "source": "/api/(.*)", "destination": "/api/$1" },
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- add a catch-all rewrite so deep links like `/login` resolve to the SPA entry point instead of 404s
- ensure API routes continue to pass through to their serverless functions

## Testing
- not run (infrastructure change)


------
https://chatgpt.com/codex/tasks/task_e_69025b904f8c832f90b66e7c367fe5bd