### PR TITLE
Add semantic theme tokens and enforce contrast compliance

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,42 @@
+# Theming Guidelines
+
+SoundRoom themes define a set of CSS custom properties that power both the runtime theming system and Tailwind utilities. When introducing a new theme, supply the full set of tokens described below so the UI renders consistently before the JavaScript theme loader runs.
+
+## Required tokens
+
+Each variant must provide the following tokens inside `cssVars`:
+
+| Token | Purpose |
+| --- | --- |
+| `surface` | Default application background.
+| `panel` | Elevated surfaces such as dialogs and cards.
+| `border` | Outlines and separators between elements.
+| `accent` | Primary interactive background color (buttons, toggles, etc.).
+| `accentForeground` | Text or icon color placed on top of the accent color.
+| `textPrimary` | Legacy token for main text; still consumed by older components.
+| `textMuted` | Secondary text for subdued UI.
+| `textOnSurface` | Primary text placed directly on the `surface` color.
+| `textOnPanel` | Primary text placed on `panel` surfaces.
+| `overlayBackground` | Backdrop color for overlays, sheets, and floating chrome.
+| `onOverlayText` | Text and icon color on top of `overlayBackground`.
+
+## Contrast requirements
+
+To meet WCAG AA for normal-sized text, maintain a contrast ratio of **4.5:1 or higher** for every variant and color scheme using the following pairings:
+
+- `textOnSurface` on `surface`
+- `textOnPanel` on `panel`
+- `accentForeground` on `accent`
+- `onOverlayText` on `overlayBackground`
+
+The automated contrast check fails the build if any pairing falls below the threshold or if a token is missing.
+
+## Validation
+
+Run the contrast verifier locally with:
+
+```bash
+npm run check:theme-contrast
+```
+
+The script evaluates every theme/variant declared in `src/constants/themes.js`. Our CI pipeline calls the same command via `npm test`, so a theme will not ship without passing contrast validation.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "npm run test:unit && npm run test:e2e",
+    "check:theme-contrast": "node scripts/check-theme-contrast.js",
+    "test": "npm run check:theme-contrast && npm run test:unit && npm run test:e2e",
     "test:unit": "vitest run",
     "test:e2e": "playwright test"
   },

--- a/scripts/check-theme-contrast.js
+++ b/scripts/check-theme-contrast.js
@@ -1,0 +1,83 @@
+import { THEMES } from '../src/constants/themes.js'
+
+const REQUIRED_PAIRINGS = [
+  { foreground: 'textOnSurface', background: 'surface', label: 'surface text' },
+  { foreground: 'textOnPanel', background: 'panel', label: 'panel text' },
+  { foreground: 'accentForeground', background: 'accent', label: 'accent foreground' },
+  { foreground: 'onOverlayText', background: 'overlayBackground', label: 'overlay text' }
+]
+
+function hexToRgb(hex) {
+  const normalized = hex.trim()
+  if (!/^#([\da-f]{3}|[\da-f]{6})$/i.test(normalized)) {
+    throw new Error(`Unsupported color format: ${hex}`)
+  }
+
+  const value = normalized.slice(1)
+  const chunk = value.length === 3 ? value.split('').map((c) => c + c).join('') : value
+  const intVal = parseInt(chunk, 16)
+  return {
+    r: (intVal >> 16) & 0xff,
+    g: (intVal >> 8) & 0xff,
+    b: intVal & 0xff
+  }
+}
+
+function relativeLuminance({ r, g, b }) {
+  const srgb = [r, g, b].map((channel) => {
+    const c = channel / 255
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+  })
+
+  return 0.2126 * srgb[0] + 0.7152 * srgb[1] + 0.0722 * srgb[2]
+}
+
+function contrastRatio(foreground, background) {
+  const fg = relativeLuminance(hexToRgb(foreground))
+  const bg = relativeLuminance(hexToRgb(background))
+
+  const light = Math.max(fg, bg)
+  const dark = Math.min(fg, bg)
+
+  return (light + 0.05) / (dark + 0.05)
+}
+
+const failures = []
+
+for (const theme of THEMES) {
+  const variants = theme.variants ?? {}
+  for (const [scheme, variant] of Object.entries(variants)) {
+    const vars = variant.cssVars ?? {}
+    for (const pairing of REQUIRED_PAIRINGS) {
+      const foreground = vars[pairing.foreground]
+      const background = vars[pairing.background]
+      if (!foreground || !background) {
+        failures.push(
+          `${theme.id}.${scheme} is missing ${pairing.foreground} or ${pairing.background}`
+        )
+        continue
+      }
+
+      try {
+        const ratio = contrastRatio(foreground, background)
+        if (ratio < 4.5) {
+          failures.push(
+            `${theme.id}.${scheme} ${pairing.label} contrast is ${ratio.toFixed(2)} (< 4.5)`
+          )
+        }
+      } catch (error) {
+        failures.push(
+          `${theme.id}.${scheme} has invalid colors for ${pairing.label}: ${error.message}`
+        )
+      }
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Theme contrast check failed:')
+  failures.forEach((failure) => console.error(` • ${failure}`))
+  process.exit(1)
+}
+
+console.log('All theme contrast checks passed.')

--- a/src/constants/themes.js
+++ b/src/constants/themes.js
@@ -39,7 +39,11 @@ export const THEMES = [
           accent: '#2563eb',
           accentForeground: '#ffffff',
           textPrimary: '#0f172a',
-          textMuted: '#475569'
+          textMuted: '#475569',
+          textOnSurface: '#0f172a',
+          textOnPanel: '#0f172a',
+          overlayBackground: '#1f2937',
+          onOverlayText: '#f8fafc'
         }
       },
       dark: {
@@ -52,7 +56,11 @@ export const THEMES = [
           accent: '#38bdf8',
           accentForeground: '#0f172a',
           textPrimary: '#e2e8f0',
-          textMuted: '#94a3b8'
+          textMuted: '#94a3b8',
+          textOnSurface: '#e2e8f0',
+          textOnPanel: '#f8fafc',
+          overlayBackground: '#111827',
+          onOverlayText: '#f8fafc'
         }
       }
     }
