### PR TITLE
Add theme catalog constants and theme entitlement helpers

### DIFF
--- a/src/constants/themes.js
+++ b/src/constants/themes.js
@@ -1,0 +1,74 @@
+export const THEME_AVAILABILITY = {
+  none: 0,
+  basic: 1,
+  pro: 2
+}
+
+export const DEFAULT_THEME_ID = 'classic'
+
+export const THEMES = [
+  {
+    id: 'classic',
+    label: 'Classic Neutral',
+    description: 'Balanced neutrals that match the existing SoundRoom look and feel.',
+    availability: 'none',
+    isDark: false,
+    cssVars: {
+      surface: '#f9fafb',
+      panel: '#ffffff',
+      border: '#e5e7eb',
+      accent: '#2563eb',
+      accentForeground: '#ffffff',
+      textPrimary: '#0f172a',
+      textMuted: '#475569'
+    },
+    preview: ['#f9fafb', '#ffffff', '#2563eb']
+  },
+  {
+    id: 'skyline',
+    label: 'Skyline',
+    description: 'Airy blues and soft panels for a brighter workspace.',
+    availability: 'basic',
+    isDark: false,
+    cssVars: {
+      surface: '#f3f4ff',
+      panel: '#ffffff',
+      border: '#c7d2fe',
+      accent: '#0ea5e9',
+      accentForeground: '#ffffff',
+      textPrimary: '#0f172a',
+      textMuted: '#1e3a8a'
+    },
+    preview: ['#f3f4ff', '#0ea5e9', '#1e3a8a']
+  },
+  {
+    id: 'nocturne',
+    label: 'Nocturne',
+    description: 'Deep violets and high-contrast panels designed for late-night sessions.',
+    availability: 'pro',
+    isDark: true,
+    cssVars: {
+      surface: '#0f172a',
+      panel: '#111827',
+      border: '#1f2937',
+      accent: '#7c3aed',
+      accentForeground: '#f8fafc',
+      textPrimary: '#f8fafc',
+      textMuted: '#cbd5f5'
+    },
+    preview: ['#0f172a', '#7c3aed', '#f8fafc']
+  }
+]
+
+export const THEME_LOOKUP = THEMES.reduce((lookup, theme) => {
+  lookup[theme.id] = theme
+  return lookup
+}, {})
+
+export function getThemeById(themeId) {
+  return THEME_LOOKUP[themeId] ?? THEME_LOOKUP[DEFAULT_THEME_ID]
+}
+
+export function getThemeAvailabilityRank(level) {
+  return THEME_AVAILABILITY[level] ?? THEME_AVAILABILITY.none
+}

