### PR TITLE
Add theme selector to settings

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,16 +2,16 @@
 <template>
   <SpeedInsights />
   <MobileComingSoon v-if="isMobile" />
-  <div class="h-screen max-h-screen min-w-screen flex flex-col">
+  <div class="h-screen max-h-screen min-w-screen flex flex-col bg-surface text-primary">
     <HeaderBar />
     <div class="flex-1 min-h-0 flex flex-col">
       <div
         v-if="globalError"
-        class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-white text-neutral-900 dark:bg-black dark:text-white"
+        class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-panel text-primary"
       >
         <p class="text-sm uppercase tracking-[0.2em] text-rose-500 mb-3">Navigation error</p>
         <h2 class="text-2xl font-semibold mb-3">We couldn't load that page.</h2>
-        <p class="max-w-md text-gray-600 dark:text-gray-400 mb-8">
+        <p class="max-w-md text-muted mb-8">
           {{ globalError.message }}
         </p>
         <div class="flex flex-wrap items-center justify-center gap-3">
@@ -20,7 +20,7 @@
           </BaseButton>
           <BaseButton
             variant="naked"
-            class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 text-sm font-medium"
+            class="text-accent hover:text-accent/80 text-sm font-medium"
             @click="returnHome"
           >
             Go back home
@@ -35,10 +35,10 @@
             </ErrorBoundary>
           </template>
           <template #fallback>
-            <div class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-white text-neutral-900 dark:bg-black dark:text-white">
-              <p class="text-sm uppercase tracking-[0.2em] text-blue-500 mb-3">Loading</p>
+            <div class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-panel text-primary">
+              <p class="text-sm uppercase tracking-[0.2em] text-accent mb-3">Loading</p>
               <h2 class="text-2xl font-semibold mb-3">Preparing SoundRoom…</h2>
-              <p class="max-w-md text-gray-600 dark:text-gray-400">
+              <p class="max-w-md text-muted">
                 Hang tight while we load the experience.
               </p>
             </div>

--- a/src/components/ErrorBoundary.vue
+++ b/src/components/ErrorBoundary.vue
@@ -2,11 +2,11 @@
   <slot v-if="!hasError" />
   <div
     v-else
-    class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-white text-neutral-900 dark:bg-black dark:text-white"
+    class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-panel text-primary"
   >
     <p class="text-sm uppercase tracking-[0.2em] text-rose-500 mb-3">Unexpected error</p>
     <h2 class="text-2xl font-semibold mb-3">We couldn't load this view.</h2>
-    <p class="max-w-md text-gray-600 dark:text-gray-400 mb-8">
+    <p class="max-w-md text-muted mb-8">
       {{ errorMessage }}
     </p>
     <div class="flex flex-wrap items-center justify-center gap-3">
@@ -15,7 +15,7 @@
       </BaseButton>
       <BaseButton
         variant="naked"
-        class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 text-sm font-medium"
+        class="text-accent hover:text-accent/80 text-sm font-medium"
         @click="goHome"
       >
         Go back home

--- a/src/components/SoundRoom/HeaderBar.vue
+++ b/src/components/SoundRoom/HeaderBar.vue
@@ -1,6 +1,8 @@
 <template>
   <PulsingOverlay v-if="isLoggingOut" :duration="2000" :text="'Logging out...'" @done="isLoggingOut = false" />
-  <header class="px-6 py-4 border-b border-neutral-300 dark:border-neutral-800 dark:bg-black flex items-center justify-between relative">
+  <header
+    class="relative flex items-center justify-between border-b border-border/80 bg-panel/80 px-6 py-4 backdrop-blur supports-[backdrop-filter]:bg-panel/60"
+  >
     <h1 class="text-xl font-bold tracking-wide dark:text-gray-300"><RouterLink to="/" style="text-decoration: none; color: inherit;">SoundRoom</RouterLink></h1>
     
     <div v-if="shouldShowNavButtons" class="relative">
@@ -8,7 +10,7 @@
         ref="menuButton"
         type="button"
         @click="toggleMenu"
-        class="flex items-center justify-center w-12 h-12 !p-1 !bg-transparent"
+        class="flex h-12 w-12 items-center justify-center rounded-full border border-border/70 bg-panel/90 text-primary shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 hover:bg-panel"
         :aria-expanded="isMenuOpen"
         aria-haspopup="true"
       >
@@ -20,11 +22,11 @@
           v-if="isMenuOpen"
           @mouseleave="closeMenu"
           ref="menuPanel"
-          class="absolute right-0 mt-2 w-44 rounded-lg shadow-lg border border-border bg-panel py-2 z-50 flex flex-col divide-y divide-neutral-200 overflow-hidden"
+          class="absolute right-0 z-50 mt-2 flex w-44 flex-col overflow-hidden rounded-xl border border-border/80 bg-panel/95 py-2 shadow-xl backdrop-blur supports-[backdrop-filter]:bg-panel/70 divide-y divide-border/60"
         >
           <template v-for="button in visibleButtons" :key="button.label">
             <button
-              class="w-full px-4 py-2 text-left text-sm text-neutral-800 hover:bg-panel-muted focus:outline-none !bg-transparent"
+              class="w-full px-4 py-2 text-left text-sm text-primary transition hover:bg-panel-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/30"
               type="button"
               @click="runAction(button.action)"
             >

--- a/src/components/SoundRoom/HeaderBar.vue
+++ b/src/components/SoundRoom/HeaderBar.vue
@@ -20,11 +20,11 @@
           v-if="isMenuOpen"
           @mouseleave="closeMenu"
           ref="menuPanel"
-          class="absolute right-0 mt-2 w-44 rounded-lg shadow-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 py-2 z-50 flex flex-col divide-y divide-neutral-200 dark:divide-neutral-800 overflow-hidden"
+          class="absolute right-0 mt-2 w-44 rounded-lg shadow-lg border border-border bg-panel py-2 z-50 flex flex-col divide-y divide-neutral-200 overflow-hidden"
         >
           <template v-for="button in visibleButtons" :key="button.label">
             <button
-              class="w-full px-4 py-2 text-left text-sm text-neutral-800 dark:text-neutral-100 hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-none !bg-transparent"
+              class="w-full px-4 py-2 text-left text-sm text-neutral-800 hover:bg-panel-muted focus:outline-none !bg-transparent"
               type="button"
               @click="runAction(button.action)"
             >

--- a/src/components/ui/context/ContextMenu.vue
+++ b/src/components/ui/context/ContextMenu.vue
@@ -7,7 +7,7 @@
       top: `${pos.y}px`,
       left: `${pos.x}px`,
     }"
-    class="context-menu bg-white dark:bg-neutral-800 rounded shadow p-2 text-sm border border-neutral-300 dark:border-neutral-700"
+    class="context-menu rounded border border-border bg-panel p-2 text-sm shadow"
     role="menu"
     aria-label="Context menu"
   >
@@ -15,7 +15,7 @@
       <li
         v-for="(f, i) in functionList"
         :key="f.label"
-        class="px-2 py-1 rounded cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        class="px-2 py-1 rounded cursor-pointer hover:bg-panel-muted transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
         tabindex="0"
         role="menuitem"
         @click="() => handleClick(f.function)"

--- a/src/components/ui/input/BaseButton.vue
+++ b/src/components/ui/input/BaseButton.vue
@@ -3,9 +3,11 @@
   :type="type"
   :disabled="disabled"
   :class="[
-    'transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed',
-    variant === 'default' && 'px-4 py-2 rounded text-sm font-medium bg-blue-600 hover:bg-blue-700 text-white',
-    variant === 'naked' && ''
+    'inline-flex items-center justify-center rounded-lg border border-transparent px-4 py-2 text-sm font-medium transition',
+    'focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-60',
+    variant === 'default' && 'bg-accent text-accent-foreground shadow-sm hover:bg-accent/90',
+    variant === 'naked' && 'bg-transparent text-primary hover:text-accent',
+    loading && 'pointer-events-none'
   ]"
   @click="(e) => $emit('click', e)"
 >
@@ -14,7 +16,7 @@
     </span>
     <span v-else class="flex items-center justify-center space-x-2">
       <svg
-        class="w-4 h-4 animate-spin text-white"
+        class="h-4 w-4 animate-spin text-accent-foreground"
         fill="none"
         viewBox="0 0 24 24"
       >

--- a/src/components/ui/input/BaseInput.vue
+++ b/src/components/ui/input/BaseInput.vue
@@ -3,7 +3,7 @@
     <label
       v-if="label"
       :for="id"
-      class="text-sm font-medium text-neutral-700 dark:text-neutral-200"
+      class="text-sm font-medium text-primary"
     >
       {{ label }}
     </label>
@@ -16,12 +16,12 @@
       :autocomplete="autocomplete"
       :disabled="disabled"
       :class="[
-        'px-3 py-2 rounded border w-full text-sm focus:outline-none',
-        'focus-visible:ring-2 focus-visible:ring-blue-500',
+        'w-full rounded-lg border px-3 py-2 text-sm focus:outline-none',
+        'focus-visible:ring-2 focus-visible:ring-accent/40 transition shadow-sm',
         props.class,
         error
           ? 'border-red-500 text-red-700 bg-red-50'
-          : 'border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white',
+          : 'border-border bg-panel text-primary',
       ]"
       v-model="internalValue"
       :aria-describedby="error ? errorId : undefined"

--- a/src/components/ui/input/PasswordInput.vue
+++ b/src/components/ui/input/PasswordInput.vue
@@ -8,11 +8,12 @@
       placeholder="Enter your password"
     />
     <BaseButton
-      class="absolute right-1 top-1/2 -translate-y-1/2 eye-button"
+      variant="naked"
+      class="absolute right-1 top-1/2 -translate-y-1/2 !px-2 !py-2 text-muted hover:text-primary"
       @click.prevent="show = !show"
       :aria-label="show ? 'Hide password' : 'Show password'"
     >
