### PR TITLE
Guard canvas label positioning when stage ref missing

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -101,14 +101,19 @@ function updateCoords() {
 
 const soundNodeTitleCoords = computed(() => {
   coordsVersion.value // makes it reactive to window resize
-  return audioEngine.value.soundSources.value.map(sn => {          
-  const stagePos = stageDivRef.value.getBoundingClientRect();
-  return {
-        x: stagePos.left + sn.instance.state.x,
-        y: stagePos.top + sn.instance.state.y + 20, //20 is to account for directional arrow
-        name: sn.name
-      }
-});
+
+  const stageElement = stageDivRef.value
+  if (!stageElement) {
+    return []
+  }
+
+  const stagePos = stageElement.getBoundingClientRect()
+
+  return audioEngine.value.soundSources.value.map(sn => ({
+    x: stagePos.left + sn.instance.state.x,
+    y: stagePos.top + sn.instance.state.y + 20, //20 is to account for directional arrow
+    name: sn.name,
+  }))
 })
 
 


### PR DESCRIPTION
## Summary
- avoid calling getBoundingClientRect when the stage element has not yet mounted
- return no sound node labels until the stage reference is available to prevent runtime errors

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69126719cc18832faa1e92943cc7ec23)