### PR TITLE
Document testing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ Planned next-phase upgrades:
    npm run build
    ```
 
+6. **Run the tests (optional)**
+   ```bash
+   # Run both unit and end-to-end suites
+   npm test
+
+   # Or run a single suite
+   npm run test:unit
+   npm run test:e2e
+   ```
+
 ---
 
 ## 🎮 Usage Overview

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,44 +1,79 @@
 # Project Architecture
 
-This document provides a high level overview of the major files and modules that power SoundRoom. It can be helpful when adding new features or refactoring existing logic.
+This document explains how the main SoundRoom subsystems fit together so new contributors can quickly reason about feature work. The focus is on **runtime flow**, **state boundaries**, and **key integration points** between audio, canvas rendering, and Supabase.
 
-## src/lib
+## High-level runtime
 
-- **AudioEngine.js** – Central manager for the Web Audio API. It owns the `AudioContext`, master gain, and a collection of `SoundSource` instances. The engine exposes helpers for loading sources, controlling playback, connecting to the optional reverb chain and serialising state for saving a room.
-- **SoundSource.js** – Thin wrapper around an `<audio>` element and the Web Audio nodes needed for spatialisation. Each source tracks its position, angle and scheduling information so that the visual canvas and audio stay in sync.
-- **Listener.js** – Represents the user's listening position in the room. It synchronises its orientation with the `AudioContext` listener so rotations and movements are heard correctly.
-- **ActionManager.js** – Provides undo and redo functionality. Actions are registered with handlers which are executed and stored on a stack for later reversal.
-- **SoundScheduler.js** – Handles interval based playback for sources that have a schedule enabled. It keeps track of timers and supports pausing/resuming when the engine is stopped.
-- **Room.js** – Simple container describing room dimensions and metadata with helper methods for clamping values and serialising to JSON.
+1. **Bootstrap** – `main.js` mounts the Vue app, registers the router, and wires global styles. The initial route loads `App.vue`, which renders layout chrome and the `SoundRoom` view.
+2. **Store initialisation** – Pinia stores eagerly construct the long-lived singletons (`AudioEngine`, `ActionManager`, `Listener`). They expose actions for loading sounds, mutating spatial data, and serialising the room.
+3. **Canvas + UI rendering** – Konva canvases render the spatial grid and directional cones while Tailwind-powered components handle panels, forms, and modals.
+4. **User interaction loop** – Keyboard shortcuts (`useKeyboardControls`) and pointer events dispatch store actions. Changes propagate to both the audio engine and canvas layer.
+5. **Persistence / external APIs** – Supabase provides the sound library and (future) scene persistence. Stripe environment variables are present for future monetisation flows.
 
+The diagram below summarises the major flows:
 
-## src/utils
+```
+User Input → Pinia Actions → Audio Engine + Canvas → UI Updates
+                     ↘ Supabase fetches / uploads ↙
+```
 
-- **router.js** – Sets up the application router and route guards. Routes for the modal based views (login, help, etc.) are nested under the root component.
-- **supabase.js** – Exposes a preconfigured Supabase client based on environment variables.
-- **resetRoomState.js** – Utility that disposes of all active audio objects and reinitialises the Pinia stores so a brand new room can be started.
+## Core libraries (`src/lib`)
 
-## src/composables
+| Module | Responsibility | Key Consumers |
+| --- | --- | --- |
+| **AudioEngine.js** | Manages the `AudioContext`, master gain, and the list of `SoundSource` instances. Provides lifecycle hooks (`start`, `stop`), scene serialisation, and impulse response wiring. | `useAudioEngineStore`, undo actions, scheduler |
+| **SoundSource.js** | Wraps `<audio>` elements with Panner/ Gain nodes. Stores spatial data (position, orientation, cone angles) and exposes mutations that synchronise visual + audio state. | Audio engine, canvas interactions |
+| **Listener.js** | Represents the listener transform. Keeps the `AudioContext.listener` node in sync with keyboard-driven movement/rotation. | `useListenerStore`, keyboard controls |
+| **ActionManager.js** | Command-pattern undo/redo stack. Stores closures for `do`/`undo` and broadcasts changes to interested components. | `useActionManagerStore`, toolbar/keyboard shortcuts |
+| **SoundScheduler.js** | Timer based playback for ambient loops. Handles pause/resume when the engine stops and recalculates offsets after seeking. | `useAudioEngineStore`, future automation UIs |
+| **Room.js** | Data container describing room size, background, and metadata. Includes helper guards to keep values within expected limits. | `useRoomStore`, save/load routines |
 
-- **useAuth.js** – Reactive wrapper around Supabase authentication providing `user`, `isAuthenticated` and `sessionLoaded` state used throughout the app.
-- **useKeyboardControls.js** – Manages global keyboard shortcuts for moving the listener and manipulating the currently selected sound source.
+These classes are intentionally framework-agnostic, enabling easier unit testing and potential reuse outside Vue.
 
-## src/stores
+## State management (`src/stores`)
 
-The application state is organised with [Pinia](https://pinia.vuejs.org/). Each store wraps a key class or concern from `src/lib`:
+SoundRoom relies on [Pinia](https://pinia.vuejs.org/) stores as the source of truth. Each store wraps a lib module and exposes a compact API surface to the rest of the app.
 
-- **useAudioEngineStore.js** – Holds the singleton `AudioEngine` instance and exposes helpers for loading data, connecting the Web Audio context and managing impulse responses.
-- **useListenerStore.js** – Wraps the `Listener` class and provides serialisation helpers.
-- **useActionManagerStore.js** – Provides a single `ActionManager` used for undo and redo across the app.
-- **useAudioCacheStore.js** – Tracks loaded audio buffers and sound library metadata.
-- **useCanvasStore.js** – Coordinates canvas scale and selected source state.
-- **useRoomStore.js** – Manages room metadata and serialises the entire session for saving to Supabase.
+- **useAudioEngineStore.js** – Instantiates the `AudioEngine`, fetches sound metadata, and orchestrates adding/removing `SoundSource`s. Also coordinates impulse response downloads.
+- **useListenerStore.js** – Wraps `Listener` and provides derived state (e.g., heading angles) consumed by UI panels.
+- **useActionManagerStore.js** – Singleton undo/redo stack. UI components push actions for keyboard or toolbar operations.
+- **useAudioCacheStore.js** – Keeps a cache of downloaded buffers and Supabase metadata to avoid refetching.
+- **useCanvasStore.js** – Tracks zoom level, canvas dimensions, and the currently selected sound source so Konva layers stay in sync.
+- **useRoomStore.js** – Owns the `Room` model plus session metadata (title, description). Serialises/deserialises room payloads for Supabase storage.
 
-## src/components
+Each store only mutates its local domain but can **listen to other stores** through actions. For example, when `useAudioEngineStore` removes a sound, it notifies `useCanvasStore` to clear selection.
 
-The UI is split between high level SoundRoom views and reusable UI primitives under `src/components/ui`.
+## Composables & utilities
 
-- **SoundRoom/** – Contains the main canvas and sidebars used when editing a room.
-- **ui/** – Buttons, inputs, modals and overlay components shared throughout the application.
+- **`src/composables/useAuth.js`** – Wraps Supabase auth state. Sets `sessionLoaded` once the client bootstraps to prevent UI flicker.
+- **`src/composables/useKeyboardControls.js`** – Registers global keyboard handlers. Delegates to `useListenerStore`, `useAudioEngineStore`, and `useActionManagerStore` for actual mutations.
+- **`src/utils/router.js`** – Configures routes for the root layout, SoundRoom editor, and modal overlays. Navigation guards ensure certain flows wait for Supabase auth.
+- **`src/utils/supabase.js`** – Creates the Supabase client using Vite env variables; shared by stores and composables that fetch audio libraries.
+- **`src/utils/resetRoomState.js`** – Centralised teardown that disposes audio nodes, clears timers, and resets Pinia stores. Used when loading a saved scene or signing out.
 
-Referencing these modules when adding features will help keep new code consistent with the existing structure.
+## UI composition (`src/components`)
+
+The UI is divided into two layers:
+
+1. **Feature views (`src/components/SoundRoom/`)** – Canvas, inspector panels, transport controls, and dialogs responsible for editing a room. They subscribe to Pinia stores and trigger undoable actions.
+2. **Primitive UI elements (`src/components/ui/`)** – Tailwind-based buttons, toggles, sliders, and dialog shells. These components are stateless and reusable across future features like onboarding or authentication flows.
+
+`SoundRoomCanvas.vue` sits at the centre of the feature layer. It binds Konva stages to store state, reflects selection outlines, and emits events when the user drags/rotates sources.
+
+## External integrations
+
+- **Supabase Storage** – Hosts the curated library of ambient sound files. Fetches happen through the audio engine store, which caches responses and passes object URLs to `SoundSource` instances.
+- **Stripe (planned)** – Environment variables are wired in but there is no live checkout flow. Keeping the config centralised makes it easier to turn on monetisation without touching core audio logic.
+- **GitHub Pages / Vercel** – Static output built by Vite. The configuration lives in `vercel.json` while GitHub Pages is used for the public demo.
+
+## Adding new features
+
+When introducing a feature, prefer the following workflow:
+
+1. **Identify the domain** – Does the change affect audio playback, canvas interactions, or metadata/persistence? Choose the corresponding Pinia store or create a new one wrapping a lib module.
+2. **Keep lib modules UI-agnostic** – Add pure functions or class methods inside `src/lib` first, then expose them through store actions.
+3. **Surface state via stores** – Components should only depend on store getters/actions. This keeps undo/redo integration straightforward.
+4. **Leverage ActionManager** – Any destructive or reversible operation should register a command with `useActionManagerStore` so keyboard shortcuts stay consistent.
+5. **Reset gracefully** – If the feature changes scene data, hook into `resetRoomState` to ensure switching sessions clears derived state and audio nodes.
+
+Adhering to this structure keeps the codebase modular and helps maintain parity between the visual canvas and audio experience.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -30,6 +30,21 @@ npm run build
 
 The compiled site will be output to the `dist/` directory.
 
+## Testing
+
+SoundRoom ships with configured test runners, although only a small number of
+assertions are in place today. You can run:
+
+```bash
+npm test        # run unit + end-to-end suites
+npm run test:unit
+npm run test:e2e
+```
+
+Playwright requires Chromium (installed automatically on first run) and will
+look for the dev server at `http://127.0.0.1:4173` when executing the production
+build tests.
+
 ## Project Structure Overview
 
 ```
@@ -47,6 +62,6 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for more detailed explanations of these f
 ## Tips
 
 - Restart the dev server if you add new environment variables.
-- The project currently has no automated tests, but Playwright is included for future end‑to‑end testing.
+- Playwright downloads browsers the first time you execute `npm run test:e2e`.
 
 Happy hacking!


### PR DESCRIPTION
## Summary
- document the npm scripts for running unit and end-to-end tests in the README setup section
- expand the development guide with testing instructions and tips for Playwright browser downloads
- expand the architecture guide with runtime, state, and integration details for the audio and canvas subsystems

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690b97b73668832f91c458d182015145