### PR TITLE
Add overlay-specific theme tokens and align UI surfaces

### DIFF
--- a/src/components/SoundRoom/HeaderBar.vue
+++ b/src/components/SoundRoom/HeaderBar.vue
@@ -1,6 +1,6 @@
 <template>
   <PulsingOverlay v-if="isLoggingOut" :duration="2000" :text="'Logging out...'" @done="isLoggingOut = false" />
-  <header class="px-6 py-4 border-b border-neutral-300 dark:border-neutral-800 dark:bg-black flex items-center justify-between relative">
+  <header class="px-6 py-4 border-b border-base bg-panel-raised text-panel-raised flex items-center justify-between relative">
     <h1 class="text-xl font-bold tracking-wide dark:text-gray-300"><RouterLink to="/" style="text-decoration: none; color: inherit;">SoundRoom</RouterLink></h1>
     
     <div v-if="shouldShowNavButtons" class="relative">
@@ -20,11 +20,11 @@
           v-if="isMenuOpen"
           @mouseleave="closeMenu"
           ref="menuPanel"
-          class="absolute right-0 mt-2 w-44 rounded-lg shadow-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 py-2 z-50 flex flex-col divide-y divide-neutral-200 dark:divide-neutral-800 overflow-hidden"
+          class="absolute right-0 mt-2 w-44 rounded-lg shadow-lg border border-base bg-menu text-menu py-2 z-50 flex flex-col divide-y divide-base overflow-hidden"
         >
           <template v-for="button in visibleButtons" :key="button.label">
             <button
-              class="w-full px-4 py-2 text-left text-sm text-neutral-800 dark:text-neutral-100 hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-none !bg-transparent"
+              class="w-full px-4 py-2 text-left text-sm text-menu hover:bg-panel-overlay focus:outline-none !bg-transparent"
               type="button"
               @click="runAction(button.action)"
             >

--- a/src/components/ui/context/ContextMenu.vue
+++ b/src/components/ui/context/ContextMenu.vue
@@ -7,7 +7,7 @@
       top: `${pos.y}px`,
       left: `${pos.x}px`,
     }"
-    class="context-menu bg-white dark:bg-neutral-800 rounded shadow p-2 text-sm border border-neutral-300 dark:border-neutral-700"
+    class="context-menu bg-menu text-menu rounded shadow p-2 text-sm border border-base"
     role="menu"
     aria-label="Context menu"
   >
@@ -15,7 +15,7 @@
       <li
         v-for="(f, i) in functionList"
         :key="f.label"
-        class="px-2 py-1 rounded cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        class="px-2 py-1 rounded cursor-pointer hover:bg-panel-overlay transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         tabindex="0"
         role="menuitem"
         @click="() => handleClick(f.function)"

--- a/src/components/ui/input/BaseInput.vue
+++ b/src/components/ui/input/BaseInput.vue
@@ -3,7 +3,7 @@
     <label
       v-if="label"
       :for="id"
-      class="text-sm font-medium text-neutral-700 dark:text-neutral-200"
+      class="text-sm font-medium text-primary"
     >
       {{ label }}
     </label>
@@ -17,11 +17,11 @@
       :disabled="disabled"
       :class="[
         'px-3 py-2 rounded border w-full text-sm focus:outline-none',
-        'focus-visible:ring-2 focus-visible:ring-blue-500',
+        'focus-visible:ring-2 focus-visible:ring-accent',
         props.class,
         error
           ? 'border-red-500 text-red-700 bg-red-50'
-          : 'border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white',
+          : 'border-base bg-panel-raised text-panel-raised',
       ]"
       v-model="internalValue"
       :aria-describedby="error ? errorId : undefined"

--- a/src/components/ui/modals/Help.vue
+++ b/src/components/ui/modals/Help.vue
@@ -1,11 +1,11 @@
 <template>
   <div @click.self="handleClose" class="modal-backdrop">
-    <div class="bg-white dark:bg-neutral-950 rounded-2xl w-[80vw] h-[80vh] relative flex flex-col overflow-hidden shadow-2xl border border-neutral-300 dark:border-neutral-800">
+    <div class="bg-panel-raised text-panel-raised rounded-2xl w-[80vw] h-[80vh] relative flex flex-col overflow-hidden shadow-2xl border border-base">
       
       <!-- Absolute Floating Header -->
       <div class="modal-header-float">
         <h1 class="text-2xl font-bold tracking-tight">Welcome to SoundRoom</h1>
-        <BaseButton @click="handleClose" class="text-sm hover:text-neutral-600 dark:hover:text-neutral-400">Close</BaseButton>
+        <BaseButton @click="handleClose" class="text-sm text-muted hover:text-primary">Close</BaseButton>
       </div>
 
       <!-- Scrollable Content -->
@@ -85,8 +85,8 @@
           </section>
 
           <section>
-            <h2 class="text-lg font-semibold mb-4 border-b border-neutral-300 dark:border-neutral-800 pb-1">FAQ</h2>
-            <ul class=" dark:divide-neutral-800">
+            <h2 class="text-lg font-semibold mb-4 border-b border-base pb-1">FAQ</h2>
+            <ul class="divide-y divide-base">
               <li
                 v-for="(faq, i) in faqs"
                 :key="i"
@@ -94,13 +94,13 @@
               >
                 <BaseButton
                   @click="faq.open = !faq.open"
