### PR TITLE
Enforce authenticated access for audio storage APIs

### DIFF
--- a/api/_utils/auth.js
+++ b/api/_utils/auth.js
@@ -1,0 +1,50 @@
+import { supabaseAdmin } from './serverClients.js'
+import { HttpError } from './errors.js'
+import { getEntitlementsForPlan, normalizePlan } from './entitlements.js'
+
+export async function authenticateRequest(request) {
+  if (!supabaseAdmin) {
+    throw new HttpError(500, 'Supabase admin client is not configured')
+  }
+
+  const authHeader = request.headers.get('authorization') || request.headers.get('Authorization') || ''
+  const token = authHeader.startsWith('Bearer ') ? authHeader.slice('Bearer '.length).trim() : ''
+
+  if (!token) {
+    throw new HttpError(401, 'Missing bearer token')
+  }
+
+  const { data, error } = await supabaseAdmin.auth.getUser(token)
+
+  if (error || !data?.user) {
+    throw new HttpError(401, 'Invalid or expired access token')
+  }
+
+  return { user: data.user, token }
+}
+
+export async function getUserPlan(userId) {
+  if (!supabaseAdmin) {
+    throw new HttpError(500, 'Supabase admin client is not configured')
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from('users')
+    .select('plan_tier')
+    .eq('id', userId)
+    .maybeSingle()
+
+  if (error) {
+    console.error('Failed to load user profile', error)
+    throw new HttpError(500, 'Unable to load user profile')
+  }
+
+  return normalizePlan(data?.plan_tier)
+}
+
+export async function resolveUserAccessContext(userId) {
+  const plan = await getUserPlan(userId)
+  const entitlements = getEntitlementsForPlan(plan)
+
+  return { plan, entitlements }
+}

--- a/api/_utils/entitlements.js
+++ b/api/_utils/entitlements.js
@@ -1,0 +1,73 @@
+export const PLAN_ORDER = ['free', 'basic', 'pro']
+
+export const ENTITLEMENTS = {
+  free: {
+    canUpload: false,
+  },
+  basic: {
+    canUpload: false,
+  },
+  pro: {
+    canUpload: true,
+  },
+}
+
+export function normalizePlan(plan) {
+  const normalized = typeof plan === 'string' ? plan.toLowerCase() : 'free'
+
+  if (normalized === 'users') {
+    return 'users'
+  }
+
+  return PLAN_ORDER.includes(normalized) ? normalized : 'free'
+}
+
+export function getEntitlementsForPlan(plan) {
+  const normalized = normalizePlan(plan)
+  return ENTITLEMENTS[normalized] ?? ENTITLEMENTS.free
+}
+
+export function hasPlanAccess(userPlan, requiredPlan) {
+  if (!requiredPlan) {
+    return true
+  }
+
+  const normalizedRequired = normalizePlan(requiredPlan)
+
+  if (normalizedRequired === 'users') {
+    return false
+  }
+
+  const userRank = PLAN_ORDER.indexOf(normalizePlan(userPlan))
+  const requiredRank = PLAN_ORDER.indexOf(normalizedRequired)
+
+  if (requiredRank === -1) {
+    return false
+  }
+
+  return userRank >= requiredRank
+}
+
+export function resolveRequiredPlan(soundFile, fallbackBase) {
+  if (!soundFile) {
+    return normalizePlan(fallbackBase)
+  }
+
+  if (soundFile.required_plan) {
+    return normalizePlan(soundFile.required_plan)
+  }
+
+  if (soundFile.requiredPlan) {
+    return normalizePlan(soundFile.requiredPlan)
+  }
+
+  if (soundFile.plan_tier) {
+    return normalizePlan(soundFile.plan_tier)
+  }
+
+  if (soundFile.base) {
+    return normalizePlan(soundFile.base)
+  }
+
+  return normalizePlan(fallbackBase)
+}

--- a/api/_utils/errors.js
+++ b/api/_utils/errors.js
@@ -1,0 +1,11 @@
+export class HttpError extends Error {
+  /**
+   * @param {number} status
+   * @param {string} message
+   */
+  constructor(status, message) {
+    super(message)
+    this.name = 'HttpError'
+    this.status = status
+  }
+}

--- a/api/delete-file.js
+++ b/api/delete-file.js
@@ -1,79 +1,127 @@
-import { AwsClient } from "aws4fetch";
+import { AwsClient } from 'aws4fetch'
+import { supabaseAdmin } from './_utils/serverClients.js'
+import { authenticateRequest, resolveUserAccessContext } from './_utils/auth.js'
+import { HttpError } from './_utils/errors.js'
+
+const ALLOWED_ORIGIN =
+  process.env.NODE_ENV === 'production' ? 'https://soundroom.live' : '*'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
+  'Access-Control-Allow-Methods': 'DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Credentials': 'true',
+}
+
+export function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders,
+  })
+}
 
 export async function DELETE(request) {
-  const ALLOWED_ORIGIN =
-    process.env.NODE_ENV === 'production'
-      ? 'https://soundroom.live'
-      : '*';
-
-  const {
-    R2_ACCESS_KEY_ID,
-    R2_SECRET_ACCESS_KEY,
-    R2_BUCKET_NAME,
-    R2_ACCOUNT_ID,
-  } = process.env;
-
-  const corsHeaders = {
-    'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
-    'Access-Control-Allow-Methods': 'DELETE, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
-    'Access-Control-Allow-Credentials': 'true',
-  };
-
-  if (request.method === 'OPTIONS') {
-    return new Response(null, {
-      status: 204,
-      headers: corsHeaders,
-    });
-  }
-
   try {
-    const { searchParams } = new URL(request.url);
-    const bucket = searchParams.get('bucket');
-    const path = searchParams.get('path');
-    const base = searchParams.get('base');
+    const { user } = await authenticateRequest(request)
+    const userAccess = await resolveUserAccessContext(user.id)
 
-    if (!bucket || !path) {
-      return new Response(
-        JSON.stringify({ error: "Missing 'bucket' or 'path' query param" }),
-        {
-          status: 400,
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        }
-      );
+    if (!userAccess.entitlements.canUpload) {
+      throw new HttpError(403, 'You are not allowed to delete files')
+    }
+
+    if (!supabaseAdmin) {
+      throw new HttpError(500, 'Supabase admin client is not configured')
+    }
+
+    const { searchParams } = new URL(request.url)
+    const requestedBucket = searchParams.get('bucket')
+    const requestedBase = searchParams.get('base')
+    const pathParam = searchParams.get('path')?.trim()
+
+    if (!pathParam) {
+      throw new HttpError(400, "Missing 'path' query param")
+    }
+
+    const { data: soundFile, error: soundFileError } = await supabaseAdmin
+      .from('sound_files')
+      .select('id, owner_id, base, bucket, path')
+      .eq('owner_id', user.id)
+      .eq('path', pathParam)
+      .eq('bucket', user.id)
+      .maybeSingle()
+
+    if (soundFileError) {
+      console.error('Failed to resolve sound file for deletion', soundFileError)
+      throw new HttpError(500, 'Unable to validate delete request')
+    }
+
+    if (!soundFile) {
+      throw new HttpError(404, 'Sound file not found')
+    }
+
+    const storageBase = soundFile.base || 'users'
+    const storageBucket = soundFile.bucket || user.id
+
+    if (storageBucket !== user.id) {
+      throw new HttpError(403, 'You can only delete files from your own bucket')
+    }
+
+    if (storageBase !== 'users') {
+      throw new HttpError(403, 'Invalid storage base for deletion')
+    }
+
+    if (requestedBucket && requestedBucket !== storageBucket) {
+      throw new HttpError(403, 'Bucket mismatch')
+    }
+
+    if (requestedBase && requestedBase !== storageBase) {
+      throw new HttpError(403, 'Base mismatch')
+    }
+
+    const {
+      R2_ACCESS_KEY_ID,
+      R2_SECRET_ACCESS_KEY,
+      R2_BUCKET_NAME,
+      R2_ACCOUNT_ID,
+    } = process.env
+
+    if (!R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY || !R2_BUCKET_NAME || !R2_ACCOUNT_ID) {
+      throw new HttpError(500, 'R2 storage is not configured')
     }
 
     const client = new AwsClient({
       accessKeyId: R2_ACCESS_KEY_ID,
       secretAccessKey: R2_SECRET_ACCESS_KEY,
-    });
+    })
 
-    const url = `https://${R2_BUCKET_NAME}.${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${base}/${bucket}/${path}`;
-    const signed = await client.sign(
-      new Request(url, { method: 'DELETE' }),
-      { aws: { signQuery: true } }
-    );
+    const url = `https://${R2_BUCKET_NAME}.${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${storageBase}/${storageBucket}/${soundFile.path}`
+    const signed = await client.sign(new Request(url, { method: 'DELETE' }), {
+      aws: { signQuery: true },
+    })
 
-    const res = await fetch(signed);
+    const res = await fetch(signed)
+
     if (!res.ok) {
-      return new Response(
-        JSON.stringify({ error: 'Failed to delete file' }),
-        { status: res.status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
+      console.error('R2 deletion failed', await res.text())
+      throw new HttpError(res.status, 'Failed to delete file')
     }
 
     return new Response(JSON.stringify({ success: true }), {
       status: 200,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
-  } catch (err) {
-    console.error('💥 DELETE ERROR:', err);
-    return new Response(
-      JSON.stringify({ error: 'Internal Server Error', message: err.message }),
-      {
-        status: 500,
+    })
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: error.status,
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      }
-    );
+      })
+    }
+
+    console.error('💥 DELETE ERROR:', error)
+    return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
   }
 }

