### PR TITLE
Prevent modal routes from clearing the canvas

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -30,7 +30,7 @@
       <RouterView v-else v-slot="{ Component, route }">
         <Suspense>
           <template #default>
-            <ErrorBoundary :key="route.fullPath">
+            <ErrorBoundary :key="routeKey">
               <component v-if="Component" :is="Component" />
             </ErrorBoundary>
           </template>
@@ -53,7 +53,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { SpeedInsights } from '@vercel/speed-insights/vue'
 import HeaderBar from '@/components/SoundRoom/HeaderBar.vue'
@@ -67,6 +67,7 @@ const isMobile = isMobileBrowser()
 const globalError = ref(null)
 const router = useRouter()
 const route = useRoute()
+const routeKey = computed(() => route.matched[0]?.path ?? route.fullPath)
 
 router.onError((error, to) => {
   console.error('Router navigation error:', error)


### PR DESCRIPTION
## Summary
- keep the SoundRoom view mounted when navigating to modal routes by keying the error boundary with the parent route
- compute a stable route key so opening overlays no longer disposes of the audio engine and canvas

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69126831d860832f9430ae4031c2ad3d)