-                  class="w-full text-left font-medium text-neutral-800 dark:text-neutral-200 focus:outline-none transition-colors"
+                  class="w-full text-left font-medium text-panel-raised focus:outline-none transition-colors"
                 >
                   {{ faq.question }}
                 </BaseButton>
                 <p
                   v-if="faq.open"
-                  class="mt-2 text-sm text-neutral-600 dark:text-neutral-400 leading-snug italic indent-3"
+                  class="mt-2 text-sm text-muted leading-snug italic indent-3"
                 >
                   <span
                     v-if="faq.isHtml"
@@ -133,7 +133,7 @@
                     v-model="form.name"
                     required
                     autocomplete="name"
-                    class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                    class="w-full px-3 py-2 border border-base rounded bg-panel-raised text-panel-raised focus:outline-none focus:ring-2 focus:ring-accent text-sm"
                   />
                 </div>
 
@@ -145,7 +145,7 @@
                     v-model="form.email"
                     required
                     autocomplete="email"
-                    class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                    class="w-full px-3 py-2 border border-base rounded bg-panel-raised text-panel-raised focus:outline-none focus:ring-2 focus:ring-accent text-sm"
                   />
                 </div>
               </div>
@@ -157,7 +157,7 @@
                     id="topic"
                     v-model="form.topic"
                     required
-                    class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                    class="w-full px-3 py-2 border border-base rounded bg-panel-raised text-panel-raised focus:outline-none focus:ring-2 focus:ring-accent text-sm"
                   >
                     <option v-for="item in topicOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
                   </select>
@@ -168,7 +168,7 @@
                   <select
                     id="plan"
                     v-model="form.plan"
-                    class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                    class="w-full px-3 py-2 border border-base rounded bg-panel-raised text-panel-raised focus:outline-none focus:ring-2 focus:ring-accent text-sm"
                   >
                     <option value="">Select your plan</option>
                     <option v-for="option in planOptions" :key="option" :value="option">{{ PLAN_LABELS[option] }}</option>
@@ -178,13 +178,13 @@
               </div>
 
               <div>
-                <label for="roomLink" class="block text-sm font-medium mb-1">Room link or ID <span class="text-xs text-neutral-400">(optional)</span></label>
+                <label for="roomLink" class="block text-sm font-medium mb-1">Room link or ID <span class="text-xs text-muted">(optional)</span></label>
                 <input
                   type="text"
                   id="roomLink"
                   v-model="form.roomLink"
                   placeholder="Paste a RoomManager link or card ID"
-                  class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                  class="w-full px-3 py-2 border border-base rounded bg-panel-raised text-panel-raised focus:outline-none focus:ring-2 focus:ring-accent text-sm"
                 />
               </div>
 
@@ -196,18 +196,18 @@
                   rows="4"
                   required
                   placeholder="Tell us what you were working on and what you expected to happen."
-                  class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                  class="w-full px-3 py-2 border border-base rounded bg-panel-raised text-panel-raised focus:outline-none focus:ring-2 focus:ring-accent text-sm"
                 ></textarea>
               </div>
 
               <div>
-                <label for="reproSteps" class="block text-sm font-medium mb-1">Steps to reproduce <span class="text-xs text-neutral-400">(optional)</span></label>
+                <label for="reproSteps" class="block text-sm font-medium mb-1">Steps to reproduce <span class="text-xs text-muted">(optional)</span></label>
                 <textarea
                   id="reproSteps"
                   v-model="form.reproSteps"
                   rows="3"
                   placeholder="Step-by-step details help us debug much faster."
-                  class="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 rounded bg-white dark:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                  class="w-full px-3 py-2 border border-base rounded bg-panel-raised text-panel-raised focus:outline-none focus:ring-2 focus:ring-accent text-sm"
                 ></textarea>
               </div>
 

--- a/src/components/ui/modals/RoomManager/EditableRoomName.vue
+++ b/src/components/ui/modals/RoomManager/EditableRoomName.vue
@@ -3,7 +3,7 @@
     <template v-if="isEditing">
       <input
         v-model="localName"
-        class="w-full bg-neutral-700 text-white px-2 py-1 rounded"
+        class="w-full bg-panel-overlay text-panel-overlay px-2 py-1 rounded border border-base"
         @blur="handleBlur"
         @keyup.enter="handleBlur"
         @keyup.esc="cancelEdit"

--- a/src/components/ui/modals/RoomManager/PaginationControls.vue
+++ b/src/components/ui/modals/RoomManager/PaginationControls.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="absolute flex bottom-0 left-0 right-0 p-4 bg-white dark:bg-neutral-950 border-t border-neutral-300 dark:border-neutral-800">
+  <div class="absolute flex bottom-0 left-0 right-0 p-4 bg-panel-raised text-panel-raised border-t border-base">
     <span class="w-1/4"></span>
     <div class="flex items-center justify-center w-1/2 space-x-3" :class="{ invisible: loading }">
       <BaseButton class="px-3 py-1" :disabled="currentPage === 0" @click="emit('prev')">← Prev</BaseButton>

--- a/src/components/ui/modals/RoomManager/RoomCard.vue
+++ b/src/components/ui/modals/RoomManager/RoomCard.vue
@@ -1,17 +1,17 @@
 <template>