--- a/api/get-signed-url.js
+++ b/api/get-signed-url.js
@@ -1,67 +1,126 @@
-import { getEnv } from '@vercel/functions';
-import { AwsClient } from "aws4fetch";
+import { AwsClient } from 'aws4fetch'
+import { supabaseAdmin } from './_utils/serverClients.js'
+import { authenticateRequest, resolveUserAccessContext } from './_utils/auth.js'
+import { HttpError } from './_utils/errors.js'
+import { hasPlanAccess, resolveRequiredPlan } from './_utils/entitlements.js'
 
+const ALLOWED_ORIGIN =
+  process.env.NODE_ENV === 'production' ? 'https://soundroom.live' : '*'
 
-/**
- * API endpoint that signs a temporary URL for a file in the R2 bucket.
- *
- * @param {Request} request - incoming HTTP request
- * @returns {Promise<Response>} signed URL response
- */
-export async function GET(request) {
-  const ALLOWED_ORIGIN =
-  process.env.NODE_ENV === 'production'
-    ? 'https://soundroom.live'
-    : '*';
+const corsHeaders = {
+  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Credentials': 'true',
+}
 
-  const {
-    R2_ACCESS_KEY_ID,
-    R2_SECRET_ACCESS_KEY,
-    R2_BUCKET_NAME,
-    R2_ACCOUNT_ID
-  } = process.env;
+function parseStorageKey(key) {
+  const sanitized = key.replace(/^\/+|\/+$/g, '')
+  const segments = sanitized.split('/')
 
-  const corsHeaders = {
-    'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
-    'Access-Control-Allow-Methods': 'GET, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
-    'Access-Control-Allow-Credentials': 'true',
-  };
-
-  if (request.method === 'OPTIONS') {
-    return new Response(null, {
-      status: 204,
-      headers: corsHeaders,
-    });
+  if (segments.length < 3) {
+    throw new HttpError(400, 'Invalid storage key')
   }
 
+  const [base, bucket, ...rest] = segments
+  const objectPath = rest.join('/')
+
+  if (!base || !bucket || !objectPath) {
+    throw new HttpError(400, 'Invalid storage key')
+  }
+
+  if (base.includes('..') || bucket.includes('..') || objectPath.includes('..')) {
+    throw new HttpError(400, 'Invalid storage key')
+  }
+
+  return { base, bucket, objectPath }
+}
+
+export function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders,
+  })
+}
+
+export async function GET(request) {
   try {
-   
+    const {
+      R2_ACCESS_KEY_ID,
+      R2_SECRET_ACCESS_KEY,
+      R2_BUCKET_NAME,
+      R2_ACCOUNT_ID,
+    } = process.env
+
+    if (!R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY || !R2_BUCKET_NAME || !R2_ACCOUNT_ID) {
+      throw new HttpError(500, 'R2 storage is not configured')
+    }
+
+    const { searchParams } = new URL(request.url)
+    const key = searchParams.get('key')
+
+    if (!key) {
+      throw new HttpError(400, "Missing 'key' query param")
+    }
+
+    const { user } = await authenticateRequest(request)
+    const userAccess = await resolveUserAccessContext(user.id)
+
+    const { base, bucket, objectPath } = parseStorageKey(key)
+
+    if (!supabaseAdmin) {
+      throw new HttpError(500, 'Supabase admin client is not configured')
+    }
+
+    const { data: soundFile, error: soundFileError } = await supabaseAdmin
+      .from('sound_files')
+      .select('id, owner_id, plan_tier, base, bucket, path')
+      .eq('bucket', bucket)
+      .eq('path', objectPath)
+      .maybeSingle()
+
+    if (soundFileError) {
+      console.error('Failed to validate storage key', soundFileError)
+      throw new HttpError(500, 'Unable to validate storage key')
+    }
+
+    if (!soundFile) {
+      throw new HttpError(404, 'Sound file not found')
+    }
+
+    const isOwner = !!soundFile.owner_id && soundFile.owner_id === user.id
+
+    if (soundFile.owner_id && !isOwner) {
+      throw new HttpError(403, 'You do not have access to this file')
+    }
+
+    if (!isOwner) {
+      const requiredPlan = resolveRequiredPlan(soundFile, base)
+
+      if (!hasPlanAccess(userAccess.plan, requiredPlan)) {
+        throw new HttpError(403, 'Your plan does not permit access to this file')
+      }
+    }
+
+    if (soundFile.bucket && soundFile.bucket !== bucket) {
+      throw new HttpError(403, 'Storage bucket mismatch')
+    }
+
+    if (soundFile.base && soundFile.base !== base) {
+      throw new HttpError(403, 'Storage base mismatch')
+    }
+
     const client = new AwsClient({
       accessKeyId: R2_ACCESS_KEY_ID,
       secretAccessKey: R2_SECRET_ACCESS_KEY,
-    });
+    })
 