@@ -76,9 +84,13 @@ export const THEMES = [
           panel: '#ffffff',
           border: '#c7d2fe',
           accent: '#0ea5e9',
-          accentForeground: '#ffffff',
+          accentForeground: '#082f49',
           textPrimary: '#0f172a',
-          textMuted: '#1e3a8a'
+          textMuted: '#1e3a8a',
+          textOnSurface: '#0f172a',
+          textOnPanel: '#0f172a',
+          overlayBackground: '#1e3a8a',
+          onOverlayText: '#f8fafc'
         }
       },
       dark: {
@@ -91,7 +103,11 @@ export const THEMES = [
           accent: '#38bdf8',
           accentForeground: '#081226',
           textPrimary: '#e0f2fe',
-          textMuted: '#93c5fd'
+          textMuted: '#93c5fd',
+          textOnSurface: '#e0f2fe',
+          textOnPanel: '#f8fafc',
+          overlayBackground: '#112240',
+          onOverlayText: '#f8fafc'
         }
       }
     }
@@ -117,7 +133,11 @@ export const THEMES = [
           accent: '#7c3aed',
           accentForeground: '#f8fafc',
           textPrimary: '#312e81',
-          textMuted: '#5b21b6'
+          textMuted: '#5b21b6',
+          textOnSurface: '#1e1b4b',
+          textOnPanel: '#1e1b4b',
+          overlayBackground: '#312e81',
+          onOverlayText: '#f8fafc'
         }
       },
       dark: {
@@ -130,7 +150,11 @@ export const THEMES = [
           accent: '#7c3aed',
           accentForeground: '#f8fafc',
           textPrimary: '#f8fafc',
-          textMuted: '#cbd5f5'
+          textMuted: '#cbd5f5',
+          textOnSurface: '#f8fafc',
+          textOnPanel: '#f4f1ff',
+          overlayBackground: '#111827',
+          onOverlayText: '#f8fafc'
         }
       }
     }
@@ -199,7 +223,27 @@ export function applyThemeVariant(themeId, colorScheme) {
     return null
   }
 