-  <div class="room-row p-4 border border-neutral-700 rounded-lg shadow-sm hover:bg-neutral-800 transition">
+  <div class="room-row p-4 border border-base rounded-lg shadow-sm hover:bg-panel-overlay transition bg-panel-raised text-panel-raised">
     <img
       v-if="room.thumbnail"
       :src="room.thumbnail"
       alt="Room preview"
-      class="rounded mb-3 w-full aspect-video object-cover border border-neutral-800"
+      class="rounded mb-3 w-full aspect-video object-cover border border-base"
     />
     <EditableRoomName
       :roomId="room.id"
       :name="room.name"
       @updated="name => emit('update-name', name)"
     />
-    <div class="room-meta text-xs text-neutral-400">{{ formatDate(room.updated_at) }}</div>
+    <div class="room-meta text-xs text-muted">{{ formatDate(room.updated_at) }}</div>
     <div class="room-actions mt-3 flex gap-2">
       <BaseButton @click="emit('load', room.id)">Load</BaseButton>
       <BaseButton @click="emit('delete', room.id)">Delete</BaseButton>

--- a/src/components/ui/modals/RoomManager/RoomManager.vue
+++ b/src/components/ui/modals/RoomManager/RoomManager.vue
@@ -7,8 +7,8 @@
       class="modal-panel flex"
     >
       <!-- Left Sidebar -->
-      <aside 
-        class="w-60 bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-300 dark:border-neutral-800 p-4 space-y-3 overflow-y-auto"
+      <aside
+        class="w-60 bg-panel-raised text-panel-raised border-r border-base p-4 space-y-3 overflow-y-auto"
       >
         <h2 class="font-bold text-sm mb-2"></h2>
         <BaseButton
@@ -26,7 +26,7 @@
         <!-- Floating Top Bar -->
         <div
           ref="headerBar"
-          class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-white/50 dark:bg-neutral-950/50 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800"
+          class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-panel-overlay text-panel-overlay backdrop-blur-md border-b border-base"
         >
           <h2 class="text-2xl font-bold">RoomManager</h2>
           <BaseButton class="text-sm" @click="router.push('/')">Close</BaseButton>
@@ -53,7 +53,7 @@
         </template>
 
         <template v-else-if="!loading && rooms.length === 0">
-          <div class="col-span-full text-center text-neutral-400 mt-32">
+          <div class="col-span-full text-center text-muted mt-32">
             <div class="text-xl font-semibold mb-2">No rooms yet</div>
             <div class="mb-4">Create your first ambient scene and it’ll show up here.</div>
             <BaseButton @click="createNewRoom">+ Create New Room</BaseButton>

--- a/src/components/ui/modals/SmallModalBase.vue
+++ b/src/components/ui/modals/SmallModalBase.vue
@@ -1,19 +1,19 @@
 <template>
   <div
     @click.self="canClickOutside && emit('close')"
-    class="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center"
+    class="modal-backdrop"
     role="dialog"
     aria-modal="true"
     :aria-labelledby="'modal-title'"
   >
     <div
       ref="modalContent"
-      class="bg-white dark:bg-neutral-950 rounded-2xl w-[90vw] max-w-md h-auto max-h-[85vh] shadow-xl border border-neutral-300 dark:border-neutral-800 relative overflow-hidden"
+      class="bg-panel-raised text-panel-raised rounded-2xl w-[90vw] max-w-md h-auto max-h-[85vh] shadow-xl border border-base relative overflow-hidden"
       tabindex="-1"
     >
       <!-- Header -->
       <div
-        class="top-0 left-0 right-0 z-10 flex justify-between items-center px-4 py-3 bg-white/70 dark:bg-neutral-950/70 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800"
+        class="top-0 left-0 right-0 z-10 flex justify-between items-center px-4 py-3 bg-panel-overlay text-panel-overlay backdrop-blur-md border-b border-base"
       >
         <h2 id="modal-title" class="text-lg font-semibold tracking-tight">
           {{ title }}
@@ -21,7 +21,7 @@
         <BaseButton
           v-if="showCloseButton"
           @click="emit('close')"
-          class="text-sm hover:text-neutral-600 dark:hover:text-neutral-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          class="text-sm text-muted hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           aria-label="Close modal"
         >
           Close

--- a/src/components/ui/modals/SoundLibrary/CategoryList.vue
+++ b/src/components/ui/modals/SoundLibrary/CategoryList.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside class="w-60 bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-300 dark:border-neutral-800 p-4 space-y-3 overflow-y-auto">
+  <aside class="w-60 bg-panel-raised text-panel-raised border-r border-base p-4 space-y-3 overflow-y-auto">
     <h2 class="font-bold text-sm mb-2">Categories</h2>
     <BaseButton
       v-if="isAuthenticated"
@@ -12,7 +12,7 @@
         <span v-if="!canUpload" class="badge">Pro</span>
       </span>
     </BaseButton>
-    <hr v-if="isAuthenticated" class="text-neutral-300 dark:text-neutral-800"/>
+    <hr v-if="isAuthenticated" class="border-t border-base opacity-60"/>
     <BaseButton
       v-for="cat in categories"
       :key="cat.id"
@@ -61,16 +61,11 @@ function handleSelectYourSounds() {
   border-radius: 0.375rem;
   transition: background-color 0.2s;
 }
