### PR TITLE
Limit SPA rewrite to HTML requests

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,11 @@
 {
   "rewrites": [
-    { "source": "/@vite/(.*)", "destination": "/@vite/$1" },
-    { "source": "/src/(.*)", "destination": "/src/$1" },
-    { "source": "/api/(.*)", "destination": "/api/$1" },
-    { "source": "/(.*)", "destination": "/index.html" }
+    {
+      "source": "/:path((?!api).*)",
+      "has": [
+        { "type": "header", "key": "accept", "value": ".*text/html.*" }
+      ],
+      "destination": "/index.html"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- gate the SPA rewrite so it only runs for HTML navigation requests
- keep API routes untouched by leaving all other paths to the filesystem

## Testing
- npm run build *(fails: missing optional dependency `@sentry/vite-plugin` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69028527fdc4832fbd16f15f2d3425f0