-      <component :is="show ? EyeOpen : EyeClosed" class="w-5 h-5 text-gray-500 dark:text-neutral-900" />
+      <component :is="show ? EyeOpen : EyeClosed" class="h-5 w-5" />
     </BaseButton>
   </div>
 </template>
@@ -54,12 +55,3 @@ const inputProps = computed(() => ({
   type: undefined // override actual `type` via `:type="show ? 'text' : 'password'"`
 }))
 </script>
-<style scoped>
-.eye-button {
-  background: none;
-  
-}
-.eye-button:focus {
-  outline: 2px solid #4a90e2; /* Focus ring color */
-}
-</style> 

--- a/src/components/ui/loading/LoadingDiv.vue
+++ b/src/components/ui/loading/LoadingDiv.vue
@@ -2,11 +2,11 @@
   <transition name="fade" @after-leave="emit('done')">
     <div
       v-if="visible"
-      class="absolute top-0 left-0 right-0 bottom-0 flex items-center justify-center backdrop-blur-sm bg-white/30 dark:bg-black/40 z-20"
+      class="absolute top-0 left-0 right-0 bottom-0 flex items-center justify-center backdrop-blur-sm bg-panel/60 z-20"
       :class="[props.class]"
     >
       <div
-        class="text-xl font-medium tracking-wide text-neutral-800 dark:text-white animate-pulse"
+        class="text-xl font-medium tracking-wide text-primary animate-pulse"
       >
         {{ text }}
       </div>

--- a/src/components/ui/loading/LoadingSpinner.vue
+++ b/src/components/ui/loading/LoadingSpinner.vue
@@ -1,5 +1,5 @@
 <template>
-  <svg class="animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <svg class="animate-spin h-4 w-4 text-accent-foreground" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
   </svg>

--- a/src/components/ui/modals/Help.vue
+++ b/src/components/ui/modals/Help.vue
@@ -1,11 +1,11 @@
 <template>
   <div @click.self="handleClose" class="modal-backdrop">
-    <div class="bg-white dark:bg-neutral-950 rounded-2xl w-[80vw] h-[80vh] relative flex flex-col overflow-hidden shadow-2xl border border-neutral-300 dark:border-neutral-800">
+    <div class="rounded-2xl w-[80vw] h-[80vh] relative flex flex-col overflow-hidden border border-border bg-panel shadow-2xl">
       
       <!-- Absolute Floating Header -->
       <div class="modal-header-float">
         <h1 class="text-2xl font-bold tracking-tight">Welcome to SoundRoom</h1>
-        <BaseButton @click="handleClose" class="text-sm hover:text-neutral-600 dark:hover:text-neutral-400">Close</BaseButton>
+        <BaseButton @click="handleClose" class="text-sm text-muted hover:text-primary">Close</BaseButton>
       </div>
 
       <!-- Scrollable Content -->
@@ -85,7 +85,7 @@
           </section>
 
           <section>
-            <h2 class="text-lg font-semibold mb-4 border-b border-neutral-300 dark:border-neutral-800 pb-1">FAQ</h2>
+            <h2 class="text-lg font-semibold mb-4 border-b border-border pb-1">FAQ</h2>
             <ul class=" dark:divide-neutral-800">
               <li
                 v-for="(faq, i) in faqs"
@@ -133,7 +133,7 @@
                     v-model="form.name"
                     required
                     autocomplete="name"
-                    class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                    class="w-full px-3 py-2 rounded border border-border bg-panel focus:outline-none focus:ring-2 focus:ring-accent/40 text-sm"
                   />
                 </div>
 
@@ -145,7 +145,7 @@
                     v-model="form.email"
                     required
                     autocomplete="email"
-                    class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                    class="w-full px-3 py-2 rounded border border-border bg-panel focus:outline-none focus:ring-2 focus:ring-accent/40 text-sm"
                   />
                 </div>
               </div>
@@ -157,7 +157,7 @@
                     id="topic"
                     v-model="form.topic"
                     required
-                    class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                    class="w-full px-3 py-2 rounded border border-border bg-panel focus:outline-none focus:ring-2 focus:ring-accent/40 text-sm"
                   >
                     <option v-for="item in topicOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
                   </select>
@@ -168,7 +168,7 @@
                   <select
                     id="plan"
                     v-model="form.plan"
-                    class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                    class="w-full px-3 py-2 rounded border border-border bg-panel focus:outline-none focus:ring-2 focus:ring-accent/40 text-sm"
                   >
                     <option value="">Select your plan</option>
                     <option v-for="option in planOptions" :key="option" :value="option">{{ PLAN_LABELS[option] }}</option>
@@ -184,7 +184,7 @@
                   id="roomLink"
                   v-model="form.roomLink"
                   placeholder="Paste a RoomManager link or card ID"
-                  class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                  class="w-full px-3 py-2 rounded border border-border bg-panel focus:outline-none focus:ring-2 focus:ring-accent/40 text-sm"
                 />
               </div>
 
@@ -196,7 +196,7 @@
                   rows="4"
                   required
                   placeholder="Tell us what you were working on and what you expected to happen."
-                  class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                  class="w-full px-3 py-2 rounded border border-border bg-panel focus:outline-none focus:ring-2 focus:ring-accent/40 text-sm"
                 ></textarea>
               </div>
 
@@ -207,7 +207,7 @@
                   v-model="form.reproSteps"
                   rows="3"
                   placeholder="Step-by-step details help us debug much faster."
-                  class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                  class="w-full px-3 py-2 rounded border border-border bg-panel focus:outline-none focus:ring-2 focus:ring-accent/40 text-sm"
                 ></textarea>
               </div>
 
@@ -216,7 +216,7 @@
               <BaseButton
                 type="submit"
                 :disabled="submitting"
-                class="bg-blue-600 hover:bg-blue-700 disabled:opacity-60 disabled:cursor-not-allowed text-white px-4 py-2 rounded text-sm"
+                class="px-4 py-2 text-sm rounded"
               >
                 <span v-if="submitting">Sending…</span>
                 <span v-else>Send Message</span>

--- a/src/components/ui/modals/Onboarding.vue
+++ b/src/components/ui/modals/Onboarding.vue
@@ -1,9 +1,9 @@
 <template>
   <div @click.self="emit('close')" class="modal-backdrop">
-    <div class="bg-white dark:bg-neutral-950 rounded-2xl w-[80vw] max-w-xl h-auto relative flex flex-col overflow-hidden shadow-2xl border border-neutral-300 dark:border-neutral-800">
+    <div class="rounded-2xl w-[80vw] max-w-xl h-auto relative flex flex-col overflow-hidden border border-border bg-panel shadow-2xl">
       
       <!-- Floating Header -->
-      <div class="modal-header p-6 border-b border-neutral-300 dark:border-neutral-800">
+      <div class="modal-header p-6 border-b border-border">
         <h1 class="text-2xl font-bold tracking-tight">Welcome to SoundRoom</h1>
       </div>
 
@@ -27,8 +27,8 @@
       </div>
 
       <!-- Footer -->
-      <div class="flex justify-end p-4 border-t border-neutral-300 dark:border-neutral-800">
-        <BaseButton @click="router.push('/')" class="text-sm px-4 py-2 font-medium rounded hover:text-neutral-600 dark:hover:text-neutral-300">
+      <div class="flex justify-end p-4 border-t border-border">
+        <BaseButton @click="router.push('/')" class="text-sm px-4 py-2 font-medium rounded">
           Let's Go
         </BaseButton>
       </div>

--- a/src/components/ui/modals/RoomManager/EditableRoomName.vue
+++ b/src/components/ui/modals/RoomManager/EditableRoomName.vue
@@ -3,7 +3,7 @@
     <template v-if="isEditing">
       <input
         v-model="localName"
-        class="w-full bg-neutral-700 text-white px-2 py-1 rounded"
+        class="w-full rounded border border-border bg-panel px-2 py-1 text-primary focus:outline-none focus:ring-2 focus:ring-accent/30"
         @blur="handleBlur"
         @keyup.enter="handleBlur"
         @keyup.esc="cancelEdit"

--- a/src/components/ui/modals/RoomManager/PaginationControls.vue
+++ b/src/components/ui/modals/RoomManager/PaginationControls.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="absolute flex bottom-0 left-0 right-0 p-4 bg-white dark:bg-neutral-950 border-t border-neutral-300 dark:border-neutral-800">
+  <div class="absolute flex bottom-0 left-0 right-0 p-4 bg-panel border-t border-border">
     <span class="w-1/4"></span>
     <div class="flex items-center justify-center w-1/2 space-x-3" :class="{ invisible: loading }">
       <BaseButton class="px-3 py-1" :disabled="currentPage === 0" @click="emit('prev')">← Prev</BaseButton>

--- a/src/components/ui/modals/RoomManager/RoomManager.vue
+++ b/src/components/ui/modals/RoomManager/RoomManager.vue
@@ -26,7 +26,7 @@
         <!-- Floating Top Bar -->
         <div
           ref="headerBar"
-          class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-white/50 dark:bg-neutral-950/50 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800"
+          class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-panel/70 backdrop-blur-md border-b border-border"
         >
           <h2 class="text-2xl font-bold">RoomManager</h2>
           <BaseButton class="text-sm" @click="router.push('/')">Close</BaseButton>

--- a/src/components/ui/modals/SmallModalBase.vue
+++ b/src/components/ui/modals/SmallModalBase.vue
@@ -8,12 +8,12 @@
   >
     <div
       ref="modalContent"
-      class="bg-white dark:bg-neutral-950 rounded-2xl w-[90vw] max-w-md h-auto max-h-[85vh] shadow-xl border border-neutral-300 dark:border-neutral-800 relative overflow-hidden"
+      class="rounded-2xl w-[90vw] max-w-md h-auto max-h-[85vh] border border-border bg-panel shadow-xl relative overflow-hidden"
       tabindex="-1"
     >
       <!-- Header -->
       <div