-  Object.entries(variant.cssVars ?? {}).forEach(([token, value]) => {
+  const resolvedCssVars = {
+    ...(variant.cssVars ?? {})
+  }
+
+  if (!resolvedCssVars.textOnSurface && resolvedCssVars.textPrimary) {
+    resolvedCssVars.textOnSurface = resolvedCssVars.textPrimary
+  }
+
+  if (!resolvedCssVars.textOnPanel && resolvedCssVars.textOnSurface) {
+    resolvedCssVars.textOnPanel = resolvedCssVars.textOnSurface
+  }
+
+  if (!resolvedCssVars.overlayBackground && resolvedCssVars.panel) {
+    resolvedCssVars.overlayBackground = resolvedCssVars.panel
+  }
+
+  if (!resolvedCssVars.onOverlayText && resolvedCssVars.textOnPanel) {
+    resolvedCssVars.onOverlayText = resolvedCssVars.textOnPanel
+  }
+
+  Object.entries(resolvedCssVars).forEach(([token, value]) => {
     root.style.setProperty(`${CSS_VAR_PREFIX}${token}`, value)
   })
 
@@ -210,15 +254,19 @@ export function applyThemeVariant(themeId, colorScheme) {
   root.classList.toggle('dark', Boolean(variant.isDark))
   root.classList.toggle('sr-dark', Boolean(variant.isDark))
 
-  if (variant.cssVars?.surface) {
-    root.style.backgroundColor = variant.cssVars.surface
+  if (resolvedCssVars.surface) {
+    root.style.backgroundColor = resolvedCssVars.surface
     if (body) {
-      body.style.backgroundColor = variant.cssVars.surface
+      body.style.backgroundColor = resolvedCssVars.surface
     }
   }
 
-  if (variant.cssVars?.textPrimary && body) {
-    body.style.color = variant.cssVars.textPrimary
+  if (body) {
+    const bodyTextColor =
+      resolvedCssVars.textOnSurface ?? resolvedCssVars.textPrimary ?? body.style.color
+    if (bodyTextColor) {
+      body.style.color = bodyTextColor
+    }
   }
 
   return {

--- a/src/style.css
+++ b/src/style.css
@@ -3,15 +3,26 @@
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  --sr-surface: #f9fafb;
+  --sr-panel: #ffffff;
+  --sr-border: #e5e7eb;
+  --sr-accent: #2563eb;
+  --sr-accentForeground: #ffffff;
+  --sr-textPrimary: #0f172a;
+  --sr-textMuted: #475569;
+  --sr-textOnSurface: #0f172a;
+  --sr-textOnPanel: #0f172a;
+  --sr-overlayBackground: #1f2937;
+  --sr-onOverlayText: #f8fafc;
+
+  color-scheme: light;
+  color: var(--sr-textOnSurface);
+  background-color: var(--sr-surface);
 }
 
 a {
@@ -25,6 +36,8 @@ a:hover {
 
 body {
   margin: 0;
+  background-color: var(--sr-surface);
+  color: var(--sr-textOnSurface);
   display: flex;
   place-items: center;
   min-width: 320px;
@@ -109,13 +122,13 @@ input:disabled {
 
 @media (prefers-color-scheme: light) {
   :root {
-    color: #213547;
-    background-color: #ffffff;
+    color: var(--sr-textOnSurface);
+    background-color: var(--sr-surface);
   }
   a:hover {
     color: #747bff;
   }
- 
+
   button:disabled {
     background-color: #b9b9b9;
     color: #505050;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,31 @@
 // tailwind.config.js
 module.exports = {
   important: true,
+  theme: {
+    extend: {
+      backgroundColor: {
+        surface: 'var(--sr-surface)',
+        panel: 'var(--sr-panel)',
+        overlay: 'var(--sr-overlayBackground)',
+        accent: 'var(--sr-accent)'
+      },
+      textColor: {
+        surface: 'var(--sr-textOnSurface)',
+        panel: 'var(--sr-textOnPanel)',
+        primary: 'var(--sr-textPrimary)',
+        muted: 'var(--sr-textMuted)',
+        overlay: 'var(--sr-onOverlayText)',
+        accent: 'var(--sr-accent)',
+        onAccent: 'var(--sr-accentForeground)'
+      },
+      borderColor: {
+        base: 'var(--sr-border)',
+        accent: 'var(--sr-accent)',
+        panel: 'var(--sr-panel)'
+      },
+      ringColor: {
+        accent: 'var(--sr-accent)'
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- expand theme definitions with explicit surface, panel, and overlay text roles while updating the runtime applicator
- add default CSS variable fallbacks and expose the semantic tokens through Tailwind utilities
- document theming requirements and add a contrast validation script wired into npm test

## Testing
- npm run check:theme-contrast

------
https://chatgpt.com/codex/tasks/task_e_6902a6ca90c4832fb5a6bc64f2ebab0d