-    const { searchParams } = new URL(request.url);
-    const key = searchParams.get("key");
+    const url = new URL(`https://${R2_BUCKET_NAME}.${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${key}`)
+    url.searchParams.set('X-Amz-Expires', '120')
 
-    if (!key) {
-      return new Response(JSON.stringify({ error: "Missing 'key' query param" }), {
-        status: 400,
-        headers: {
-          ...corsHeaders,
-          'Content-Type': 'application/json',
-        },
-      });
-    }
-
-    const url = new URL(`https://${R2_BUCKET_NAME}.${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${key}`);
-    url.searchParams.set("X-Amz-Expires", "120");
-
-    const signed = await client.sign(
-      new Request(url, { method: "GET" }),
-      { aws: { signQuery: true } }
-    );
+    const signed = await client.sign(new Request(url, { method: 'GET' }), {
+      aws: { signQuery: true },
+    })
 
     return new Response(JSON.stringify({ signedUrl: signed.url }), {
       status: 200,
@@ -69,16 +128,25 @@ export async function GET(request) {
         ...corsHeaders,
         'Content-Type': 'application/json',
       },
-    });
+    })
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: error.status,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json',
+        },
+      })
+    }
 
-  } catch (err) {
-    console.error("💥 SIGNING ERROR:", err);
-    return new Response(JSON.stringify({ error: "Internal Server Error", message: err.message }), {
+    console.error('💥 SIGNING ERROR:', error)
+    return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
       status: 500,
       headers: {
         ...corsHeaders,
         'Content-Type': 'application/json',
       },
-    });
+    })
   }
 }