-        class="top-0 left-0 right-0 z-10 flex justify-between items-center px-4 py-3 bg-white/70 dark:bg-neutral-950/70 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800"
+        class="top-0 left-0 right-0 z-10 flex justify-between items-center px-4 py-3 bg-panel/70 backdrop-blur-md border-b border-border"
       >
         <h2 id="modal-title" class="text-lg font-semibold tracking-tight">
           {{ title }}
@@ -21,7 +21,7 @@
         <BaseButton
           v-if="showCloseButton"
           @click="emit('close')"
-          class="text-sm hover:text-neutral-600 dark:hover:text-neutral-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          class="text-sm text-muted hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
           aria-label="Close modal"
         >
           Close

--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex-1 relative overflow-hidden">
-    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-white/50 dark:bg-neutral-950/50 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800">
+    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-panel/70 backdrop-blur-md border-b border-border">
       <h2 class="text-2xl font-bold">SoundLibrary</h2>
       <BaseButton class="text-sm" @click="$emit('close')">Close</BaseButton>
     </div>
@@ -25,7 +25,7 @@
     </div>
      <div
         v-if="isAuthenticated && activeCategory === 'your-sounds'"
-        class="absolute bottom-0 left-0 right-0 p-4 bg-white dark:bg-neutral-950 border-t border-neutral-300 dark:border-neutral-800"
+        class="absolute bottom-0 left-0 right-0 p-4 bg-panel border-t border-border"
       >
         <div class="flex items-center justify-between gap-3">
           <button

--- a/src/components/ui/modals/SoundLibrary/UploadPanel.vue
+++ b/src/components/ui/modals/SoundLibrary/UploadPanel.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="modal-backdrop z-50" @click.self="$emit('close')">
-    <div class="modal-panel max-w-3xl mx-auto p-6 bg-white dark:bg-neutral-950 rounded-xl shadow-lg overflow-y-auto max-h-[90vh]">
+    <div class="modal-panel max-w-3xl mx-auto p-6 rounded-xl shadow-lg overflow-y-auto max-h-[90vh]">
       <h2 class="text-xl font-bold mb-4">Upload Your Sounds</h2>
 
-      <div class="border border-dashed border-neutral-400 dark:border-neutral-700 rounded-lg p-6 text-center mb-6">
+      <div class="border border-dashed border-border rounded-lg p-6 text-center mb-6">
         <input
           type="file"
           accept="audio/*"
@@ -17,11 +17,11 @@
       </div>
 
       <div v-if="files.length > 0" class="space-y-4">
-        <div v-for="file in files" :key="file.id" class="bg-neutral-100 dark:bg-neutral-900 rounded-md p-4 flex flex-col gap-2">
+        <div v-for="file in files" :key="file.id" class="bg-panel rounded-md p-4 flex flex-col gap-2">
           <div class="flex justify-between items-center">
             <input
               v-model="file.name"
-              class="flex-1 p-1 text-base border border-neutral-300 dark:border-neutral-700 rounded-md bg-white dark:bg-neutral-800"
+              class="flex-1 rounded-md border border-border bg-panel px-2 py-1 text-base focus:outline-none focus:ring-2 focus:ring-accent/30"
             />
             <BaseButton class="ml-2" @click="autoTag(file)" :disabled="file.tagging">
               <template v-if="file.tagging">
@@ -37,7 +37,7 @@
           <div class="flex items-center gap-2">
             <audio :src="file.previewUrl" controls class="w-full" />
           </div>
-          <div class="h-2 bg-neutral-300 dark:bg-neutral-700 rounded overflow-hidden" v-if="uploading">
+          <div class="h-2 bg-surface-muted rounded overflow-hidden" v-if="uploading">
             <div
               class="h-full bg-green-500 transition-all duration-300"
               :style="{ width: `${file.progress}%` }"
@@ -48,7 +48,7 @@
           <span
             v-for="(tag, index) in file.tags"
             :key="tag"
-            class="flex items-center bg-neutral-200 dark:bg-neutral-800 text-xs px-2 rounded"
+            class="flex items-center bg-panel-muted text-xs px-2 rounded"
           >
             {{ tag }}
             <label
@@ -69,7 +69,7 @@
             @keydown="','"
             @blur="addTag(file)"
             placeholder="Add tag..."
-            class="text-sm p-1 rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 w-25"
+            class="text-sm px-2 py-1 rounded border border-border bg-panel w-25 focus:outline-none focus:ring-2 focus:ring-accent/30"
           />
         </div>
 

--- a/src/components/ui/modals/YesNoModal.vue
+++ b/src/components/ui/modals/YesNoModal.vue
@@ -22,7 +22,7 @@
         <BaseButton
           v-for="button in buttons"
           :key="button.label"
-          class="px-4 py-2 text-sm font-medium rounded bg-blue-600 text-white hover:bg-blue-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+          class="px-4 py-2 text-sm font-medium rounded"
           @click="button.action"
           type="button"
         >

--- a/src/components/ui/overlays/PulsingOverlay.vue
+++ b/src/components/ui/overlays/PulsingOverlay.vue
@@ -2,10 +2,10 @@
   <transition name="fade" @after-leave="emit('done')">
     <div
       v-if="visible"
-      class="absolute inset-0 flex items-center justify-center backdrop-blur-sm bg-white/30 dark:bg-black/40 z-50"
+      class="absolute inset-0 flex items-center justify-center backdrop-blur-sm bg-panel/60 z-50"
     >
       <div
-        class="text-xl font-medium tracking-wide text-neutral-800 dark:text-white animate-pulse"
+        class="text-xl font-medium tracking-wide text-primary animate-pulse"
       >
         {{ text }}
       </div>

--- a/src/components/ui/overlays/WelcomeOverlay.vue
+++ b/src/components/ui/overlays/WelcomeOverlay.vue
@@ -2,7 +2,7 @@
   <transition name="fade">
     <div
       v-if="visible"
-      class="absolute inset-0 z-50 flex items-center justify-center backdrop-blur-md bg-white/30 dark:bg-black/50"
+      class="absolute inset-0 z-50 flex items-center justify-center backdrop-blur-md bg-panel/60"
     >
       <div class="text-center space-y-4">
         <h1
@@ -12,7 +12,7 @@
         </h1>
         <p
           v-if="subtext"
-          class="text-lg text-neutral-700 dark:text-neutral-300 opacity-80"
+          class="text-lg text-muted opacity-80"
         >
           {{ subtext }}
         </p>