--- a/src/constants/themes.js
+++ b/src/constants/themes.js
@@ -7,6 +7,15 @@ export const THEME_AVAILABILITY = {
 export const DEFAULT_THEME_ID = 'classic'
 export const DEFAULT_COLOR_SCHEME = 'light'
 export const SUPPORTED_COLOR_SCHEMES = ['light', 'dark']
+const CSS_VAR_PREFIX = '--sr-'
+
+function resolveSystemColorScheme() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return DEFAULT_COLOR_SCHEME
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
 
 export const THEMES = [
   {
@@ -171,4 +180,50 @@ export function getThemeVariant(themeId, colorScheme = DEFAULT_COLOR_SCHEME) {
 
 export function getThemeAvailabilityRank(level) {
   return THEME_AVAILABILITY[level] ?? THEME_AVAILABILITY.none
+}
+
+export function applyThemeVariant(themeId, colorScheme) {
+  if (typeof document === 'undefined') {
+    return null
+  }
+
+  const resolvedScheme =
+    colorScheme === 'system' || !colorScheme
+      ? resolveSystemColorScheme()
+      : colorScheme
+  const variant = getThemeVariant(themeId, resolvedScheme)
+  const root = document.documentElement
+  const body = document.body
+
+  if (!root || !variant) {
+    return null
+  }
+
+  Object.entries(variant.cssVars ?? {}).forEach(([token, value]) => {
+    root.style.setProperty(`${CSS_VAR_PREFIX}${token}`, value)
+  })
+
+  root.dataset.themeId = themeId
+  root.dataset.themePreference = colorScheme ?? 'system'
+  root.dataset.themeScheme = resolvedScheme
+  root.style.colorScheme = variant.isDark ? 'dark' : 'light'
+  root.classList.toggle('dark', Boolean(variant.isDark))
+  root.classList.toggle('sr-dark', Boolean(variant.isDark))
+
+  if (variant.cssVars?.surface) {
+    root.style.backgroundColor = variant.cssVars.surface
+    if (body) {
+      body.style.backgroundColor = variant.cssVars.surface
+    }
+  }
+
+  if (variant.cssVars?.textPrimary && body) {
+    body.style.color = variant.cssVars.textPrimary
+  }
+
+  return {
+    themeId,
+    colorScheme: resolvedScheme,
+    variant
+  }
 }

--- a/src/constants/themes.js
+++ b/src/constants/themes.js
@@ -5,6 +5,8 @@ export const THEME_AVAILABILITY = {
 }
 
 export const DEFAULT_THEME_ID = 'classic'
+export const DEFAULT_COLOR_SCHEME = 'light'
+export const SUPPORTED_COLOR_SCHEMES = ['light', 'dark']
 
 export const THEMES = [
   {
@@ -12,51 +14,117 @@ export const THEMES = [
     label: 'Classic Neutral',
     description: 'Balanced neutrals that match the existing SoundRoom look and feel.',
     availability: 'none',
-    isDark: false,
-    cssVars: {
-      surface: '#f9fafb',
-      panel: '#ffffff',
-      border: '#e5e7eb',
-      accent: '#2563eb',
-      accentForeground: '#ffffff',
-      textPrimary: '#0f172a',
-      textMuted: '#475569'
+    defaultColorScheme: 'light',
+    preview: {
+      light: ['#f9fafb', '#ffffff', '#2563eb'],
+      dark: ['#0b1120', '#111827', '#38bdf8']
     },
-    preview: ['#f9fafb', '#ffffff', '#2563eb']
+    variants: {
+      light: {
+        label: 'Classic Day',
+        isDark: false,
+        cssVars: {
+          surface: '#f9fafb',
+          panel: '#ffffff',
+          border: '#e5e7eb',
+          accent: '#2563eb',
+          accentForeground: '#ffffff',
+          textPrimary: '#0f172a',
+          textMuted: '#475569'
+        }
+      },
+      dark: {
+        label: 'Classic Night',
+        isDark: true,
+        cssVars: {
+          surface: '#0b1120',
+          panel: '#111827',
+          border: '#1e293b',
+          accent: '#38bdf8',
+          accentForeground: '#0f172a',
+          textPrimary: '#e2e8f0',
+          textMuted: '#94a3b8'
+        }
+      }
+    }
   },
   {
     id: 'skyline',
     label: 'Skyline',
     description: 'Airy blues and soft panels for a brighter workspace.',
     availability: 'basic',
-    isDark: false,
-    cssVars: {
-      surface: '#f3f4ff',
-      panel: '#ffffff',
-      border: '#c7d2fe',
-      accent: '#0ea5e9',
-      accentForeground: '#ffffff',
-      textPrimary: '#0f172a',
-      textMuted: '#1e3a8a'
+    defaultColorScheme: 'light',
+    preview: {
+      light: ['#f3f4ff', '#0ea5e9', '#1e3a8a'],
+      dark: ['#0d1b2a', '#112240', '#38bdf8']
     },
-    preview: ['#f3f4ff', '#0ea5e9', '#1e3a8a']
+    variants: {
+      light: {
+        label: 'Skyline Day',
+        isDark: false,
+        cssVars: {
+          surface: '#f3f4ff',
+          panel: '#ffffff',
+          border: '#c7d2fe',
+          accent: '#0ea5e9',
+          accentForeground: '#ffffff',
+          textPrimary: '#0f172a',
+          textMuted: '#1e3a8a'
+        }
+      },
+      dark: {
+        label: 'Skyline Night',
+        isDark: true,
+        cssVars: {
+          surface: '#0d1b2a',
+          panel: '#112240',
+          border: '#1d3557',
+          accent: '#38bdf8',
+          accentForeground: '#081226',
+          textPrimary: '#e0f2fe',
+          textMuted: '#93c5fd'
+        }
+      }
+    }
   },
   {
     id: 'nocturne',
     label: 'Nocturne',
     description: 'Deep violets and high-contrast panels designed for late-night sessions.',
     availability: 'pro',
-    isDark: true,
-    cssVars: {
-      surface: '#0f172a',
-      panel: '#111827',
-      border: '#1f2937',
-      accent: '#7c3aed',
-      accentForeground: '#f8fafc',
-      textPrimary: '#f8fafc',
-      textMuted: '#cbd5f5'
+    defaultColorScheme: 'dark',
+    preview: {
+      light: ['#f5f3ff', '#7c3aed', '#312e81'],
+      dark: ['#0f172a', '#7c3aed', '#f8fafc']
     },
-    preview: ['#0f172a', '#7c3aed', '#f8fafc']
+    variants: {
+      light: {
+        label: 'Nocturne Dawn',
+        isDark: false,
+        cssVars: {
+          surface: '#f5f3ff',
+          panel: '#ede9fe',
+          border: '#ddd6fe',
+          accent: '#7c3aed',
+          accentForeground: '#f8fafc',
+          textPrimary: '#312e81',
+          textMuted: '#5b21b6'
+        }
+      },
+      dark: {
+        label: 'Nocturne Night',
+        isDark: true,
+        cssVars: {
+          surface: '#0f172a',
+          panel: '#111827',
+          border: '#1f2937',
+          accent: '#7c3aed',
+          accentForeground: '#f8fafc',
+          textPrimary: '#f8fafc',
+          textMuted: '#cbd5f5'
+        }
+      }
+    }
   }
 ]
 
@@ -67,6 +135,38 @@ export const THEME_LOOKUP = THEMES.reduce((lookup, theme) => {
 
 export function getThemeById(themeId) {
   return THEME_LOOKUP[themeId] ?? THEME_LOOKUP[DEFAULT_THEME_ID]
+}
+
+export function getThemeVariant(themeId, colorScheme = DEFAULT_COLOR_SCHEME) {
+  const theme = getThemeById(themeId)
+  const preferredScheme = SUPPORTED_COLOR_SCHEMES.includes(colorScheme)
+    ? colorScheme
+    : theme.defaultColorScheme ?? DEFAULT_COLOR_SCHEME
+
+  if (theme.variants?.[preferredScheme]) {
+    return theme.variants[preferredScheme]
+  }
+
+  const fallbackScheme = theme.defaultColorScheme ?? DEFAULT_COLOR_SCHEME
+  if (theme.variants?.[fallbackScheme]) {
+    return theme.variants[fallbackScheme]
+  }
+
+  const firstVariant = theme.variants
+    ? theme.variants[Object.keys(theme.variants)[0]]
+    : undefined
+
+  return (
+    firstVariant ?? {
+      label: theme.label,
+      isDark: false,
+      cssVars: theme.cssVars ?? {},
+      preview:
+        Array.isArray(theme.preview) || !theme.preview
+          ? theme.preview ?? []
+          : theme.preview[theme.defaultColorScheme ?? DEFAULT_COLOR_SCHEME] ?? []
+    }
+  )
 }
 
 export function getThemeAvailabilityRank(level) {

--- a/src/dev/setupThemePreview.js
+++ b/src/dev/setupThemePreview.js
@@ -1,0 +1,67 @@
+import {
+  applyThemeVariant,
+  DEFAULT_THEME_ID,
+  SUPPORTED_COLOR_SCHEMES
+} from '@/constants/themes.js'
+
+const url = new URL(window.location.href)
+const queryTheme = url.searchParams.get('theme')?.trim()
+const queryScheme = url.searchParams.get('scheme')?.trim()?.toLowerCase()
+
+const initialThemeId = queryTheme && queryTheme.length ? queryTheme : DEFAULT_THEME_ID
+const initialScheme =
+  queryScheme && (SUPPORTED_COLOR_SCHEMES.includes(queryScheme) || queryScheme === 'system')
+    ? queryScheme
+    : 'system'
+
+let activeTheme = initialThemeId
+let activeScheme = initialScheme
+let systemMediaQuery = null
+
+function apply(themeId = activeTheme, scheme = activeScheme) {
+  activeTheme = themeId
+  activeScheme = scheme
+
+  const result = applyThemeVariant(themeId, scheme)
+
+  if (systemMediaQuery) {
+    if (typeof systemMediaQuery.removeEventListener === 'function') {
+      systemMediaQuery.removeEventListener('change', handleSystemSchemeChange)
+    } else if (typeof systemMediaQuery.removeListener === 'function') {
+      systemMediaQuery.removeListener(handleSystemSchemeChange)
+    }
+    systemMediaQuery = null
+  }
+
+  if (!scheme || scheme === 'system') {
+    if (typeof window.matchMedia === 'function') {
+      systemMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+      if (typeof systemMediaQuery.addEventListener === 'function') {
+        systemMediaQuery.addEventListener('change', handleSystemSchemeChange)
+      } else if (typeof systemMediaQuery.addListener === 'function') {
+        systemMediaQuery.addListener(handleSystemSchemeChange)
+      }
+    }
+  }
+
+  return result
+}
+
+function handleSystemSchemeChange() {
+  applyThemeVariant(activeTheme, 'system')
+}
+
+apply(initialThemeId, initialScheme)
+
+window.__SOUNDROOM_THEME__ = {
+  apply,
+  get activeTheme() {
+    return activeTheme
+  },
+  get activeScheme() {
+    return activeScheme
+  },
+  reset() {
+    apply(DEFAULT_THEME_ID, 'system')
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -22,10 +22,17 @@ Sentry.init({
   ],
 });
 
+function mountApp() {
+  app
+    .use(VueKonva)
+    .use(PortalVue)
+    .use(router)
+    .use(createPinia())
+    .mount('#app')
+}
 
-app
-.use(VueKonva)
-.use(PortalVue)
-.use(router)
-.use(createPinia())
-.mount('#app')
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  import('@/dev/setupThemePreview.js').finally(mountApp)
+} else {
+  mountApp()
+}

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -1,5 +1,6 @@
 // permissions.js
 import { ENTITLEMENTS } from '@/constants/entitlements'
+import { getThemeAvailabilityRank } from '@/constants/themes'
 
 export function can(plan, feature) {
   const e = ENTITLEMENTS[plan] || ENTITLEMENTS.free
@@ -9,4 +10,13 @@ export function can(plan, feature) {
 export function limit(plan, key) {
   const e = ENTITLEMENTS[plan] || ENTITLEMENTS.free
   return e[key] ?? 0 // e.g. e.maxSavedRooms
+}
+
+export function themeAccessRank(plan) {
+  const entitlementLevel = (ENTITLEMENTS[plan] || ENTITLEMENTS.free).themes
+  return getThemeAvailabilityRank(entitlementLevel)
+}
+
+export function canUseTheme(plan, themeAvailability) {
+  return themeAccessRank(plan) >= getThemeAvailabilityRank(themeAvailability)
 }


### PR DESCRIPTION
## Summary
- add a central theme catalog with availability, metadata, and CSS variable tokens
- add permission helpers to compute theme access levels from plan entitlements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69028800e480832fbba84ca5cf0e2b1b