--- a/api/get-upload-url.js
+++ b/api/get-upload-url.js
@@ -1,69 +1,73 @@
-import { AwsClient } from "aws4fetch";
+import { AwsClient } from 'aws4fetch'
+import { authenticateRequest, resolveUserAccessContext } from './_utils/auth.js'
+import { HttpError } from './_utils/errors.js'
 
-/**
- * API endpoint that signs a temporary upload URL for the R2 bucket.
- *
- * @param {Request} request - incoming HTTP request
- * @returns {Promise<Response>} signed upload URL response
- */
+const ALLOWED_ORIGIN =
+  process.env.NODE_ENV === 'production' ? 'https://soundroom.live' : '*'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Credentials': 'true',
+}
+
+export function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders,
+  })
+}
+
 export async function GET(request) {
-  const ALLOWED_ORIGIN =
-    process.env.NODE_ENV === 'production'
-      ? 'https://soundroom.live'
-      : '*';
-
-  const {
-    R2_ACCESS_KEY_ID,
-    R2_SECRET_ACCESS_KEY,
-    R2_BUCKET_NAME,
-    R2_ACCOUNT_ID
-  } = process.env;
-
-  const corsHeaders = {
-    'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
-    'Access-Control-Allow-Methods': 'GET, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
-    'Access-Control-Allow-Credentials': 'true',
-  };
-
-  if (request.method === 'OPTIONS') {
-    return new Response(null, {
-      status: 204,
-      headers: corsHeaders,
-    });
-  }
-
   try {
+    const { user } = await authenticateRequest(request)
+    const userAccess = await resolveUserAccessContext(user.id)
+
+    if (!userAccess.entitlements.canUpload) {
+      throw new HttpError(403, 'Uploads are not available for your plan')
+    }
+
+    const {
+      R2_ACCESS_KEY_ID,
+      R2_SECRET_ACCESS_KEY,
+      R2_BUCKET_NAME,
+      R2_ACCOUNT_ID,
+    } = process.env
+
+    if (!R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY || !R2_BUCKET_NAME || !R2_ACCOUNT_ID) {
+      throw new HttpError(500, 'R2 storage is not configured')
+    }
+
+    const { searchParams } = new URL(request.url)
+    const userIdParam = searchParams.get('userId')
+    const filename = searchParams.get('filename')?.trim()
+
+    if (!userIdParam || !filename) {
+      throw new HttpError(400, "Missing 'userId' or 'filename' query param")
+    }
+
+    if (userIdParam !== user.id) {
+      throw new HttpError(403, 'You can only upload files to your own library')
+    }
+
+    if (filename.includes('..') || filename.includes('/')) {
+      throw new HttpError(400, 'Invalid filename')
+    }
+
     const client = new AwsClient({
       accessKeyId: R2_ACCESS_KEY_ID,
       secretAccessKey: R2_SECRET_ACCESS_KEY,
-    });
+    })
 
