### PR TITLE
Allow unauthenticated playback of free-tier audio

### DIFF
--- a/api/get-signed-url.js
+++ b/api/get-signed-url.js
@@ -63,8 +63,18 @@ export async function GET(request) {
       throw new HttpError(400, "Missing 'key' query param")
     }
 
-    const { user } = await authenticateRequest(request)
-    const userAccess = await resolveUserAccessContext(user.id)
+    const authHeader =
+      request.headers.get('authorization') || request.headers.get('Authorization') || ''
+    const hasBearerToken = /^Bearer\s+\S+/.test(authHeader)
+
+    let user = null
+    let userAccess = { plan: 'free' }
+
+    if (hasBearerToken) {
+      const authResult = await authenticateRequest(request)
+      user = authResult.user
+      userAccess = await resolveUserAccessContext(user.id)
+    }
 
     const { base, bucket, objectPath } = parseStorageKey(key)
 
@@ -88,7 +98,8 @@ export async function GET(request) {
       throw new HttpError(404, 'Sound file not found')
     }
 
-    const isOwner = !!soundFile.owner_id && soundFile.owner_id === user.id
+    const userId = user?.id ?? null
+    const isOwner = !!soundFile.owner_id && soundFile.owner_id === userId
 
     if (soundFile.owner_id && !isOwner) {
       throw new HttpError(403, 'You do not have access to this file')

--- a/src/utils/downloadAudio.js
+++ b/src/utils/downloadAudio.js
@@ -31,14 +31,12 @@ export function buildStorageKey(base, bucket, path) {
 export async function fetchAudioBlob(key) {
   const token = await getAccessToken()
 
-  if (!token) {
-    throw new Error('You must be signed in to access audio files')
-  }
-
   const res = await fetch(`/api/get-signed-url?key=${encodeURIComponent(key)}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
+    headers: token
+      ? {
+          Authorization: `Bearer ${token}`,
+        }
+      : undefined,
   })
 
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- treat the bearer token as optional in the signed URL endpoint and gate non-free content by plan
- stop client-side downloads from throwing when no Supabase session is present so free files remain accessible

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691262da3060832fb5d1de9a5a5c5de8)