### PR TITLE
Ensure upload keys are unique

### DIFF
--- a/api/get-upload-url.js
+++ b/api/get-upload-url.js
@@ -56,8 +56,9 @@ export async function GET(request) {
       );
     }
 
-    const key = `${filename}`;
-    const url = new URL(`https://${R2_BUCKET_NAME}.${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/users/${userId}/${key}`);
+    const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    const generatedKey = `${uniqueSuffix}-${filename}`;
+    const url = new URL(`https://${R2_BUCKET_NAME}.${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/users/${userId}/${generatedKey}`);
     url.searchParams.set('X-Amz-Expires', '120');
 
     const signed = await client.sign(
@@ -65,13 +66,16 @@ export async function GET(request) {
       { aws: { signQuery: true } }
     );
 
-    return new Response(JSON.stringify({ signedUrl: signed.url, key: filename }), {
-      status: 200,
-      headers: {
-        ...corsHeaders,
-        'Content-Type': 'application/json',
-      },
-    });
+    return new Response(
+      JSON.stringify({ signedUrl: signed.url, key: generatedKey, displayName: filename }),
+      {
+        status: 200,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
   } catch (err) {
     console.error('💥 SIGNING ERROR:', err);
     return new Response(

--- a/src/components/ui/modals/SoundLibrary/UploadPanel.vue
+++ b/src/components/ui/modals/SoundLibrary/UploadPanel.vue
@@ -161,13 +161,13 @@ async function uploadAll() {
 
   const uploadPromises = files.value.map(file =>
     limit(async () => {
-      const key = await uploadAudio(file.raw, user.value.id, (percent) => {
-      file.progress = percent
-    })
+      const storageKey = await uploadAudio(file.raw, user.value.id, (percent) => {
+        file.progress = percent
+      })
       const duration = await getFileDuration(file.raw)
 
       await supabase.from('sound_files').insert({
-        path: key,
+        path: storageKey,
         name: file.name,
         bucket: user.value.id,
         duration_seconds: duration,

--- a/src/utils/uploadAudio.js
+++ b/src/utils/uploadAudio.js
@@ -5,14 +5,18 @@
  * @param {string} filename - original file name
  * @returns {Promise<{signedUrl: string, key: string}>}
  */
-async function getSignedUploadUrl(userId, filename) {
-  const params = new URLSearchParams({ userId, filename });
+async function getSignedUploadUrl(userId, displayName) {
+  const params = new URLSearchParams({ userId, filename: displayName });
   const res = await fetch(`/api/get-upload-url?${params.toString()}`);
   if (!res.ok) {
     const errorData = await res.json().catch(() => ({ error: 'Invalid JSON response' }));
     throw new Error(errorData.error || 'Failed to get signed upload URL');
   }
-  return await res.json();
+  const payload = await res.json();
+  if (!payload?.key || !payload?.signedUrl) {
+    throw new Error('Signed upload URL response is missing required fields');
+  }
+  return payload;
 }
 
 /**


### PR DESCRIPTION
## Summary
- generate a unique storage key before signing upload URLs and return it alongside the original filename
- harden the upload helper to validate the API response and use the server-generated key
- store the generated key when inserting new sound files so filenames remain for display without risking collisions

## Testing
- `npm run test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6902c6c1f758832fb635050f38d79c83