-    const { searchParams } = new URL(request.url);
-    const userId = searchParams.get('userId');
-    const filename = searchParams.get('filename');
+    const url = new URL(
+      `https://${R2_BUCKET_NAME}.${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/users/${user.id}/${filename}`,
+    )
+    url.searchParams.set('X-Amz-Expires', '120')
 
-    if (!userId || !filename) {
-      return new Response(
-        JSON.stringify({ error: "Missing 'userId' or 'filename' query param" }),
-        {
-          status: 400,
-          headers: {
-            ...corsHeaders,
-            'Content-Type': 'application/json',
-          },
-        }
-      );
-    }
-
-    const key = `${filename}`;
-    const url = new URL(`https://${R2_BUCKET_NAME}.${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/users/${userId}/${key}`);
-    url.searchParams.set('X-Amz-Expires', '120');
-
-    const signed = await client.sign(
-      new Request(url, { method: 'PUT' }),
-      { aws: { signQuery: true } }
-    );
+    const signed = await client.sign(new Request(url, { method: 'PUT' }), {
+      aws: { signQuery: true },
+    })
 
     return new Response(JSON.stringify({ signedUrl: signed.url, key: filename }), {
       status: 200,
@@ -71,18 +75,25 @@ export async function GET(request) {
         ...corsHeaders,
         'Content-Type': 'application/json',
       },
-    });
-  } catch (err) {
-    console.error('💥 SIGNING ERROR:', err);
-    return new Response(
-      JSON.stringify({ error: 'Internal Server Error', message: err.message }),
-      {
-        status: 500,
+    })
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: error.status,
         headers: {
           ...corsHeaders,
           'Content-Type': 'application/json',
         },
-      }
-    );
+      })
+    }
+
+    console.error('💥 SIGNING ERROR:', error)
+    return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+      status: 500,
+      headers: {
+        ...corsHeaders,
+        'Content-Type': 'application/json',
+      },
+    })
   }
 }

