### PR TITLE
Improve upload key generation and error handling

### DIFF
--- a/api/get-upload-url.js
+++ b/api/get-upload-url.js
@@ -1,5 +1,46 @@
 import { AwsClient } from "aws4fetch";
 
+function sanitizeFilename(filename = "") {
+  const trimmed = filename.trim() || "file";
+  const normalized = trimmed.normalize("NFKD").replace(/[\u0300-\u036f]/g, "");
+  const lastDot = normalized.lastIndexOf(".");
+  const base = lastDot > 0 ? normalized.slice(0, lastDot) : normalized;
+  const extension = lastDot > 0 ? normalized.slice(lastDot) : "";
+  const safeBase = base
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "");
+  const finalBase = (safeBase.length > 0 ? safeBase.slice(0, 80) : "file").toLowerCase();
+  const safeExtension = extension
+    .replace(/[^.a-zA-Z0-9_-]+/g, "")
+    .slice(0, 16)
+    .toLowerCase();
+  return `${finalBase}${safeExtension}`;
+}
+
+function createRandomId() {
+  const cryptoObj = globalThis.crypto;
+
+  if (cryptoObj?.randomUUID) {
+    return cryptoObj.randomUUID().replace(/-/g, "");
+  }
+
+  if (cryptoObj?.getRandomValues) {
+    const bytes = new Uint32Array(3);
+    cryptoObj.getRandomValues(bytes);
+    return Array.from(bytes, (value) => value.toString(36)).join("");
+  }
+
+  return Math.random().toString(36).slice(2);
+}
+
+function generateObjectKey(filename) {
+  const timestamp = new Date().toISOString().replace(/[-:.TZ]/g, "");
+  const randomId = createRandomId().slice(0, 12);
+  const safeFilename = sanitizeFilename(filename);
+  return `${timestamp}-${randomId}-${safeFilename}`;
+}
+
 /**
  * API endpoint that signs a temporary upload URL for the R2 bucket.
  *
@@ -56,8 +97,8 @@ export async function GET(request) {
       );
     }
 
-    const key = `${filename}`;
-    const url = new URL(`https://${R2_BUCKET_NAME}.${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/users/${userId}/${key}`);
+    const generatedKey = generateObjectKey(filename);
+    const url = new URL(`https://${R2_BUCKET_NAME}.${R2_ACCOUNT_ID}.r2.cloudflarestorage.com/users/${userId}/${generatedKey}`);
     url.searchParams.set('X-Amz-Expires', '120');
 
     const signed = await client.sign(
@@ -65,13 +106,16 @@ export async function GET(request) {
       { aws: { signQuery: true } }
     );
 
-    return new Response(JSON.stringify({ signedUrl: signed.url, key: filename }), {
-      status: 200,
-      headers: {
-        ...corsHeaders,
-        'Content-Type': 'application/json',
-      },
-    });
+    return new Response(
+      JSON.stringify({ signedUrl: signed.url, key: generatedKey, displayName: filename }),
+      {
+        status: 200,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
   } catch (err) {
     console.error('💥 SIGNING ERROR:', err);
     return new Response(

--- a/src/components/ui/modals/SoundLibrary/UploadPanel.vue
+++ b/src/components/ui/modals/SoundLibrary/UploadPanel.vue
@@ -161,13 +161,13 @@ async function uploadAll() {
 
   const uploadPromises = files.value.map(file =>
     limit(async () => {
-      const key = await uploadAudio(file.raw, user.value.id, (percent) => {
-      file.progress = percent
-    })
+      const storageKey = await uploadAudio(file.raw, user.value.id, (percent) => {
+        file.progress = percent
+      })
       const duration = await getFileDuration(file.raw)
 
       await supabase.from('sound_files').insert({
-        path: key,
+        path: storageKey,
         name: file.name,
         bucket: user.value.id,
         duration_seconds: duration,

--- a/src/utils/uploadAudio.js
+++ b/src/utils/uploadAudio.js
@@ -5,14 +5,30 @@
  * @param {string} filename - original file name
  * @returns {Promise<{signedUrl: string, key: string}>}
  */
-async function getSignedUploadUrl(userId, filename) {
-  const params = new URLSearchParams({ userId, filename });
+async function getSignedUploadUrl(userId, displayName) {
+  const params = new URLSearchParams({ userId, filename: displayName });
   const res = await fetch(`/api/get-upload-url?${params.toString()}`);
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({ error: 'Invalid JSON response' }));
-    throw new Error(errorData.error || 'Failed to get signed upload URL');
+    let message = 'Failed to get signed upload URL';
+    const rawBody = await res.text().catch(() => '');
+
+    if (rawBody) {
+      try {
+        const errorData = JSON.parse(rawBody);
+        message = errorData?.error || errorData?.message || message;
+      } catch (parseError) {
+        message = rawBody;
+      }
+    }
+
+    throw new Error(message);
   }
-  return await res.json();
+
+  const payload = await res.json();
+  if (!payload?.key || !payload?.signedUrl) {
+    throw new Error('Signed upload URL response is missing required fields');
+  }
+  return payload;
 }
 
 /**


### PR DESCRIPTION
## Summary
- sanitize filenames and generate deterministic unique storage keys to prevent collisions and invalid characters
- prefer cryptographically strong randomness when available while keeping fallbacks for other runtimes
- surface detailed signing errors from the upload helper when the API response is invalid JSON

## Testing
- `npm run test:unit` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6902c6c1f758832fb635050f38d79c83