-.sound-lib-button:hover { background-color: #e5e5e5; }
-@media (prefers-color-scheme: dark) {
-  .sound-lib-button:hover { background-color: #1f2937; }
-}
+.sound-lib-button:hover { background-color: var(--sr-panelOverlay); }
 .sound-lib-button.active {
   font-weight: 600;
-  background-color: #d4d4d4;
-}
-@media (prefers-color-scheme: dark) {
-  .sound-lib-button.active { background-color: #1f2937; }
+  background-color: var(--sr-panelOverlay);
+  color: var(--sr-textOnPanelOverlay);
 }
 
 .sound-lib-button.locked {
@@ -88,12 +83,6 @@ function handleSelectYourSounds() {
   font-size: 0.625rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #7c3aed;
-}
-
-@media (prefers-color-scheme: dark) {
-  .badge {
-    color: #a855f7;
-  }
+  color: var(--sr-accent);
 }
 </style>

--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex-1 relative overflow-hidden">
-    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-white/50 dark:bg-neutral-950/50 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800">
+    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-panel-overlay text-panel-overlay backdrop-blur-md border-b border-base">
       <h2 class="text-2xl font-bold">SoundLibrary</h2>
       <BaseButton class="text-sm" @click="$emit('close')">Close</BaseButton>
     </div>
@@ -17,7 +17,7 @@
         @locked="$emit('locked', $event)"
         />
       <template v-if="canUpload && activeCategory === 'your-sounds' && sounds.length === 0">
-          <div class="col-span-full text-center text-neutral-400 mt-32">
+          <div class="col-span-full text-center text-muted mt-32">
             <div class="text-xl font-semibold mb-2">Nothing to hear!</div>
             <div class="mb-4">Upload your first sound below and it'll show up here.</div>
           </div>
@@ -25,17 +25,17 @@
     </div>
      <div
         v-if="isAuthenticated && activeCategory === 'your-sounds'"
-        class="absolute bottom-0 left-0 right-0 p-4 bg-white dark:bg-neutral-950 border-t border-neutral-300 dark:border-neutral-800"
+        class="absolute bottom-0 left-0 right-0 p-4 bg-panel-raised text-panel-raised border-t border-base"
       >
         <div class="flex items-center justify-between gap-3">
           <button
             type="button"
-            class="text-sm font-medium text-neutral-800 dark:text-neutral-100 hover:underline"
+            class="text-sm font-medium hover:underline"
             @click="handleUploadClick"
           >
             {{ uploadCtaLabel }}
           </button>
-        <span v-if="!canUpload" class="text-xs uppercase tracking-wide text-violet-500 dark:text-violet-300">Pro feature</span>
+        <span v-if="!canUpload" class="text-xs uppercase tracking-wide text-accent">Pro feature</span>
         </div>
       </div>
   </div>

--- a/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
@@ -1,9 +1,9 @@
 <template>
   <div
     :class="[
-      'relative aspect-square flex flex-col items-center justify-between p-4 rounded-xl bg-neutral-100 dark:bg-neutral-800 shadow border transition-shadow duration-200',
+      'relative aspect-square flex flex-col items-center justify-between p-4 rounded-xl bg-panel-raised text-panel-raised shadow border transition-shadow duration-200',
       highlightClass,
-      { 'border-neutral-300 dark:border-neutral-700': !highlightClass }
+      { 'border-base': !highlightClass }
     ]"
   >
 

--- a/src/components/ui/modals/SoundLibrary/UploadPanel.vue
+++ b/src/components/ui/modals/SoundLibrary/UploadPanel.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="modal-backdrop z-50" @click.self="$emit('close')">
-    <div class="modal-panel max-w-3xl mx-auto p-6 bg-white dark:bg-neutral-950 rounded-xl shadow-lg overflow-y-auto max-h-[90vh]">
+    <div class="modal-panel max-w-3xl mx-auto p-6 rounded-xl shadow-lg overflow-y-auto max-h-[90vh]">
       <h2 class="text-xl font-bold mb-4">Upload Your Sounds</h2>
 
-      <div class="border border-dashed border-neutral-400 dark:border-neutral-700 rounded-lg p-6 text-center mb-6">
+      <div class="border border-dashed border-base rounded-lg p-6 text-center mb-6">
         <input
           type="file"
           accept="audio/*"
@@ -13,15 +13,15 @@
           @change="handleFileSelect"
         />
         <BaseButton @click="fileInput.click()">Select Audio Files</BaseButton>
-        <p class="text-sm text-neutral-500 mt-2">Max 10MB per file</p>
+        <p class="text-sm text-muted mt-2">Max 10MB per file</p>
       </div>
 
       <div v-if="files.length > 0" class="space-y-4">
-        <div v-for="file in files" :key="file.id" class="bg-neutral-100 dark:bg-neutral-900 rounded-md p-4 flex flex-col gap-2">
+        <div v-for="file in files" :key="file.id" class="bg-panel-raised text-panel-raised rounded-md p-4 flex flex-col gap-2">
           <div class="flex justify-between items-center">
             <input
               v-model="file.name"
-              class="flex-1 p-1 text-base border border-neutral-300 dark:border-neutral-700 rounded-md bg-white dark:bg-neutral-800"
+              class="flex-1 p-1 text-base border border-base rounded-md bg-panel-raised text-panel-raised"
             />
             <BaseButton class="ml-2" @click="autoTag(file)" :disabled="file.tagging">
               <template v-if="file.tagging">
@@ -37,7 +37,7 @@
           <div class="flex items-center gap-2">
             <audio :src="file.previewUrl" controls class="w-full" />
           </div>
-          <div class="h-2 bg-neutral-300 dark:bg-neutral-700 rounded overflow-hidden" v-if="uploading">
+          <div class="h-2 bg-panel-overlay rounded overflow-hidden" v-if="uploading">
             <div
               class="h-full bg-green-500 transition-all duration-300"
               :style="{ width: `${file.progress}%` }"
@@ -48,12 +48,12 @@
           <span
             v-for="(tag, index) in file.tags"
             :key="tag"
-            class="flex items-center bg-neutral-200 dark:bg-neutral-800 text-xs px-2 rounded"
+            class="flex items-center bg-panel-overlay text-panel-overlay text-xs px-2 rounded"
           >
             {{ tag }}
             <label
               type="button"
-              class="ml-1 text-neutral-500 hover:text-red-500 cursor-pointer"
+              class="ml-1 text-muted hover:text-red-500 cursor-pointer"
               @click="file.tags.splice(index, 1)"
               aria-label="Remove tag"
             >
@@ -69,7 +69,7 @@
             @keydown="','"
             @blur="addTag(file)"
             placeholder="Add tag..."
-            class="text-sm p-1 rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 w-25"
+            class="text-sm p-1 rounded border border-base bg-panel-raised text-panel-raised w-25"
           />
         </div>
 

--- a/src/components/ui/modals/YesNoModal.vue
+++ b/src/components/ui/modals/YesNoModal.vue
@@ -13,7 +13,7 @@
       :id="`modal-desc-save`"
     >
       <p
-        class="text-lg font-medium text-neutral-800 dark:text-neutral-200"
+        class="text-lg font-medium text-panel-raised"
         :id="`modal-title-save`"
       >
         {{ message }}
@@ -22,7 +22,7 @@
         <BaseButton
           v-for="button in buttons"
           :key="button.label"
-          class="px-4 py-2 text-sm font-medium rounded bg-blue-600 text-white hover:bg-blue-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+          class="px-4 py-2 text-sm font-medium rounded bg-accent text-onAccent hover:opacity-90 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
           @click="button.action"
           type="button"
         >

--- a/src/components/ui/overlays/PulsingOverlay.vue
+++ b/src/components/ui/overlays/PulsingOverlay.vue
@@ -2,10 +2,10 @@
   <transition name="fade" @after-leave="emit('done')">
     <div
       v-if="visible"
-      class="absolute inset-0 flex items-center justify-center backdrop-blur-sm bg-white/30 dark:bg-black/40 z-50"
+      class="absolute inset-0 flex items-center justify-center backdrop-blur-sm bg-panel-overlay text-panel-overlay z-50"
     >
       <div
-        class="text-xl font-medium tracking-wide text-neutral-800 dark:text-white animate-pulse"
+        class="text-xl font-medium tracking-wide animate-pulse"
       >
         {{ text }}
       </div>

--- a/src/components/ui/overlays/WelcomeOverlay.vue
+++ b/src/components/ui/overlays/WelcomeOverlay.vue
@@ -2,7 +2,7 @@
   <transition name="fade">
     <div
       v-if="visible"
-      class="absolute inset-0 z-50 flex items-center justify-center backdrop-blur-md bg-white/30 dark:bg-black/50"
+      class="absolute inset-0 z-50 flex items-center justify-center backdrop-blur-md bg-panel-overlay text-panel-overlay"
     >
       <div class="text-center space-y-4">
         <h1
@@ -12,7 +12,7 @@
         </h1>
         <p
           v-if="subtext"
-          class="text-lg text-neutral-700 dark:text-neutral-300 opacity-80"
+          class="text-lg opacity-80"
         >
           {{ subtext }}
         </p>

--- a/src/constants/themes.js
+++ b/src/constants/themes.js
@@ -35,6 +35,12 @@ export const THEMES = [
         cssVars: {
           surface: '#f9fafb',
           panel: '#ffffff',
+          panelRaised: '#ffffff',
+          textOnPanelRaised: '#0f172a',
+          panelOverlay: 'rgba(248, 250, 252, 0.85)',
+          textOnPanelOverlay: '#0f172a',
+          menuBackground: '#ffffff',
+          textOnMenu: '#0f172a',
           border: '#e5e7eb',
           accent: '#2563eb',
           accentForeground: '#ffffff',
@@ -52,6 +58,12 @@ export const THEMES = [
         cssVars: {
           surface: '#0b1120',
           panel: '#111827',
+          panelRaised: '#1f2937',
+          textOnPanelRaised: '#f8fafc',
+          panelOverlay: 'rgba(15, 23, 42, 0.75)',
+          textOnPanelOverlay: '#f8fafc',
+          menuBackground: '#1f2937',
+          textOnMenu: '#f8fafc',
           border: '#1e293b',
           accent: '#38bdf8',
           accentForeground: '#0f172a',
@@ -82,6 +94,12 @@ export const THEMES = [
         cssVars: {
           surface: '#f3f4ff',
           panel: '#ffffff',
+          panelRaised: '#ffffff',
+          textOnPanelRaised: '#0f172a',
+          panelOverlay: 'rgba(240, 249, 255, 0.85)',
+          textOnPanelOverlay: '#0f172a',
+          menuBackground: '#ffffff',
+          textOnMenu: '#0f172a',
           border: '#c7d2fe',
           accent: '#0ea5e9',
           accentForeground: '#082f49',
@@ -99,6 +117,12 @@ export const THEMES = [
         cssVars: {
           surface: '#0d1b2a',
           panel: '#112240',
+          panelRaised: '#1d3557',
+          textOnPanelRaised: '#e0f2fe',
+          panelOverlay: 'rgba(13, 27, 42, 0.78)',
+          textOnPanelOverlay: '#f8fafc',
+          menuBackground: '#112240',
+          textOnMenu: '#f8fafc',
           border: '#1d3557',
           accent: '#38bdf8',
           accentForeground: '#081226',
@@ -129,6 +153,12 @@ export const THEMES = [
         cssVars: {
           surface: '#f5f3ff',
           panel: '#ede9fe',
+          panelRaised: '#ffffff',
+          textOnPanelRaised: '#1e1b4b',
+          panelOverlay: 'rgba(237, 233, 254, 0.88)',
+          textOnPanelOverlay: '#1e1b4b',
+          menuBackground: '#ede9fe',
+          textOnMenu: '#1e1b4b',
           border: '#ddd6fe',
           accent: '#7c3aed',
           accentForeground: '#f8fafc',
@@ -146,6 +176,12 @@ export const THEMES = [
         cssVars: {
           surface: '#0f172a',
           panel: '#111827',
+          panelRaised: '#1e1b4b',
+          textOnPanelRaised: '#f4f1ff',
+          panelOverlay: 'rgba(17, 24, 39, 0.78)',
+          textOnPanelOverlay: '#f8fafc',
+          menuBackground: '#161b33',
+          textOnMenu: '#f4f1ff',
           border: '#1f2937',
           accent: '#7c3aed',
           accentForeground: '#f8fafc',
@@ -233,6 +269,33 @@ export function applyThemeVariant(themeId, colorScheme) {
 
   if (!resolvedCssVars.textOnPanel && resolvedCssVars.textOnSurface) {
     resolvedCssVars.textOnPanel = resolvedCssVars.textOnSurface
+  }
+
+  if (!resolvedCssVars.panelRaised && resolvedCssVars.panel) {
+    resolvedCssVars.panelRaised = resolvedCssVars.panel
+  }
+
+  if (!resolvedCssVars.textOnPanelRaised && resolvedCssVars.textOnPanel) {
+    resolvedCssVars.textOnPanelRaised = resolvedCssVars.textOnPanel
+  }
+
+  if (!resolvedCssVars.panelOverlay) {
+    resolvedCssVars.panelOverlay =
+      resolvedCssVars.overlayBackground ?? resolvedCssVars.panelRaised ?? resolvedCssVars.panel
+  }
+
+  if (!resolvedCssVars.textOnPanelOverlay) {
+    resolvedCssVars.textOnPanelOverlay =
+      resolvedCssVars.onOverlayText ?? resolvedCssVars.textOnPanelRaised ?? resolvedCssVars.textOnPanel
+  }
+
+  if (!resolvedCssVars.menuBackground) {
+    resolvedCssVars.menuBackground = resolvedCssVars.panelRaised ?? resolvedCssVars.panel
+  }
+
+  if (!resolvedCssVars.textOnMenu) {
+    resolvedCssVars.textOnMenu =
+      resolvedCssVars.textOnPanelRaised ?? resolvedCssVars.textOnPanel ?? resolvedCssVars.textOnSurface
   }
 
   if (!resolvedCssVars.overlayBackground && resolvedCssVars.panel) {

--- a/src/style.css
+++ b/src/style.css
@@ -10,6 +10,12 @@
 
   --sr-surface: #f9fafb;
   --sr-panel: #ffffff;
+  --sr-panelRaised: #ffffff;
+  --sr-textOnPanelRaised: #0f172a;
+  --sr-panelOverlay: rgba(248, 250, 252, 0.85);
+  --sr-textOnPanelOverlay: #0f172a;
+  --sr-menuBackground: #ffffff;
+  --sr-textOnMenu: #0f172a;
   --sr-border: #e5e7eb;
   --sr-accent: #2563eb;
   --sr-accentForeground: #ffffff;
@@ -104,17 +110,17 @@ input:disabled {
 }
 
 .modal-panel {
-  @apply bg-white dark:bg-neutral-950 rounded-2xl w-[80vw] h-[80vh] shadow-2xl border border-neutral-300 dark:border-neutral-800 overflow-hidden;
+  @apply bg-panel-raised text-panel-raised rounded-2xl w-[80vw] h-[80vh] shadow-2xl border border-base overflow-hidden;
 }
 
 .modal-header-float {
   @apply absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4
-         bg-white/50 dark:bg-neutral-950/50 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800;
+         bg-panel-overlay text-panel-overlay backdrop-blur-md border-b border-base;
 }
 
 .modal-header {
   @apply top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4
-         bg-white/50 dark:bg-neutral-950/50 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800;
+         bg-panel-overlay text-panel-overlay backdrop-blur-md border-b border-base;
 }
 
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -1,16 +1,16 @@
 <template>
-  <main class="flex-1 overflow-y-auto bg-neutral-100 dark:bg-neutral-950 text-neutral-900 dark:text-neutral-100">
+  <main class="flex-1 overflow-y-auto bg-surface text-surface">
     <div class="max-w-5xl mx-auto px-6 py-10 space-y-10">
       <section class="space-y-4">
         <div class="flex items-center justify-between gap-6 flex-wrap">
           <div class="space-y-2">
             <h1 class="text-3xl font-semibold tracking-tight">Settings</h1>
-            <p class="text-sm text-neutral-600 dark:text-neutral-400 max-w-xl">
+            <p class="text-sm text-muted max-w-xl">
               Update how you appear in SoundRoom, adjust playback preferences, and keep your account secure.
             </p>
           </div>
-          <div class="flex items-center gap-3 rounded-full border border-neutral-200 dark:border-neutral-800 px-4 py-2 bg-white/70 dark:bg-neutral-900/70">
-            <span class="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">Plan</span>
+          <div class="flex items-center gap-3 rounded-full border border-base px-4 py-2 bg-panel-overlay text-panel-overlay">
+            <span class="text-xs uppercase tracking-wide text-muted">Plan</span>
             <span class="text-sm font-medium">{{ planLabel }}</span>
             <RouterLink v-if="tier.value === 'free'" :to="'/upgrade'" class="ml-2">
               <BaseButton type="button">
@@ -43,13 +43,13 @@
           <p v-else-if="planErrorMessage" class="text-sm font-medium">{{ planErrorMessage }}</p>
         </div>
 
-        <div class="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white/70 dark:bg-neutral-900/70 p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
+        <div class="rounded-2xl border border-base bg-panel-raised text-panel-raised p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
           <div>
-            <p class="text-sm text-neutral-500 dark:text-neutral-400">Signed in as</p>
+            <p class="text-sm text-muted">Signed in as</p>
             <p class="text-lg font-medium break-all">{{ userEmail }}</p>
           </div>
           <div class="flex items-center gap-4">
-            <div class="relative w-16 h-16 rounded-full bg-neutral-200 dark:bg-neutral-800 flex items-center justify-center overflow-hidden text-xl font-semibold">
+            <div class="relative w-16 h-16 rounded-full bg-panel-overlay text-panel-overlay flex items-center justify-center overflow-hidden text-xl font-semibold">
               <img
                 v-if="avatarPreview && !avatarFailed"
                 :src="avatarPreview"
@@ -60,23 +60,23 @@
               <span v-else>{{ avatarInitial }}</span>
             </div>
             <div>
-              <p class="text-sm text-neutral-500 dark:text-neutral-400">Display name</p>
+              <p class="text-sm text-muted">Display name</p>
               <p class="text-base font-medium">{{ profileForm.displayName || '—' }}</p>
             </div>
           </div>
         </div>
       </section>
 
-      <section class="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl border border-base bg-panel-raised text-panel-raised p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Profile</h2>
-          <p class="text-sm text-neutral-600 dark:text-neutral-400">Set how teammates and collaborators see you.</p>
+          <p class="text-sm text-muted">Set how teammates and collaborators see you.</p>
         </header>
 
         <div v-if="isFetchingProfile" class="space-y-4 animate-pulse">
-          <div class="h-4 bg-neutral-200 dark:bg-neutral-800 rounded"></div>
-          <div class="h-4 bg-neutral-200 dark:bg-neutral-800 rounded w-2/3"></div>
-          <div class="h-40 bg-neutral-200 dark:bg-neutral-800 rounded"></div>
+          <div class="h-4 bg-panel-overlay rounded"></div>
+          <div class="h-4 bg-panel-overlay rounded w-2/3"></div>
+          <div class="h-40 bg-panel-overlay rounded"></div>
         </div>
 
         <form v-else @submit.prevent="saveProfile" class="space-y-8">
@@ -114,7 +114,7 @@
           <div class="flex flex-wrap items-center justify-end gap-3">
             <button
               type="button"
-              class="text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 transition"
+              class="text-sm text-muted hover:text-primary transition"
               @click="resetProfileForm"
               :disabled="profileSaving || !hasProfileChanges"
             >
@@ -134,21 +134,21 @@
         </form>
       </section>
 
-      <section class="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl border border-base bg-panel-raised text-panel-raised p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Playback Preferences</h2>
-          <p class="text-sm text-neutral-600 dark:text-neutral-400">These settings are stored locally in your browser.</p>
+          <p class="text-sm text-muted">These settings are stored locally in your browser.</p>
         </header>
 
         <div class="space-y-6">
           <div class="flex items-start justify-between gap-6">
             <div>
               <h3 class="text-base font-medium">Auto-resume sessions</h3>
-              <p class="text-sm text-neutral-600 dark:text-neutral-400">Automatically reload your last SoundRoom when you sign back in.</p>
+              <p class="text-sm text-muted">Automatically reload your last SoundRoom when you sign back in.</p>
             </div>
             <label class="relative inline-flex items-center cursor-pointer select-none">
               <input type="checkbox" class="sr-only peer" v-model="preferences.autoResumePlayback">
-              <span class="block w-12 h-6 rounded-full bg-neutral-300 dark:bg-neutral-700 transition-colors peer-focus:outline peer-focus:outline-2 peer-focus:outline-blue-500 peer-checked:bg-blue-600"></span>
+              <span class="block w-12 h-6 rounded-full bg-panel-overlay transition-colors peer-focus:outline peer-focus:outline-2 peer-focus:outline-blue-500 peer-checked:bg-accent"></span>
               <span class="absolute left-1 top-1 block w-4 h-4 rounded-full bg-white shadow transition-transform peer-checked:translate-x-6"></span>
             </label>
           </div>
@@ -156,11 +156,11 @@
           <div class="flex items-start justify-between gap-6">
             <div>
               <h3 class="text-base font-medium">Show interface tips</h3>
-              <p class="text-sm text-neutral-600 dark:text-neutral-400">Keep lightweight reminders visible for keyboard shortcuts and best practices.</p>
+              <p class="text-sm text-muted">Keep lightweight reminders visible for keyboard shortcuts and best practices.</p>
             </div>
             <label class="relative inline-flex items-center cursor-pointer select-none">
               <input type="checkbox" class="sr-only peer" v-model="preferences.showInterfaceTips">
-              <span class="block w-12 h-6 rounded-full bg-neutral-300 dark:bg-neutral-700 transition-colors peer-focus:outline peer-focus:outline-2 peer-focus:outline-blue-500 peer-checked:bg-blue-600"></span>
+              <span class="block w-12 h-6 rounded-full bg-panel-overlay transition-colors peer-focus:outline peer-focus:outline-2 peer-focus:outline-blue-500 peer-checked:bg-accent"></span>
               <span class="absolute left-1 top-1 block w-4 h-4 rounded-full bg-white shadow transition-transform peer-checked:translate-x-6"></span>
             </label>
           </div>
@@ -169,7 +169,7 @@
         <div class="flex flex-wrap items-center justify-end gap-3">
           <button
             type="button"
-            class="text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 transition"
+            class="text-sm text-muted hover:text-primary transition"
             @click="resetPreferences"
             :disabled="!hasPreferenceChanges"
           >
@@ -186,17 +186,17 @@
         <p v-if="preferenceMessage" class="text-sm text-green-600">{{ preferenceMessage }}</p>
       </section>
 
-      <section class="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl border border-base bg-panel-raised text-panel-raised p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Security</h2>
-          <p class="text-sm text-neutral-600 dark:text-neutral-400">Keep your account protected and up to date.</p>
+          <p class="text-sm text-muted">Keep your account protected and up to date.</p>
         </header>
 
         <div class="space-y-6">
           <div class="flex flex-wrap items-start justify-between gap-6">
             <div>
               <h3 class="text-base font-medium">Password</h3>
-              <p class="text-sm text-neutral-600 dark:text-neutral-400">Use a strong password to protect your SoundRoom sessions and purchases.</p>
+              <p class="text-sm text-muted">Use a strong password to protect your SoundRoom sessions and purchases.</p>
             </div>
             <RouterLink to="/update-password">
               <BaseButton type="button">Update password</BaseButton>
@@ -206,7 +206,7 @@
           <div class="flex flex-wrap items-start justify-between gap-6">
             <div>
               <h3 class="text-base font-medium">Sign out</h3>
-              <p class="text-sm text-neutral-600 dark:text-neutral-400">Need to switch devices? Sign out to end your session on this browser.</p>
+              <p class="text-sm text-muted">Need to switch devices? Sign out to end your session on this browser.</p>
             </div>
             <BaseButton type="button" @click="signOutCurrentSession">Sign out of this device</BaseButton>
           </div>

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full bg-white text-neutral-900 dark:bg-neutral-950 dark:text-white flex flex-col">
+  <div class="h-full bg-surface text-surface flex flex-col">
     <!-- Main Layout -->
     <div class="flex flex-1 overflow-hidden">
 
@@ -17,7 +17,7 @@
         <Toolbar/>
 
         <!-- Canvas Area -->
-        <div class="flex-1 bg-neutral-200 dark:bg-black flex items-center justify-center">
+        <div class="flex-1 bg-panel-raised flex items-center justify-center">
           <MainCanvasStage
             v-bind="{
               handleDrop,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,12 +6,18 @@ module.exports = {
       backgroundColor: {
         surface: 'var(--sr-surface)',
         panel: 'var(--sr-panel)',
+        'panel-raised': 'var(--sr-panelRaised)',
+        'panel-overlay': 'var(--sr-panelOverlay)',
+        menu: 'var(--sr-menuBackground)',
         overlay: 'var(--sr-overlayBackground)',
         accent: 'var(--sr-accent)'
       },
       textColor: {
         surface: 'var(--sr-textOnSurface)',
         panel: 'var(--sr-textOnPanel)',
+        'panel-raised': 'var(--sr-textOnPanelRaised)',
+        'panel-overlay': 'var(--sr-textOnPanelOverlay)',
+        menu: 'var(--sr-textOnMenu)',
         primary: 'var(--sr-textPrimary)',
         muted: 'var(--sr-textMuted)',
         overlay: 'var(--sr-onOverlayText)',
@@ -20,8 +26,13 @@ module.exports = {
       },
       borderColor: {
         base: 'var(--sr-border)',
+        menu: 'var(--sr-menuBackground)',
+        overlay: 'var(--sr-panelOverlay)',
         accent: 'var(--sr-accent)',
         panel: 'var(--sr-panel)'
+      },
+      divideColor: {
+        base: 'var(--sr-border)'
       },
       ringColor: {
         accent: 'var(--sr-accent)'


### PR DESCRIPTION
## Summary
- add overlay-focused CSS variables to theme variants and propagate defaults
- map new tokens into Tailwind utilities and update global modal styles
- refactor key settings, modal, and overlay components to rely on the new raised, overlay, and menu surfaces

## Testing
- npm run build *(fails: missing @sentry/vite-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6902bee42e84832fa4954f67e51a0ed3