--- a/src/utils/deleteAudio.js
+++ b/src/utils/deleteAudio.js
@@ -1,3 +1,10 @@
+import { supabase } from '@/utils/supabase';
+
+async function getAccessToken() {
+  const { data } = await supabase.auth.getSession();
+  return data.session?.access_token ?? null;
+}
+
 /**
  * Delete an audio file from the R2 bucket.
  *
@@ -7,11 +14,28 @@
  * @returns {Promise<void>}
  */
 export default async function deleteAudio(bucket, path, base) {
-  const params = new URLSearchParams({ bucket, path, base })
-  const res = await fetch(`/api/delete-file?${params.toString()}`, { method: 'DELETE' })
-  if (!res.ok) {
-    const errorData = await res.json().catch(() => ({ error: 'Invalid JSON response' }))
-    throw new Error(errorData.error || 'Failed to delete file')
+  const token = await getAccessToken();
+
+  if (!token) {
+    throw new Error('You must be signed in to delete audio');
   }
-  await res.json()
+
+  const params = new URLSearchParams({ bucket, path, base });
+  const res = await fetch(`/api/delete-file?${params.toString()}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => ({ error: 'Invalid JSON response' }));
+    const message = errorData.error || 'Failed to delete file';
+
+    if (res.status === 401 || res.status === 403) {
+      throw new Error(message || 'You are not authorized to delete this file');
+    }
+
+    throw new Error(message);
+  }
+  await res.json();
 }

--- a/src/utils/downloadAudio.js
+++ b/src/utils/downloadAudio.js
@@ -1,4 +1,10 @@
 import { useAudioCacheStore } from '@/stores/useAudioCacheStore'
+import { supabase } from '@/utils/supabase'
+
+async function getAccessToken() {
+  const { data } = await supabase.auth.getSession()
+  return data.session?.access_token ?? null
+}
 
 /**
  * Normalise and join storage segments into a canonical R2 object key.
@@ -23,10 +29,27 @@ export function buildStorageKey(base, bucket, path) {
  * @returns {Promise<Blob>} resolved audio Blob
  */
 export async function fetchAudioBlob(key) {
-  const res = await fetch(`/api/get-signed-url?key=${encodeURIComponent(key)}`)
+  const token = await getAccessToken()
+
+  if (!token) {
+    throw new Error('You must be signed in to access audio files')
+  }
+
+  const res = await fetch(`/api/get-signed-url?key=${encodeURIComponent(key)}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
+
   if (!res.ok) {
     const errorData = await res.json().catch(() => ({ error: 'Invalid JSON response' }))
-    throw new Error(errorData.error || 'Failed to get signed URL')
+    const message = errorData.error || 'Failed to get signed URL'
+
+    if (res.status === 401 || res.status === 403) {
+      throw new Error(message || 'You are not authorized to access this audio file')
+    }
+
+    throw new Error(message)
   }
   const { signedUrl } = await res.json()
 

--- a/src/utils/uploadAudio.js
+++ b/src/utils/uploadAudio.js
@@ -1,3 +1,10 @@
+import { supabase } from '@/utils/supabase';
+
+async function getAccessToken() {
+  const { data } = await supabase.auth.getSession();
+  return data.session?.access_token ?? null;
+}
+
 /**
  * Fetch a signed URL for uploading a file to the R2 bucket.
  *
@@ -6,11 +13,27 @@
  * @returns {Promise<{signedUrl: string, key: string}>}
  */
 async function getSignedUploadUrl(userId, filename) {
+  const token = await getAccessToken();
+
+  if (!token) {
+    throw new Error('You must be signed in to upload audio');
+  }
+
   const params = new URLSearchParams({ userId, filename });
-  const res = await fetch(`/api/get-upload-url?${params.toString()}`);
+  const res = await fetch(`/api/get-upload-url?${params.toString()}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
   if (!res.ok) {
     const errorData = await res.json().catch(() => ({ error: 'Invalid JSON response' }));
-    throw new Error(errorData.error || 'Failed to get signed upload URL');
+    const message = errorData.error || 'Failed to get signed upload URL';
+
+    if (res.status === 401 || res.status === 403) {
+      throw new Error(message || 'You are not authorized to upload audio');
+    }
+
+    throw new Error(message);
   }
   return await res.json();
 }


### PR DESCRIPTION
## Summary
- require Supabase bearer authentication on audio storage API routes and validate storage ownership and plan entitlements
- add shared helpers for resolving user plans/entitlements and structured HTTP errors
- attach Supabase access tokens to frontend audio upload/download/delete requests and propagate authorization failures to the UI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6902c6b20048832f8b1e884c63bb70d8