--- a/src/constants/themes.js
+++ b/src/constants/themes.js
@@ -1,0 +1,396 @@
+export const THEME_AVAILABILITY = {
+  none: 0,
+  basic: 1,
+  pro: 2
+}
+
+export const DEFAULT_THEME_ID = 'classic'
+export const DEFAULT_COLOR_SCHEME = 'light'
+export const SUPPORTED_COLOR_SCHEMES = ['light', 'dark']
+const CSS_VAR_PREFIX = '--sr-'
+
+const DEFAULT_NEUTRAL_SCALE = {
+  50: '#fafafa',
+  100: '#f5f5f5',
+  200: '#e5e5e5',
+  300: '#d4d4d4',
+  400: '#a3a3a3',
+  500: '#737373',
+  600: '#525252',
+  700: '#404040',
+  800: '#262626',
+  900: '#171717',
+  950: '#0a0a0a'
+}
+
+function resolveSystemColorScheme() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return DEFAULT_COLOR_SCHEME
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function hexToRgb(hex) {
+  const normalized = hex.replace('#', '').trim()
+  if (normalized.length === 3) {
+    const r = normalized[0]
+    const g = normalized[1]
+    const b = normalized[2]
+    return [r, r, g, g, b, b].join('').match(/.{2}/g).map((pair) => parseInt(pair, 16))
+  }
+
+  if (normalized.length === 6) {
+    return normalized.match(/.{2}/g).map((pair) => parseInt(pair, 16))
+  }
+
+  return null
+}
+
+function parseColorToRgb(value) {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const trimmed = value.trim()
+
+  if (trimmed.startsWith('#')) {
+    const components = hexToRgb(trimmed)
+    return components ? components.join(' ') : null
+  }
+
+  const rgbMatch = trimmed.match(/^rgba?\(([^)]+)\)$/i)
+  if (rgbMatch) {
+    const parts = rgbMatch[1]
+      .split(',')
+      .map((part) => part.trim())
+      .slice(0, 3)
+    if (parts.length === 3) {
+      return parts.join(' ')
+    }
+  }
+
+  return null
+}
+
+function setCssVariable(root, token, value) {
+  root.style.setProperty(`${CSS_VAR_PREFIX}${token}`, value)
+  const rgbValue = parseColorToRgb(value)
+  if (rgbValue) {
+    root.style.setProperty(`${CSS_VAR_PREFIX}${token}-rgb`, rgbValue)
+  }
+}
+
+export const THEMES = [
+  {
+    id: 'classic',
+    label: 'Classic Neutral',
+    description: 'Balanced neutrals that match the existing SoundRoom look and feel.',
+    availability: 'none',
+    defaultColorScheme: 'light',
+    preview: {
+      light: ['#f9fafb', '#ffffff', '#2563eb'],
+      dark: ['#0b1120', '#111827', '#38bdf8']
+    },
+    variants: {
+      light: {
+        label: 'Classic Day',
+        isDark: false,
+        cssVars: {
+          surface: '#f9fafb',
+          surfaceMuted: '#e2e8f0',
+          panel: '#ffffff',
+          panelMuted: '#f3f4f6',
+          border: '#e5e7eb',
+          accent: '#2563eb',
+          accentForeground: '#ffffff',
+          textPrimary: '#0f172a',
+          textMuted: '#475569'
+        },
+        neutralScale: {
+          50: '#f9fafb',
+          100: '#f3f4f6',
+          200: '#e5e7eb',
+          300: '#d1d5db',
+          400: '#94a3b8',
+          500: '#64748b',
+          600: '#475569',
+          700: '#334155',
+          800: '#1e293b',
+          900: '#0f172a',
+          950: '#020617'
+        }
+      },
+      dark: {
+        label: 'Classic Night',
+        isDark: true,
+        cssVars: {
+          surface: '#0b1120',
+          surfaceMuted: '#111a2c',
+          panel: '#111827',
+          panelMuted: '#1f2937',
+          border: '#1e293b',
+          accent: '#38bdf8',
+          accentForeground: '#0f172a',
+          textPrimary: '#e2e8f0',
+          textMuted: '#94a3b8'
+        },
+        neutralScale: {
+          50: '#e2e8f0',
+          100: '#cbd5f5',
+          200: '#94a3b8',
+          300: '#64748b',
+          400: '#475569',
+          500: '#334155',
+          600: '#1f2a3b',
+          700: '#162032',
+          800: '#0f172a',
+          900: '#0b1120',
+          950: '#030712'
+        }
+      }
+    }
+  },
+  {
+    id: 'skyline',
+    label: 'Skyline',
+    description: 'Airy blues and soft panels for a brighter workspace.',
+    availability: 'basic',
+    defaultColorScheme: 'light',
+    preview: {
+      light: ['#f3f4ff', '#0ea5e9', '#1e3a8a'],
+      dark: ['#0d1b2a', '#112240', '#38bdf8']
+    },
+    variants: {
+      light: {
+        label: 'Skyline Day',
+        isDark: false,
+        cssVars: {
+          surface: '#f3f4ff',
+          surfaceMuted: '#e0f2fe',
+          panel: '#ffffff',
+          panelMuted: '#f0f9ff',
+          border: '#c7d2fe',
+          accent: '#0ea5e9',
+          accentForeground: '#ffffff',
+          textPrimary: '#0f172a',
+          textMuted: '#1e3a8a'
+        },
+        neutralScale: {
+          50: '#f5faff',
+          100: '#e8f3ff',
+          200: '#d8e9ff',
+          300: '#c0dafb',
+          400: '#90bae9',
+          500: '#5c96d1',
+          600: '#3f75b3',
+          700: '#285a94',
+          800: '#1f4878',
+          900: '#1a3a60',
+          950: '#132846'
+        }
+      },
+      dark: {
+        label: 'Skyline Night',
+        isDark: true,
+        cssVars: {
+          surface: '#0d1b2a',
+          surfaceMuted: '#132b3f',
+          panel: '#112240',
+          panelMuted: '#1d3557',
+          border: '#1d3557',
+          accent: '#38bdf8',
+          accentForeground: '#081226',
+          textPrimary: '#e0f2fe',
+          textMuted: '#93c5fd'
+        },
+        neutralScale: {
+          50: '#e0f2fe',
+          100: '#bae6fd',
+          200: '#7dd3fc',
+          300: '#38bdf8',
+          400: '#0ea5e9',
+          500: '#0284c7',
+          600: '#0369a1',
+          700: '#0b4f7d',
+          800: '#123a5a',
+          900: '#0b2a42',
+          950: '#051a2a'
+        }
+      }
+    }
+  },
+  {
+    id: 'nocturne',
+    label: 'Nocturne',
+    description: 'Deep violets and high-contrast panels designed for late-night sessions.',
+    availability: 'pro',
+    defaultColorScheme: 'dark',
+    preview: {
+      light: ['#f5f3ff', '#7c3aed', '#312e81'],
+      dark: ['#0f172a', '#7c3aed', '#f8fafc']
+    },
+    variants: {
+      light: {
+        label: 'Nocturne Dawn',
+        isDark: false,
+        cssVars: {
+          surface: '#f5f3ff',
+          surfaceMuted: '#ede9fe',
+          panel: '#ede9fe',
+          panelMuted: '#ddd6fe',
+          border: '#c4b5fd',
+          accent: '#7c3aed',
+          accentForeground: '#f8fafc',
+          textPrimary: '#312e81',
+          textMuted: '#5b21b6'
+        },
+        neutralScale: {
+          50: '#f5f3ff',
+          100: '#ede9fe',
+          200: '#ddd6fe',
+          300: '#c4b5fd',
+          400: '#a78bfa',
+          500: '#8b5cf6',
+          600: '#7c3aed',
+          700: '#6d28d9',
+          800: '#5b21b6',
+          900: '#4c1d95',
+          950: '#2e1065'
+        }
+      },
+      dark: {
+        label: 'Nocturne Night',
+        isDark: true,
+        cssVars: {
+          surface: '#0f172a',
+          surfaceMuted: '#1a1d3b',
+          panel: '#111827',
+          panelMuted: '#1f2937',
+          border: '#1f2937',
+          accent: '#7c3aed',
+          accentForeground: '#f8fafc',
+          textPrimary: '#f8fafc',
+          textMuted: '#cbd5f5'
+        },
+        neutralScale: {
+          50: '#ede9fe',
+          100: '#ddd6fe',
+          200: '#c4b5fd',
+          300: '#a78bfa',
+          400: '#8b5cf6',
+          500: '#7c3aed',
+          600: '#6d28d9',
+          700: '#5b21b6',
+          800: '#4c1d95',
+          900: '#3b1678',
+          950: '#2a0f57'
+        }
+      }
+    }
+  }
+]
+
+export const THEME_LOOKUP = THEMES.reduce((lookup, theme) => {
+  lookup[theme.id] = theme
+  return lookup
+}, {})
+
+export function getThemeById(themeId) {
+  return THEME_LOOKUP[themeId] ?? THEME_LOOKUP[DEFAULT_THEME_ID]
+}
+
+export function getThemeVariant(themeId, colorScheme = DEFAULT_COLOR_SCHEME) {
+  const theme = getThemeById(themeId)
+  const preferredScheme = SUPPORTED_COLOR_SCHEMES.includes(colorScheme)
+    ? colorScheme
+    : theme.defaultColorScheme ?? DEFAULT_COLOR_SCHEME
+
+  if (theme.variants?.[preferredScheme]) {
+    return theme.variants[preferredScheme]
+  }
+
+  const fallbackScheme = theme.defaultColorScheme ?? DEFAULT_COLOR_SCHEME
+  if (theme.variants?.[fallbackScheme]) {
+    return theme.variants[fallbackScheme]
+  }
+
+  const firstVariant = theme.variants
+    ? theme.variants[Object.keys(theme.variants)[0]]
+    : undefined
+
+  return (
+    firstVariant ?? {
+      label: theme.label,
+      isDark: false,
+      cssVars: theme.cssVars ?? {},
+      preview:
+        Array.isArray(theme.preview) || !theme.preview
+          ? theme.preview ?? []
+          : theme.preview[theme.defaultColorScheme ?? DEFAULT_COLOR_SCHEME] ?? []
+    }
+  )
+}
+
+export function getThemeAvailabilityRank(level) {
+  return THEME_AVAILABILITY[level] ?? THEME_AVAILABILITY.none
+}
+
+export function applyThemeVariant(themeId, colorScheme) {
+  if (typeof document === 'undefined') {
+    return null
+  }
+
+  const resolvedScheme =
+    colorScheme === 'system' || !colorScheme
+      ? resolveSystemColorScheme()
+      : colorScheme
+  const variant = getThemeVariant(themeId, resolvedScheme)
+  const root = document.documentElement
+  const body = document.body
+
+  if (!root || !variant) {
+    return null
+  }
+
+  const cssVars = {
+    ...variant.cssVars,
+    surfaceMuted: variant.cssVars?.surfaceMuted ?? variant.cssVars?.surface,
+    panelMuted: variant.cssVars?.panelMuted ?? variant.cssVars?.panel
+  }
+
+  Object.entries(cssVars).forEach(([token, value]) => {
+    if (value) {
+      setCssVariable(root, token, value)
+    }
+  })
+
+  const neutralScale = variant.neutralScale ?? DEFAULT_NEUTRAL_SCALE
+  Object.entries(neutralScale).forEach(([level, value]) => {
+    setCssVariable(root, `neutral-${level}`, value)
+  })
+
+  root.dataset.themeId = themeId
+  root.dataset.themePreference = colorScheme ?? 'system'
+  root.dataset.themeScheme = resolvedScheme
+  root.style.colorScheme = variant.isDark ? 'dark' : 'light'
+  root.classList.toggle('dark', Boolean(variant.isDark))
+  root.classList.toggle('sr-dark', Boolean(variant.isDark))
+
+  if (variant.cssVars?.surface) {
+    root.style.backgroundColor = variant.cssVars.surface
+    if (body) {
+      body.style.backgroundColor = variant.cssVars.surface
+    }
+  }
+
+  if (variant.cssVars?.textPrimary && body) {
+    body.style.color = variant.cssVars.textPrimary
+  }
+
+  return {
+    themeId,
+    colorScheme: resolvedScheme,
+    variant
+  }
+}

--- a/src/constants/themes.js
+++ b/src/constants/themes.js
@@ -172,7 +172,7 @@ export const THEMES = [
           panelMuted: '#f0f9ff',
           border: '#c7d2fe',
           accent: '#0ea5e9',
-          accentForeground: '#ffffff',
+          accentForeground: '#082f49',
           textPrimary: '#0f172a',
           textMuted: '#1e3a8a'
         },

