### PR TITLE
Keep SoundRoom state alive across settings navigation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -30,8 +30,10 @@
       <RouterView v-else v-slot="{ Component, route }">
         <Suspense>
           <template #default>
-            <ErrorBoundary :key="route.fullPath">
-              <component v-if="Component" :is="Component" />
+            <ErrorBoundary :reset-on="routeKey">
+              <KeepAlive :include="keepAliveViews">
+                <component v-if="Component" :is="Component" :key="routeKey" />
+              </KeepAlive>
             </ErrorBoundary>
           </template>
           <template #fallback>
@@ -53,7 +55,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { SpeedInsights } from '@vercel/speed-insights/vue'
 import HeaderBar from '@/components/SoundRoom/HeaderBar.vue'
@@ -67,6 +69,8 @@ const isMobile = isMobileBrowser()
 const globalError = ref(null)
 const router = useRouter()
 const route = useRoute()
+const routeKey = computed(() => route.matched[0]?.path ?? route.fullPath)
+const keepAliveViews = ['SoundRoom', 'SoundRoomView']
 
 router.onError((error, to) => {
   console.error('Router navigation error:', error)

--- a/src/components/ErrorBoundary.vue
+++ b/src/components/ErrorBoundary.vue
@@ -25,13 +25,28 @@
 </template>
 
 <script setup>
-import { ref, onErrorCaptured } from 'vue'
+import { ref, onErrorCaptured, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import BaseButton from '@/components/ui/input/BaseButton.vue'
 
+const DEFAULT_ERROR_MESSAGE = 'Something went wrong. Refresh the page to try again.'
 const hasError = ref(false)
-const errorMessage = ref('Something went wrong. Refresh the page to try again.')
+const errorMessage = ref(DEFAULT_ERROR_MESSAGE)
 const router = useRouter()
+const props = defineProps({
+  resetOn: {
+    type: [String, Number, Boolean],
+    default: null,
+  },
+})
+
+watch(
+  () => props.resetOn,
+  () => {
+    hasError.value = false
+    errorMessage.value = DEFAULT_ERROR_MESSAGE
+  }
+)
 
 function reloadPage() {
   window.location.reload()
@@ -39,13 +54,13 @@ function reloadPage() {
 
 function goHome() {
   hasError.value = false
-  errorMessage.value = 'Something went wrong. Refresh the page to try again.'
+  errorMessage.value = DEFAULT_ERROR_MESSAGE
   void router.push('/')
 }
 
 onErrorCaptured((error) => {
   hasError.value = true
-  errorMessage.value = error?.message ?? 'Something went wrong. Refresh the page to try again.'
+  errorMessage.value = error?.message ?? DEFAULT_ERROR_MESSAGE
   console.error('Captured UI error:', error)
   return false
 })


### PR DESCRIPTION
## Summary
- cache the SoundRoom view with KeepAlive so navigating to Settings no longer disposes the canvas
- reset the UI error boundary via a reactive prop instead of remounting it, preserving cached views while still clearing prior errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69126831d860832f9430ae4031c2ad3d)