--- a/src/dev/setupThemePreview.js
+++ b/src/dev/setupThemePreview.js
@@ -1,0 +1,72 @@
+import {
+  applyThemeVariant,
+  DEFAULT_THEME_ID,
+  SUPPORTED_COLOR_SCHEMES
+} from '@/constants/themes.js'
+
+const url = new URL(window.location.href)
+const queryTheme = url.searchParams.get('theme')?.trim()
+const queryScheme = url.searchParams.get('scheme')?.trim()?.toLowerCase()
+
+const initialThemeId = queryTheme && queryTheme.length ? queryTheme : DEFAULT_THEME_ID
+const initialScheme =
+  queryScheme && (SUPPORTED_COLOR_SCHEMES.includes(queryScheme) || queryScheme === 'system')
+    ? queryScheme
+    : 'system'
+
+let activeTheme = initialThemeId
+let activeScheme = initialScheme
+let systemMediaQuery = null
+
+function apply(themeId = activeTheme, scheme = activeScheme) {
+  activeTheme = themeId
+  activeScheme = scheme
+
+  const result = applyThemeVariant(themeId, scheme)
+
+  const store = window.__SOUNDROOM_THEME__?.store
+  if (store && (store.themeId !== themeId || store.colorSchemePreference !== scheme)) {
+    store.apply(themeId, scheme)
+  }
+
+  if (systemMediaQuery) {
+    if (typeof systemMediaQuery.removeEventListener === 'function') {
+      systemMediaQuery.removeEventListener('change', handleSystemSchemeChange)
+    } else if (typeof systemMediaQuery.removeListener === 'function') {
+      systemMediaQuery.removeListener(handleSystemSchemeChange)
+    }
+    systemMediaQuery = null
+  }
+
+  if (!scheme || scheme === 'system') {
+    if (typeof window.matchMedia === 'function') {
+      systemMediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+      if (typeof systemMediaQuery.addEventListener === 'function') {
+        systemMediaQuery.addEventListener('change', handleSystemSchemeChange)
+      } else if (typeof systemMediaQuery.addListener === 'function') {
+        systemMediaQuery.addListener(handleSystemSchemeChange)
+      }
+    }
+  }
+
+  return result
+}
+
+function handleSystemSchemeChange() {
+  applyThemeVariant(activeTheme, 'system')
+}
+
+apply(initialThemeId, initialScheme)
+
+window.__SOUNDROOM_THEME__ = {
+  apply,
+  get activeTheme() {
+    return activeTheme
+  },
+  get activeScheme() {
+    return activeScheme
+  },
+  reset() {
+    apply(DEFAULT_THEME_ID, 'system')
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -7,8 +7,10 @@ import { createPinia } from 'pinia';
 import router from '@/utils/router.js'
 import '@/composables/useAuth.js' // Ensure auth is initialized before app mounts
 import * as Sentry from "@sentry/vue";
+import { useThemeStore } from '@/stores/useThemeStore.js'
 
 const app = createApp(App);
+const pinia = createPinia()
 
 Sentry.init({
   app,
@@ -22,10 +24,30 @@ Sentry.init({
   ],
 });
 
+function mountApp() {
+  app
+    .use(VueKonva)
+    .use(PortalVue)
+    .use(router)
+    .use(pinia)
 
-app
-.use(VueKonva)
-.use(PortalVue)
-.use(router)
-.use(createPinia())
-.mount('#app')
+  if (typeof window !== 'undefined') {
+    const themeStore = useThemeStore(pinia)
+    themeStore.initialize()
+
+    if (import.meta.env.DEV) {
+      window.__SOUNDROOM_THEME__ = {
+        ...(window.__SOUNDROOM_THEME__ ?? {}),
+        store: themeStore
+      }
+    }
+  }
+
+  app.mount('#app')
+}
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  import('@/dev/setupThemePreview.js').finally(mountApp)
+} else {
+  mountApp()
+}

--- a/src/stores/useThemeStore.js
+++ b/src/stores/useThemeStore.js
@@ -1,0 +1,167 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import {
+  applyThemeVariant,
+  DEFAULT_COLOR_SCHEME,
+  DEFAULT_THEME_ID,
+  getThemeById,
+  SUPPORTED_COLOR_SCHEMES,
+  THEMES
+} from '@/constants/themes'
+
+const STORAGE_KEY = 'soundroom:theme-preference'
+let systemMediaQuery = null
+
+function removeSystemListener() {
+  if (!systemMediaQuery) {
+    return
+  }
+
+  if (typeof systemMediaQuery.removeEventListener === 'function') {
+    systemMediaQuery.removeEventListener('change', handleSystemChange)
+  } else if (typeof systemMediaQuery.removeListener === 'function') {
+    systemMediaQuery.removeListener(handleSystemChange)
+  }
+
+  systemMediaQuery = null
+}
+
+function handleSystemChange() {
+  const store = useThemeStore()
+  store.apply(store.themeId, 'system')
+}
+
+export const useThemeStore = defineStore('theme', () => {
+  const themeId = ref(DEFAULT_THEME_ID)
+  const colorSchemePreference = ref('system')
+  const resolvedScheme = ref(DEFAULT_COLOR_SCHEME)
+  const appliedVariant = ref(null)
+
+  function persist() {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    try {
+      const payload = {
+        themeId: themeId.value,
+        scheme: colorSchemePreference.value
+      }
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+    } catch (error) {
+      console.warn('Failed to persist theme preference', error)
+    }
+  }
+
+  function normalizeScheme(preference) {
+    if (!preference || preference === 'system') {
+      return 'system'
+    }
+
+    return SUPPORTED_COLOR_SCHEMES.includes(preference) ? preference : DEFAULT_COLOR_SCHEME
+  }
+
+  function attachSystemListener() {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    if (systemMediaQuery === mediaQuery) {
+      return
+    }
+
+    removeSystemListener()
+    systemMediaQuery = mediaQuery
+
+    if (typeof systemMediaQuery.addEventListener === 'function') {
+      systemMediaQuery.addEventListener('change', handleSystemChange)
+    } else if (typeof systemMediaQuery.addListener === 'function') {
+      systemMediaQuery.addListener(handleSystemChange)
+    }
+  }
+
+  function apply(theme = themeId.value, scheme = colorSchemePreference.value) {
+    const result = applyThemeVariant(theme, scheme)
+    if (!result) {
+      return null
+    }
+
+    themeId.value = result.themeId
+    resolvedScheme.value = result.colorScheme
+    appliedVariant.value = result.variant
+
+    if (!scheme || scheme === 'system') {
+      attachSystemListener()
+    } else {
+      removeSystemListener()
+    }
+
+    persist()
+    return result
+  }
+
+  function setTheme(newThemeId) {
+    return apply(newThemeId, colorSchemePreference.value)
+  }
+
+  function setColorScheme(preference) {
+    const normalized = normalizeScheme(preference)
+    colorSchemePreference.value = normalized
+    return apply(themeId.value, normalized)
+  }
+
+  function initialize(options = {}) {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    let stored = null
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY)
+      stored = raw ? JSON.parse(raw) : null
+    } catch (error) {
+      stored = null
+    }
+
+    const root = document.documentElement
+    const initialTheme =
+      options.themeId ?? stored?.themeId ?? root?.dataset.themeId ?? DEFAULT_THEME_ID
+    const initialScheme = normalizeScheme(
+      options.scheme ?? stored?.scheme ?? root?.dataset.themePreference ?? 'system'
+    )
+
+    themeId.value = initialTheme
+    colorSchemePreference.value = initialScheme
+
+    const result = apply(initialTheme, initialScheme)
+    if (!result) {
+      apply(DEFAULT_THEME_ID, 'system')
+    }
+  }
+
+  function reset() {
+    colorSchemePreference.value = 'system'
+    apply(DEFAULT_THEME_ID, 'system')
+  }
+
+  const currentTheme = computed(() => getThemeById(themeId.value))
+  const availableThemes = computed(() => THEMES)
+  const isDark = computed(() => Boolean(appliedVariant.value?.isDark))
+
+  return {
+    themeId,
+    colorSchemePreference,
+    resolvedScheme,
+    appliedVariant,
+    availableThemes,
+    currentTheme,
+    isDark,
+    initialize,
+    apply,
+    setTheme,
+    setColorScheme,
+    reset
+  }
+})
+

--- a/src/style.css
+++ b/src/style.css
@@ -1,123 +1,111 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  color-scheme: light;
+
+  --sr-surface: #f9fafb;
+  --sr-surface-rgb: 249 250 251;
+  --sr-surface-muted: #e2e8f0;
+  --sr-surface-muted-rgb: 226 232 240;
+  --sr-panel: #ffffff;
+  --sr-panel-rgb: 255 255 255;
+  --sr-panel-muted: #f3f4f6;
+  --sr-panel-muted-rgb: 243 244 246;
+  --sr-border: #e5e7eb;
+  --sr-border-rgb: 229 231 235;
+  --sr-accent: #2563eb;
+  --sr-accent-rgb: 37 99 235;
+  --sr-accentForeground: #ffffff;
+  --sr-accentForeground-rgb: 255 255 255;
+  --sr-textPrimary: #0f172a;
+  --sr-textPrimary-rgb: 15 23 42;
+  --sr-textMuted: #475569;
+  --sr-textMuted-rgb: 71 85 105;
+
+  --sr-neutral-50: #f9fafb;
+  --sr-neutral-50-rgb: 249 250 251;
+  --sr-neutral-100: #f3f4f6;
+  --sr-neutral-100-rgb: 243 244 246;
+  --sr-neutral-200: #e5e7eb;
+  --sr-neutral-200-rgb: 229 231 235;
+  --sr-neutral-300: #d1d5db;
+  --sr-neutral-300-rgb: 209 213 219;
+  --sr-neutral-400: #94a3b8;
+  --sr-neutral-400-rgb: 148 163 184;
+  --sr-neutral-500: #64748b;
+  --sr-neutral-500-rgb: 100 116 139;
+  --sr-neutral-600: #475569;
+  --sr-neutral-600-rgb: 71 85 105;
+  --sr-neutral-700: #334155;
+  --sr-neutral-700-rgb: 51 65 85;
+  --sr-neutral-800: #1e293b;
+  --sr-neutral-800-rgb: 30 41 59;
+  --sr-neutral-900: #0f172a;
+  --sr-neutral-900-rgb: 15 23 42;
+  --sr-neutral-950: #020617;
+  --sr-neutral-950-rgb: 2 6 23;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  
-  cursor: pointer;
-  transition: border-color 0.25s;
-
-  @apply bg-[#d3d3d3e1] dark:bg-[#1a1a1a];
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-.card {
-  padding: 2em;
-}
-
-#app {
-  margin: 0 auto;
-  
-  text-align: center;
-}
-
-button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  pointer-events: none;
-  background-color: #444; /* fallback for dark mode */
-  color: #ccc;
-}
-
-input[type="text"],
-input[type="email"],
-input[type="password"] {
-  @apply w-full p-3 border-none rounded-lg dark:bg-[#333] bg-neutral-200 dark:text-white;
-}
-
-input:disabled {
-  @apply dark:bg-neutral-700 dark:text-neutral-400 opacity-50 cursor-not-allowed bg-neutral-200 text-neutral-800;
-}
-
-
-.modal-backdrop {
-  @apply fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center;
-}
-
-.modal-panel {
-  @apply bg-white dark:bg-neutral-950 rounded-2xl w-[80vw] h-[80vh] shadow-2xl border border-neutral-300 dark:border-neutral-800 overflow-hidden;
-}
-
-.modal-header-float {
-  @apply absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4
-         bg-white/50 dark:bg-neutral-950/50 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800;
-}
-
-.modal-header {
-  @apply top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4
-         bg-white/50 dark:bg-neutral-950/50 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800;
-}
-
-
-
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
+@layer base {
+  body {
+    @apply bg-surface text-primary antialiased;
+    margin: 0;
+    min-height: 100vh;
   }
-  a:hover {
-    color: #747bff;
+
+  a {
+    color: inherit;
+    text-decoration: inherit;
   }
- 
-  button:disabled {
-    background-color: #b9b9b9;
-    color: #505050;
+
+  button {
+    font-family: inherit;
+  }
+
+  #app {
+    min-height: 100vh;
+  }
+}
+
+@layer components {
+  input[type='text'],
+  input[type='email'],
+  input[type='password'],
+  input[type='search'],
+  textarea,
+  select {
+    @apply w-full rounded-xl border border-border bg-panel px-3 py-2 text-primary shadow-sm transition focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30;
+  }
+
+  input:disabled,
+  textarea:disabled,
+  select:disabled {
+    @apply cursor-not-allowed bg-surface-muted text-muted opacity-60;
+  }
+
+  .modal-backdrop {
+    @apply fixed inset-0 z-50 flex items-center justify-center bg-neutral-950/60 backdrop-blur-sm;
+  }
+
+  .modal-panel {
+    @apply relative h-[80vh] w-[80vw] overflow-hidden rounded-2xl border border-border bg-panel shadow-2xl;
+  }
+
+  .modal-header-float {
+    @apply absolute left-0 right-0 top-0 z-10 flex items-center justify-between border-b border-border bg-panel/70 px-6 py-4 backdrop-blur;
+  }
+
+  .modal-header {
+    @apply left-0 right-0 top-0 z-10 flex items-center justify-between border-b border-border bg-panel/70 px-6 py-4 backdrop-blur;
   }
 }

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -1,5 +1,6 @@
 // permissions.js
 import { ENTITLEMENTS } from '@/constants/entitlements'
+import { getThemeAvailabilityRank } from '@/constants/themes'
 
 export function can(plan, feature) {
   const e = ENTITLEMENTS[plan] || ENTITLEMENTS.free
@@ -9,4 +10,13 @@ export function can(plan, feature) {
 export function limit(plan, key) {
   const e = ENTITLEMENTS[plan] || ENTITLEMENTS.free
   return e[key] ?? 0 // e.g. e.maxSavedRooms
+}
+
+export function themeAccessRank(plan) {
+  const entitlementLevel = (ENTITLEMENTS[plan] || ENTITLEMENTS.free).themes
+  return getThemeAvailabilityRank(entitlementLevel)
+}
+
+export function canUseTheme(plan, themeAvailability) {
+  return themeAccessRank(plan) >= getThemeAvailabilityRank(themeAvailability)
 }

--- a/src/views/AuthCallback.vue
+++ b/src/views/AuthCallback.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="auth-callback w-full dark:bg-black bg-white">
+  <div class="auth-callback w-full bg-surface text-muted">
   </div>
 </template>
 
@@ -54,6 +54,6 @@ onMounted(async () => {
   align-items: center;
   height: 100dvh;
   font-size: 1.2rem;
-  color: #666;
+  color: var(--sr-textMuted);
 }
 </style>

--- a/src/views/LoggedOut.vue
+++ b/src/views/LoggedOut.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="h-full flex flex-col items-center justify-center text-center px-6 py-12 dark:bg-black bg-white text-black dark:text-white">
+  <div class="h-full flex flex-col items-center justify-center text-center px-6 py-12 bg-surface text-primary">
     <h2 class="text-2xl font-semibold mb-2">You've been signed out</h2>
-    <p class="text-gray-600 dark:text-gray-400 mb-6">We hope you come back soon.</p>
+    <p class="text-muted mb-6">We hope you come back soon.</p>
     <BaseButton @click="$router.push('/login')">Sign In Again</BaseButton>
   </div>
 </template>

--- a/src/views/ManagePlan.vue
+++ b/src/views/ManagePlan.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="flex-1 overflow-y-auto bg-neutral-100 dark:bg-neutral-950 text-neutral-900 dark:text-neutral-100">
+  <main class="flex-1 overflow-y-auto bg-surface text-primary">
     <div class="max-w-4xl mx-auto px-6 py-10 space-y-10">
       <section class="space-y-4">
         <div
@@ -32,7 +32,7 @@
         </div>
 
         <div
-          class="rounded-2xl bg-white/80 dark:bg-neutral-900/80 p-6 shadow-sm border"
+          class="rounded-2xl bg-panel/80 p-6 shadow-sm border border-border"
           :class="planTheme.card"
         >
           <header class="flex flex-wrap items-center justify-between gap-4">
@@ -42,13 +42,13 @@
             </div>
             <div class="text-right">
               <span class="text-lg font-semibold">{{ currentPlan.price }}</span>
-              <p class="text-xs text-neutral-500 dark:text-neutral-400">Billed monthly — cancel anytime.</p>
+              <p class="text-xs text-neutral-500">Billed monthly — cancel anytime.</p>
             </div>
           </header>
 
           <div class="mt-6 grid gap-4 sm:grid-cols-2">
             <div v-for="feature in currentPlan.highlights" :key="feature" class="flex items-start gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-blue-500 dark:bg-blue-400"></span>
+              <span class="mt-1 h-2 w-2 rounded-full bg-accent"></span>
               <p class="text-sm text-neutral-700 dark:text-neutral-300">{{ feature }}</p>
             </div>
           </div>
@@ -70,7 +70,7 @@
             <BaseButton
               v-if="currentPlan.cancelAction"
               variant="naked"
-              class="text-sm text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
+              class="text-sm text-accent hover:text-accent/80"
               :disabled="isDowngradeBusy || isCreatingPortalSession"
               @click="currentPlan.cancelAction.handler"
             >
@@ -80,7 +80,7 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl border border-border bg-panel/80 p-6 shadow-sm space-y-6">
         <header class="space-y-1">
           <h2 class="text-xl font-semibold">Billing & Receipts</h2>
           <p class="text-sm text-neutral-600 dark:text-neutral-400">
@@ -88,7 +88,7 @@
           </p>
         </header>
 
-        <div class="rounded-xl border border-dashed border-neutral-300 dark:border-neutral-700 bg-neutral-100/80 dark:bg-neutral-950/50 px-5 py-6 text-sm text-neutral-600 dark:text-neutral-300">
+        <div class="rounded-xl border border-dashed border-border bg-surface-muted/80 px-5 py-6 text-sm text-neutral-600">
           <p>Need an invoice, tax receipt, or want to change your payment method?</p>
           <p class="mt-3">Email <a class="underline" :href="supportEmailHref">{{ SUPPORT_EMAIL }}</a> and include the email tied to your SoundRoom account.</p>
         </div>
@@ -105,21 +105,21 @@
           <BaseButton @click="contactBilling">
             Contact billing support
           </BaseButton>
-          <BaseButton variant="naked" class="text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200" @click="openFAQ">
+          <BaseButton variant="naked" class="text-sm text-muted hover:text-primary" @click="openFAQ">
             View plan FAQ
           </BaseButton>
         </div>
       </section>
 
-      <section class="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl border border-border bg-panel/80 p-6 shadow-sm space-y-6">
         <header class="space-y-1">
           <h2 class="text-xl font-semibold">Upcoming Features</h2>
           <p class="text-sm text-neutral-600 dark:text-neutral-400">We are actively building deeper collaboration and scheduling tools. Here is what is landing next for paying members.</p>
         </header>
 
         <ul class="grid gap-4 md:grid-cols-2">
-          <li v-for="item in roadmapHighlights" :key="item.title" class="rounded-xl border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-950 p-5 space-y-2">
-            <p class="text-sm uppercase tracking-wide text-neutral-500 dark:text-neutral-400">{{ item.badge }}</p>
+          <li v-for="item in roadmapHighlights" :key="item.title" class="rounded-xl border border-border bg-panel p-5 space-y-2">
+            <p class="text-sm uppercase tracking-wide text-neutral-500">{{ item.badge }}</p>
             <h3 class="text-lg font-medium">{{ item.title }}</h3>
             <p class="text-sm text-neutral-600 dark:text-neutral-400">{{ item.copy }}</p>
           </li>

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="h-full w-full flex flex-col items-center justify-center text-center px-6 py-12 bg-white text-neutral-900 dark:bg-black dark:text-white">
+  <div class="h-full w-full flex flex-col items-center justify-center text-center px-6 py-12 bg-surface text-primary">
     <p class="text-sm uppercase tracking-[0.2em] text-rose-500 mb-3">404</p>
     <h1 class="text-3xl font-semibold mb-3">Page not found</h1>
-    <p class="max-w-md text-gray-600 dark:text-gray-400 mb-8">
+    <p class="max-w-md text-muted mb-8">
       The page you are looking for doesn't exist or may have moved. Check the address or head back to SoundRoom.
     </p>
     <div class="flex flex-wrap items-center justify-center gap-3">
@@ -11,7 +11,7 @@
       </BaseButton>
       <RouterLink
         to="/help"
-        class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 text-sm font-medium"
+        class="text-accent hover:text-accent/80 text-sm font-medium"
       >
         Visit help center
       </RouterLink>

--- a/src/views/Pricing/PlanComparisonTable.vue
+++ b/src/views/Pricing/PlanComparisonTable.vue
@@ -13,7 +13,7 @@
           </th>
         </tr>
       </thead>
-      <tbody class="divide-y divide-neutral-200 bg-white dark:divide-neutral-800 dark:bg-neutral-950">
+      <tbody class="divide-y divide-neutral-200 bg-panel">
         <tr v-for="feature in features" :key="feature.key" class="align-top">
           <th class="py-4 pl-4 pr-3 text-left font-medium text-neutral-800 dark:text-neutral-100">{{ feature.label }}</th>
           <td

--- a/src/views/Pricing/Pricing.vue
+++ b/src/views/Pricing/Pricing.vue
@@ -33,8 +33,8 @@
           >
             {{ checkoutError }}
           </p>
-          <div class="max-w-5xl mx-auto rounded-md border border-neutral-200 bg-white p-4 text-left shadow-sm dark:border-neutral-800 dark:bg-neutral-950" data-testid="pricing-feature-comparison">
-            <div class="text-sm font-semibold text-neutral-800 dark:text-neutral-200">Full feature comparison</div>
+          <div class="max-w-5xl mx-auto rounded-md border border-border bg-panel p-4 text-left shadow-sm" data-testid="pricing-feature-comparison">
+            <div class="text-sm font-semibold text-neutral-800">Full feature comparison</div>
             <PlanComparisonTable class="mt-4" :plans="basePlans" :features="FEATURE_DEFINITIONS" />
           </div>
         </div>

--- a/src/views/Pricing/PricingCard.vue
+++ b/src/views/Pricing/PricingCard.vue
@@ -85,7 +85,7 @@ const props = defineProps({
   }
 })
 
-const BASE_CARD_CLASS = 'group rounded-sm p-6 shadow-md transition-all duration-200 ease-out transform flex flex-col justify-between bg-white dark:bg-neutral-950 text-neutral-900 dark:text-white hover:shadow-xl hover:-translate-y-1 hover:scale-[1.03] focus-within:shadow-xl focus-within:-translate-y-1 focus-within:scale-[1.03]'
+const BASE_CARD_CLASS = 'group rounded-sm p-6 shadow-md transition-all duration-200 ease-out transform flex flex-col justify-between bg-panel text-primary hover:shadow-xl hover:-translate-y-1 hover:scale-[1.03] focus-within:shadow-xl focus-within:-translate-y-1 focus-within:scale-[1.03]'
 
 const BASE_CTA_CLASS = 'w-full py-2 rounded-xl font-semibold transition border border-transparent disabled:opacity-50 disabled:cursor-not-allowed disabled:dark:bg-neutral-700'
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="flex-1 overflow-y-auto bg-neutral-100 dark:bg-neutral-950 text-neutral-900 dark:text-neutral-100">
+  <main class="flex-1 overflow-y-auto bg-surface text-primary">
     <div class="max-w-5xl mx-auto px-6 py-10 space-y-10">
       <section class="space-y-4">
         <div class="flex items-center justify-between gap-6 flex-wrap">
@@ -9,8 +9,8 @@
               Update how you appear in SoundRoom, adjust playback preferences, and keep your account secure.
             </p>
           </div>
-          <div class="flex items-center gap-3 rounded-full border border-neutral-200 dark:border-neutral-800 px-4 py-2 bg-white/70 dark:bg-neutral-900/70">
-            <span class="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">Plan</span>
+          <div class="flex items-center gap-3 rounded-full border border-border px-4 py-2 bg-panel/70">
+            <span class="text-xs uppercase tracking-wide text-neutral-500">Plan</span>
             <span class="text-sm font-medium">{{ planLabel }}</span>
             <RouterLink v-if="tier.value === 'free'" :to="'/upgrade'" class="ml-2">
               <BaseButton type="button">
@@ -43,13 +43,13 @@
           <p v-else-if="planErrorMessage" class="text-sm font-medium">{{ planErrorMessage }}</p>
         </div>
 
-        <div class="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white/70 dark:bg-neutral-900/70 p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
+        <div class="rounded-2xl border border-border bg-panel/70 p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
           <div>
             <p class="text-sm text-neutral-500 dark:text-neutral-400">Signed in as</p>
             <p class="text-lg font-medium break-all">{{ userEmail }}</p>
           </div>
           <div class="flex items-center gap-4">
-            <div class="relative w-16 h-16 rounded-full bg-neutral-200 dark:bg-neutral-800 flex items-center justify-center overflow-hidden text-xl font-semibold">
+            <div class="relative w-16 h-16 rounded-full bg-surface-muted flex items-center justify-center overflow-hidden text-xl font-semibold">
               <img
                 v-if="avatarPreview && !avatarFailed"
                 :src="avatarPreview"
@@ -67,7 +67,7 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl border border-border bg-panel/80 p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Profile</h2>
           <p class="text-sm text-neutral-600 dark:text-neutral-400">Set how teammates and collaborators see you.</p>
@@ -134,7 +134,87 @@
         </form>
       </section>
 
-      <section class="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl border border-border bg-panel/80 p-6 shadow-sm space-y-6">
+        <header class="space-y-2">
+          <h2 class="text-xl font-semibold">Appearance</h2>
+          <p class="text-sm text-neutral-600 dark:text-neutral-400">
+            Choose the palette that best fits your workspace. Themes update instantly across the app.
+          </p>
+        </header>
+
+        <div class="flex flex-wrap items-start justify-between gap-6">
+          <div class="space-y-1">
+            <h3 class="text-base font-medium">Color scheme</h3>
+            <p class="text-sm text-neutral-600 dark:text-neutral-400">
+              Currently showing <span class="font-medium">{{ activeVariantLabel || 'Default palette' }}</span>
+              in the
+              <span class="font-medium">{{ resolvedSchemeLabel }}</span>
+              scheme.
+            </p>
+          </div>
+          <label class="flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-300">
+            <span class="font-medium">Preference</span>
+            <select
+              v-model="selectedScheme"
+              class="rounded-lg border border-border bg-panel px-3 py-2 text-sm text-primary shadow-sm focus:outline-none focus:ring-2 focus:ring-accent/60"
+            >
+              <option v-for="option in schemeOptions" :key="option.value" :value="option.value">
+                {{ option.label }}
+              </option>
+            </select>
+          </label>
+        </div>
+
+        <div class="space-y-4">
+          <h3 class="text-base font-medium">Theme</h3>
+          <p class="text-sm text-neutral-600 dark:text-neutral-400">
+            Switch between available SoundRoom themes. Locked themes will prompt an upgrade.
+          </p>
+
+          <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <button
+              v-for="theme in themeCards"
+              :key="theme.id"
+              type="button"
+              class="relative overflow-hidden rounded-xl border bg-panel px-4 py-4 text-left shadow-sm transition"
+              :class="[
+                theme.id === activeThemeId ? 'border-accent/70 ring-2 ring-accent/70' : 'border-border hover:border-accent/40',
+                theme.unlocked ? 'cursor-pointer' : 'cursor-pointer opacity-60'
+              ]"
+              @click="handleThemeSelection(theme)"
+              :aria-pressed="theme.id === activeThemeId"
+            >
+              <div
+                class="h-20 w-full rounded-lg border border-border bg-surface-muted"
+                :style="getThemePreviewStyle(theme)"
+              />
+              <div class="mt-4 space-y-1">
+                <div class="flex items-center justify-between gap-2">
+                  <p class="text-sm font-medium">{{ theme.label }}</p>
+                  <span
+                    v-if="theme.id === activeThemeId"
+                    class="rounded-full bg-accent/10 px-2 py-0.5 text-xs font-semibold text-accent"
+                  >
+                    Active
+                  </span>
+                </div>
+                <p class="text-xs text-neutral-600 dark:text-neutral-400">{{ theme.description }}</p>
+                <p class="text-xs text-neutral-500 dark:text-neutral-500">
+                  {{ getVariantLabel(theme) }}
+                </p>
+                <p
+                  v-if="!theme.unlocked"
+                  class="text-xs font-medium text-accent"
+                >
+                  Requires {{ theme.requiredPlanLabel }} plan
+                </p>
+              </div>
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-border bg-panel/80 p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Playback Preferences</h2>
           <p class="text-sm text-neutral-600 dark:text-neutral-400">These settings are stored locally in your browser.</p>
@@ -149,7 +229,7 @@
             <label class="relative inline-flex items-center cursor-pointer select-none">
               <input type="checkbox" class="sr-only peer" v-model="preferences.autoResumePlayback">
               <span class="block w-12 h-6 rounded-full bg-neutral-300 dark:bg-neutral-700 transition-colors peer-focus:outline peer-focus:outline-2 peer-focus:outline-blue-500 peer-checked:bg-blue-600"></span>
-              <span class="absolute left-1 top-1 block w-4 h-4 rounded-full bg-white shadow transition-transform peer-checked:translate-x-6"></span>
+              <span class="absolute left-1 top-1 block w-4 h-4 rounded-full bg-panel shadow transition-transform peer-checked:translate-x-6"></span>
             </label>
           </div>
 
@@ -161,7 +241,7 @@
             <label class="relative inline-flex items-center cursor-pointer select-none">
               <input type="checkbox" class="sr-only peer" v-model="preferences.showInterfaceTips">
               <span class="block w-12 h-6 rounded-full bg-neutral-300 dark:bg-neutral-700 transition-colors peer-focus:outline peer-focus:outline-2 peer-focus:outline-blue-500 peer-checked:bg-blue-600"></span>
-              <span class="absolute left-1 top-1 block w-4 h-4 rounded-full bg-white shadow transition-transform peer-checked:translate-x-6"></span>
+              <span class="absolute left-1 top-1 block w-4 h-4 rounded-full bg-panel shadow transition-transform peer-checked:translate-x-6"></span>
             </label>
           </div>
         </div>
@@ -186,7 +266,7 @@
         <p v-if="preferenceMessage" class="text-sm text-green-600">{{ preferenceMessage }}</p>
       </section>
 
-      <section class="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl border border-border bg-panel/80 p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Security</h2>
           <p class="text-sm text-neutral-600 dark:text-neutral-400">Keep your account protected and up to date.</p>
@@ -221,15 +301,71 @@
 
 <script setup>
 import { computed, reactive, ref, watch, onMounted } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useRoute, useRouter } from 'vue-router'
 import BaseButton from '@/components/ui/input/BaseButton.vue'
 import BaseInput from '@/components/ui/input/BaseInput.vue'
 import { useAuth } from '@/composables/useAuth'
 import { supabase } from '@/utils/supabase'
+import { useThemeStore } from '@/stores/useThemeStore.js'
+import { SUPPORTED_COLOR_SCHEMES } from '@/constants/themes.js'
+import { canUseTheme } from '@/utils/permissions.js'
+import { useEntitlementStore } from '@/stores/useEntitlementStore.js'
+import { getEntitlementCopy } from '@/constants/entitlementCopy.js'
 
 const router = useRouter()
 const route = useRoute()
 const { user, sessionLoaded, tier, refreshTier, primeTier } = useAuth()
+
+const themeStore = useThemeStore()
+const entitlementStore = useEntitlementStore()
+const { availableThemes, themeId, colorSchemePreference, resolvedScheme, appliedVariant } = storeToRefs(themeStore)
+
+const COLOR_SCHEME_LABELS = {
+  system: 'Match system',
+  light: 'Light',
+  dark: 'Dark'
+}
+
+const THEME_PLAN_LABELS = {
+  none: 'Free',
+  basic: 'Basic',
+  pro: 'Pro'
+}
+
+const schemeOptions = computed(() => {
+  const options = ['system', ...SUPPORTED_COLOR_SCHEMES]
+  return options.map((value) => ({
+    value,
+    label: COLOR_SCHEME_LABELS[value] ?? value
+  }))
+})
+
+const selectedScheme = computed({
+  get: () => colorSchemePreference.value,
+  set: (value) => {
+    themeStore.setColorScheme(value)
+  }
+})
+
+const resolvedSchemeLabel = computed(() => COLOR_SCHEME_LABELS[resolvedScheme.value] ?? 'Light')
+const activeVariantLabel = computed(() => appliedVariant.value?.label ?? '')
+const activeThemeId = computed(() => themeId.value)
+
+const currentPlan = computed(() => tier.value ?? 'free')
+
+const themeCards = computed(() => {
+  const plan = currentPlan.value
+  const themes = availableThemes.value ?? []
+  return themes.map((theme) => {
+    const unlocked = canUseTheme(plan, theme.availability)
+    return {
+      ...theme,
+      unlocked,
+      requiredPlanLabel: THEME_PLAN_LABELS[theme.availability] ?? 'Pro'
+    }
+  })
+})
 
 const profileForm = reactive({
   displayName: '',
@@ -286,6 +422,61 @@ const planLabel = computed(() => {
 function handleManagePlan() {
   //router.push({ path: '/upgrade', query: { manage: '1' } })
   router.push('/manage-plan')
+}
+
+function getVariantLabel(theme) {
+  if (!theme) return ''
+
+  const scheme = resolvedScheme.value ?? theme.defaultColorScheme ?? 'light'
+  const variants = theme.variants ?? {}
+  const variant =
+    variants[scheme] ||
+    variants[theme.defaultColorScheme] ||
+    Object.values(variants)[0]
+
+  return variant?.label ?? ''
+}
+
+function getThemePreviewStyle(theme) {
+  const scheme = resolvedScheme.value ?? theme.defaultColorScheme ?? 'light'
+  const swatches = theme.preview?.[scheme] ?? theme.preview?.light ?? []
+
+  if (!Array.isArray(swatches) || swatches.length === 0) {
+    return {}
+  }
+
+  if (swatches.length === 1) {
+    return { backgroundColor: swatches[0] }
+  }
+
+  const stops = swatches
+    .map((color, index) => {
+      const percentage = swatches.length === 1 ? 100 : Math.round((index / (swatches.length - 1)) * 100)
+      return `${color} ${percentage}%`
+    })
+    .join(', ')
+
+  return { background: `linear-gradient(135deg, ${stops})` }
+}
+
+function handleThemeSelection(theme) {
+  if (!theme) {
+    return
+  }
+
+  if (theme.unlocked) {
+    themeStore.setTheme(theme.id)
+    return
+  }
+
+  const planLabel = theme.requiredPlanLabel ?? THEME_PLAN_LABELS[theme.availability] ?? 'Pro'
+  const copy = getEntitlementCopy('themes')
+  entitlementStore.open({
+    featureKey: 'themes',
+    plan: planLabel,
+    title: `Unlock ${theme.label}`,
+    message: `Upgrade to the ${planLabel} plan to ${copy.action}.`
+  })
 }
 
 const PLAN_DISPLAY_NAME = {

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full bg-white text-neutral-900 dark:bg-neutral-950 dark:text-white flex flex-col">
+  <div class="h-full flex flex-col bg-surface text-primary">
     <!-- Main Layout -->
     <div class="flex flex-1 overflow-hidden">
 
@@ -17,7 +17,7 @@
         <Toolbar/>
 
         <!-- Canvas Area -->
-        <div class="flex-1 bg-neutral-200 dark:bg-black flex items-center justify-center">
+        <div class="flex-1 bg-surface-muted flex items-center justify-center">
           <MainCanvasStage
             v-bind="{
               handleDrop,

--- a/src/views/UpdatePasswordPage.vue
+++ b/src/views/UpdatePasswordPage.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex flex-col items-center justify-center min-h-screen px-4 py-12 bg-white text-black dark:bg-black dark:text-white transition-colors">
-    <div class="w-full max-w-sm space-y-6 bg-[#f8f8f8] dark:bg-[#111] rounded-2xl shadow-xl p-6 border border-gray-200 dark:border-neutral-800 transition-colors">
+  <div class="flex flex-col items-center justify-center min-h-screen px-4 py-12 bg-surface text-primary transition-colors">
+    <div class="w-full max-w-sm space-y-6 rounded-2xl border border-border bg-panel shadow-xl p-6 transition-colors">
       <h2 class="text-2xl font-semibold text-center tracking-wide">Reset Your Password</h2>
 
       <PasswordInput

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,70 @@
-// tailwind.config.js
+const withOpacity = (variable) => ({ opacityValue } = {}) => {
+  if (opacityValue === undefined) {
+    return `rgb(var(${variable}) / 1)`
+  }
+
+  return `rgb(var(${variable}) / ${opacityValue})`
+}
+
 module.exports = {
-  important: true,
+  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        neutral: {
+          50: withOpacity('--sr-neutral-50-rgb'),
+          100: withOpacity('--sr-neutral-100-rgb'),
+          200: withOpacity('--sr-neutral-200-rgb'),
+          300: withOpacity('--sr-neutral-300-rgb'),
+          400: withOpacity('--sr-neutral-400-rgb'),
+          500: withOpacity('--sr-neutral-500-rgb'),
+          600: withOpacity('--sr-neutral-600-rgb'),
+          700: withOpacity('--sr-neutral-700-rgb'),
+          800: withOpacity('--sr-neutral-800-rgb'),
+          900: withOpacity('--sr-neutral-900-rgb'),
+          950: withOpacity('--sr-neutral-950-rgb')
+        },
+        surface: withOpacity('--sr-surface-rgb'),
+        'surface-muted': withOpacity('--sr-surface-muted-rgb'),
+        panel: withOpacity('--sr-panel-rgb'),
+        'panel-muted': withOpacity('--sr-panel-muted-rgb'),
+        accent: withOpacity('--sr-accent-rgb'),
+        'accent-foreground': withOpacity('--sr-accentForeground-rgb')
+      },
+      backgroundColor: {
+        surface: withOpacity('--sr-surface-rgb'),
+        'surface-muted': withOpacity('--sr-surface-muted-rgb'),
+        panel: withOpacity('--sr-panel-rgb'),
+        'panel-muted': withOpacity('--sr-panel-muted-rgb'),
+        accent: withOpacity('--sr-accent-rgb')
+      },
+      textColor: {
+        primary: withOpacity('--sr-textPrimary-rgb'),
+        muted: withOpacity('--sr-textMuted-rgb'),
+        accent: withOpacity('--sr-accent-rgb'),
+        'accent-foreground': withOpacity('--sr-accentForeground-rgb')
+      },
+      borderColor: {
+        border: withOpacity('--sr-border-rgb'),
+        accent: withOpacity('--sr-accent-rgb')
+      },
+      ringColor: {
+        accent: withOpacity('--sr-accent-rgb'),
+        border: withOpacity('--sr-border-rgb')
+      },
+      divideColor: {
+        border: withOpacity('--sr-border-rgb')
+      },
+      fill: {
+        accent: withOpacity('--sr-accent-rgb'),
+        muted: withOpacity('--sr-textMuted-rgb')
+      },
+      stroke: {
+        accent: withOpacity('--sr-accent-rgb'),
+        muted: withOpacity('--sr-textMuted-rgb')
+      }
+    }
+  },
+  plugins: []
 }


### PR DESCRIPTION
## Summary
- add an Appearance section in Settings with controls to switch theme palettes and color scheme preferences
- connect the settings page to the theme store so selections apply immediately and respect plan availability
- surface upgrade messaging for locked themes while previewing the active variant swatches

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_69028800e480832fbba84ca5cf0e2b1b