### PR TITLE
Improve mobile responsiveness for SoundRoom

### DIFF
--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -21,12 +21,12 @@
   />
 
   <!-- Footer Buttons -->
-  <div class="relative flex items-center justify-between h-15 p-2">
-    <div class="flex space-x-3">
+  <div class="relative flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between p-3">
+    <div class="flex flex-wrap gap-3">
       <BaseButton
         @click="showSaveConfirm = true"
         :disabled="isSaving || !isRoomSaveable"
-        class="px-3 py-2 rounded bg-neutral-100 hover:bg-neutral-200 dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        class="px-4 py-3 min-h-[44px] min-w-[120px] rounded bg-neutral-100 hover:bg-neutral-200 dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         type="button"
         aria-label="Open save room confirmation"
       >
@@ -36,23 +36,24 @@
       <BaseButton
         @click="showNewRoomConfirm = true"
         :disabled="isSaving || isRoomEmpty"
-        class="px-3 py-2 rounded bg-neutral-100 hover:bg-neutral-200 dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        class="px-4 py-3 min-h-[44px] min-w-[120px] rounded bg-neutral-100 hover:bg-neutral-200 dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         type="button"
         aria-label="Open new room confirmation"
       >
         New Room +
       </BaseButton>
     </div>
-    <div class="absolute left-1/2 -translate-x-1/2">
+    <!-- Center the IR select inline on desktop while keeping it in flow on mobile -->
+    <div class="flex justify-center order-3 sm:order-none">
       <IRSelect />
     </div>
 
-    <div v-if="isAuthenticated" class="ml-auto">
+    <div v-if="isAuthenticated" class="flex justify-end">
       <RouterLink
         to="/room-manager"
         aria-label="Open Room Manager"
       >
-        <BaseButton class="w-full">
+        <BaseButton class="w-full px-4 py-3 min-h-[44px]">
           RoomManager
         </BaseButton>
       </RouterLink>

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -1,10 +1,11 @@
  <template>
+  <!-- touch-manipulation lets the canvas scroll while allowing Konva drag gestures -->
   <div
     ref="stageDivRef"
     role="application"
     tabindex="0"
     aria-label="SoundRoom 2D audio environment. Use keyboard or mouse to interact with sound nodes."
-    class="border-2 border-neutral-400 dark:border-neutral-700 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+    class="border-2 border-neutral-400 dark:border-neutral-700 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 touch-manipulation sm:touch-auto"
     :class="`w-[${room.width}px] h-[${room.height}px]`"
     @dragover.prevent
     @drop="handleDrop"

--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -32,7 +32,9 @@
       :fill="getFillColor"
       name="sound-node-part"
       @mousedown="onSourceMouseDown"
+      @touchstart="onSourceMouseDown"
       @mouseup="onSourceMouseUp"
+      @touchend="onSourceMouseUp"
       @mouseover="setCursor($event, 'pointer')"
       @mouseout="setCursor($event, 'default')"
     />
@@ -62,7 +64,9 @@
       stroke="#000"
       :strokeWidth="1"
       @mousedown="onSourceMouseDown"
+      @touchstart="onSourceMouseDown"
       @mouseup="onSourceMouseUp"
+      @touchend="onSourceMouseUp"
       @mouseover="setCursor($event, 'pointer')"
       @mouseout="setCursor($event, 'default')"
       name="sound-node-part"
@@ -79,7 +83,9 @@
       :rotation="source.instance.state.angle - 90 + 20"
       fill="transparent"
       @mousedown="onHandleMouseDown"
+      @touchstart="onHandleMouseDown"
       @mouseup="onHandleMouseUp"
+      @touchend="onHandleMouseUp"
       @mouseover="setCursor($event, 'pointer')"
       @mouseout="setCursor($event, 'default')"
       name="sound-node-part"
@@ -155,6 +161,7 @@ let initialSourceAngle = null
 function onSourceMouseDown(e) {
   emit('select', props.index) // select current SoundSourceNode to display in SelectSourcePanel.vue
   e.evt.stopPropagation()
+  e.evt.preventDefault()
 
   const stage = e.target.getStage()
   const mousePos = stage.getPointerPosition()
@@ -164,7 +171,11 @@ function onSourceMouseDown(e) {
   const group = e.target.getParent()
   group.draggable(true)
 
-  stage.on("mousemove.sourceDragDetect", () => {
+  // Listen for both mouse and touch move events so dragging works on touchscreens
+  const moveEvents = ["mousemove", "touchmove"]
+  const upEvents = ["mouseup", "touchend"]
+
+  const handleDragDetect = () => {
     const currentPos = stage.getPointerPosition()
     const dx = currentPos.x - mouseDownPos.x
     const dy = currentPos.y - mouseDownPos.y
@@ -173,18 +184,22 @@ function onSourceMouseDown(e) {
       isDragging = true
       group.startDrag()
     }
-  })
+  }
 
-  stage.on("mouseup.sourceDragDetect", () => {
-    stage.off("mousemove.sourceDragDetect")
-    stage.off("mouseup.sourceDragDetect")
+  moveEvents.forEach(evt => stage.on(`${evt}.sourceDragDetect`, handleDragDetect))
+
+  const handlePointerUp = (evt) => {
+    moveEvents.forEach(eventName => stage.off(`${eventName}.sourceDragDetect`))
+    upEvents.forEach(eventName => stage.off(`${eventName}.sourceDragDetect`))
 
     if (!isDragging) {
       group.draggable(false)
     }
 
-    onSourceMouseUp(e)
-  })
+    onSourceMouseUp(evt)
+  }
+
+  upEvents.forEach(evt => stage.on(`${evt}.sourceDragDetect`, handlePointerUp))
 
   moveSourcePayload = {
     index: props.index,
@@ -226,6 +241,7 @@ function onSourceMouseUp(e) {
 function onHandleMouseDown(e) {
   emit('select', props.index)
   e.evt.stopPropagation()
+  e.evt.preventDefault()
 
   initialSourceAngle = props.source.instance.state.angle
 
@@ -235,12 +251,16 @@ function onHandleMouseDown(e) {
   const dy = mousePos.y - props.source.instance.state.y
   initialMouseAngle = Math.atan2(dy, dx) * (180 / Math.PI)
 
-  stage.on("mousemove.sourceRotate", onHandleMouseMove)
-  stage.on("mouseup.sourceRotate", () => {
+  const moveEvents = ["mousemove", "touchmove"]
+  const upEvents = ["mouseup", "touchend"]
+
+  moveEvents.forEach(evt => stage.on(`${evt}.sourceRotate`, onHandleMouseMove))
+  const stopRotate = () => {
     onHandleMouseUp()
-    stage.off("mousemove.sourceRotate")
-    stage.off("mouseup.sourceRotate")
-  })
+    moveEvents.forEach(evt => stage.off(`${evt}.sourceRotate`))
+    upEvents.forEach(evt => stage.off(`${evt}.sourceRotate`))
+  }
+  upEvents.forEach(evt => stage.on(`${evt}.sourceRotate`, stopRotate))
 }
 
 function onHandleMouseMove(e) {

--- a/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
+++ b/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
@@ -1,12 +1,13 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-400 dark:border-neutral-800 p-4 space-y-6"
+    class="flex flex-col h-full w-full bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-400 dark:border-neutral-800 p-4 space-y-6"
     role="region"
     aria-labelledby="library-panel-label"
   >
     <h2 id="library-panel-label" class="sr-only">Sound Library Panel</h2>
 
-    <div class="min-h-[100px] max-h-3/5 overflow-hidden">
+    <!-- Allow the library to scroll independently on mobile while preserving desktop height cap -->
+    <div class="min-h-[100px] max-h-[50vh] sm:max-h-3/5 overflow-y-auto">
       <DraggableSourcePanel
         class="h-full"
         v-bind="{

--- a/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
+++ b/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full w-full bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-400 dark:border-neutral-800 p-4 space-y-6"
+    class="flex flex-col h-full w-full bg-neutral-200 dark:bg-neutral-900 border-b sm:border-b-0 sm:border-r border-neutral-400 dark:border-neutral-800 p-4 space-y-6"
     role="region"
     aria-labelledby="library-panel-label"
   >

--- a/src/components/SoundRoom/SidebarRight/SidebarRight.vue
+++ b/src/components/SoundRoom/SidebarRight/SidebarRight.vue
@@ -1,6 +1,7 @@
 <template>
+  <!-- Allow the inspector to scroll independently when panels stack on mobile -->
   <aside
-    class="flex flex-col h-full bg-neutral-100 dark:bg-neutral-900 border-l border-neutral-300 dark:border-neutral-800 p-4 space-y-4"
+    class="flex flex-col h-full w-full bg-neutral-100 dark:bg-neutral-900 border-l border-neutral-300 dark:border-neutral-800 p-4 space-y-4 overflow-y-auto"
     role="region"
     aria-labelledby="selected-sound-panel-label"
   >

--- a/src/components/SoundRoom/SidebarRight/SidebarRight.vue
+++ b/src/components/SoundRoom/SidebarRight/SidebarRight.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Allow the inspector to scroll independently when panels stack on mobile -->
   <aside
-    class="flex flex-col h-full w-full bg-neutral-100 dark:bg-neutral-900 border-l border-neutral-300 dark:border-neutral-800 p-4 space-y-4 overflow-y-auto"
+    class="flex flex-col h-full w-full bg-neutral-100 dark:bg-neutral-900 border-t sm:border-t-0 sm:border-l border-neutral-300 dark:border-neutral-800 p-4 space-y-4 overflow-y-auto"
     role="region"
     aria-labelledby="selected-sound-panel-label"
   >

--- a/src/components/SoundRoom/Toolbar.vue
+++ b/src/components/SoundRoom/Toolbar.vue
@@ -1,26 +1,29 @@
 <template>
-  <div class="flex items-center justify-between p-3 border-neutral-300 dark:border-neutral-800 bg-neutral-100 dark:bg-neutral-900 space-x-10 w-full">
-          
-    <div class="flex space-x-2 w-1/3">
+  <div
+    class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between p-3 border-neutral-300 dark:border-neutral-800 bg-neutral-100 dark:bg-neutral-900 w-full"
+  >
+
+    <!-- Button row stacks on small screens to keep tap targets large -->
+    <div class="flex flex-wrap gap-3 w-full sm:w-auto">
       <BaseButton
       :disabled="audioEngine.soundSources.value.length === 0"
       @click="isPlaying ? audioEngine.pauseAll() : audioEngine.playAll()"
-      class="px-3 py-1 rounded text-sm bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700"
-      > 
-        
+      class="flex items-center justify-center min-w-[44px] min-h-[44px] rounded-full bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700"
+      >
+
         <component :is="isPlaying ? Pause : Play" class="h-4 w-4 fill-black dark:fill-white" />
       </BaseButton>
       <BaseButton
         :disabled="actionStackEmpty || waiting"
         @click="actionManager.undoLastAction"
-        class="px-3 py-1 rounded text-sm bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700"
+        class="flex items-center justify-center min-w-[44px] min-h-[44px] rounded-full bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700"
       >
         <UndoRedo class="h-4 w-4 fill-black dark:fill-white"/>
       </BaseButton>
       <BaseButton
         :disabled="redoStackEmpty || waiting"
         @click="actionManager.redoLastAction"
-        class="px-3 py-1 rounded text-sm bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700"
+        class="flex items-center justify-center min-w-[44px] min-h-[44px] rounded-full bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700"
       >
         <UndoRedo class="h-4 w-4 scale-x-[-1] fill-black dark:fill-white"/>
       </BaseButton>
@@ -29,21 +32,22 @@
       v-if="isAuthenticated"
       :roomId="room.id"
       :name="room.name"
-      class="w-1/3"
+      class="w-full sm:w-1/3"
       @updated="handleRoomNameUpdate"
     />
-    <div class="flex items-center justify-center space-x-2 w-1/3">
-     
+    <!-- Master slider drops below controls on mobile to prevent crowding -->
+    <div class="flex items-center justify-between gap-3 w-full sm:w-1/3">
+
       <span class="text-xs text-neutral-500">Master</span>
-      <VueSlider 
+      <VueSlider
         v-model="audioEngine.masterVolume.value"
         :min="0" 
         :max="1" 
         :interval="0.01"
-        :width="100"
+        :width="140"
         :height="4"
         tooltip="none"
-        class="mr-3"
+        class="flex-1"
       />
     </div>
   </div>

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -1,46 +1,55 @@
 <template>
   <div class="h-full bg-white text-neutral-900 dark:bg-neutral-950 dark:text-white flex flex-col">
     <!-- Main Layout -->
-    <div class="flex flex-1 overflow-hidden">
+    <div
+      class="flex flex-1 overflow-y-auto sm:overflow-hidden flex-col sm:flex-row"
+    >
+      <!-- Stack panels vertically on mobile to prevent overlap -->
 
       <!-- Left Sidebar -->
-      <SidebarLeft 
-        class="min-w-[7.5rem] max-w-64 w-[20%] flex-shrink"
+      <SidebarLeft
+        class="w-full sm:w-[20%] min-w-[7.5rem] max-w-64 flex-shrink-0 border-b sm:border-b-0"
         :MAX_SOURCES="MAX_LIB_SOURCES"
         :handleDragStart="handleDragStart"
         :listener="listener"
       />
 
       <!-- Canvas + Controls -->
-      <main class="flex-1 flex flex-col">
+      <main class="flex-1 flex flex-col min-h-[20rem]">
         <!-- Toolbar -->
         <Toolbar/>
 
         <!-- Canvas Area -->
-        <div class="flex-1 bg-neutral-200 dark:bg-black flex items-center justify-center">
-          <MainCanvasStage
-            v-bind="{
-              handleDrop,
-              onKeyDown,
-              onKeyUp,
-              contextMenuActions,
-              showContextMenu,
-              selectedIndex,
-              handleStageClick
-            }"
-            @selectNode="e => { selectedIndex = e }"
-          />
+        <div class="flex-1 bg-neutral-200 dark:bg-black relative flex flex-col">
+          <!-- Scrollable canvas wrapper for small screens -->
+          <div class="flex-1 overflow-y-auto overflow-x-auto sm:overflow-visible overscroll-contain">
+            <div class="min-h-full flex items-center justify-center p-4 sm:p-6">
+              <MainCanvasStage
+                class="shrink-0"
+                v-bind="{
+                  handleDrop,
+                  onKeyDown,
+                  onKeyUp,
+                  contextMenuActions,
+                  showContextMenu,
+                  selectedIndex,
+                  handleStageClick
+                }"
+                @selectNode="e => { selectedIndex = e }"
+              />
+            </div>
+          </div>
           <!-- Frosted Load/Save Overlay -->
-           <PulsingOverlay
+          <PulsingOverlay
             v-if="isLoadingRoom || isSavingRoom"
             :text="isLoadingRoom ? 'Loading your room...' : 'Saving your room...'"
-            />
+          />
         </div>
       </main>
 
       <!-- Right Sidebar -->
       <SidebarRight
-        class="min-w-[7.5rem] max-w-64 w-[20%] flex-shrink"
+        class="w-full sm:w-[20%] min-w-[7.5rem] max-w-64 flex-shrink-0 border-t sm:border-t-0"
         v-bind="{
           selectedSource
         }"

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -1,14 +1,63 @@
 <template>
   <div class="h-full bg-white text-neutral-900 dark:bg-neutral-950 dark:text-white flex flex-col">
+    <Transition name="mobile-panel">
+      <div
+        v-if="mobilePanel"
+        class="sm:hidden fixed inset-0 z-40 flex flex-col justify-end pointer-events-none"
+      >
+        <button
+          type="button"
+          class="absolute inset-0 w-full h-full bg-black/40 pointer-events-auto"
+          aria-label="Close mobile panel overlay"
+          @click="toggleMobilePanel(null)"
+        ></button>
+        <div
+          class="relative pointer-events-auto bg-white dark:bg-neutral-950 rounded-t-3xl shadow-2xl border border-neutral-200 dark:border-neutral-800"
+        >
+          <div class="flex items-center justify-between px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
+            <p class="text-sm font-semibold">
+              {{ mobilePanel === 'library' ? 'Sound Library' : 'Sound Settings' }}
+            </p>
+            <button
+              type="button"
+              class="min-h-[44px] px-3 text-sm font-medium text-blue-600 dark:text-blue-400"
+              @click="toggleMobilePanel(null)"
+            >
+              Close
+            </button>
+          </div>
+          <div
+            :key="mobilePanel"
+            class="overflow-y-auto max-h-[70vh]"
+          >
+            <SidebarLeft
+              v-if="mobilePanel === 'library'"
+              id="mobile-library-panel"
+              class="border-0 rounded-t-3xl"
+              :MAX_SOURCES="MAX_LIB_SOURCES"
+              :handleDragStart="handleDragStart"
+              :listener="listener"
+            />
+            <SidebarRight
+              v-else
+              id="mobile-inspector-panel"
+              class="border-0 rounded-t-3xl"
+              v-bind="{
+                selectedSource
+              }"
+            />
+          </div>
+        </div>
+      </div>
+    </Transition>
+
     <!-- Main Layout -->
     <div
       class="flex flex-1 overflow-y-auto sm:overflow-hidden flex-col sm:flex-row"
     >
-      <!-- Stack panels vertically on mobile to prevent overlap -->
-
-      <!-- Left Sidebar -->
+      <!-- Desktop left sidebar -->
       <SidebarLeft
-        class="w-full sm:w-[20%] min-w-[7.5rem] max-w-64 flex-shrink-0 border-b sm:border-b-0"
+        class="hidden sm:flex sm:w-[20%] min-w-[7.5rem] max-w-64 flex-shrink-0"
         :MAX_SOURCES="MAX_LIB_SOURCES"
         :handleDragStart="handleDragStart"
         :listener="listener"
@@ -16,6 +65,38 @@
 
       <!-- Canvas + Controls -->
       <main class="flex-1 flex flex-col min-h-[20rem]">
+        <!-- Mobile panel toggles -->
+        <div class="sm:hidden border-b border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 px-4 py-3 flex gap-3 sticky top-0 z-10">
+          <button
+            type="button"
+            class="flex-1 min-h-[44px] rounded-full border text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            :class="[
+              mobilePanel === 'library'
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-transparent border-neutral-300 text-neutral-900 dark:text-white dark:border-neutral-700'
+            ]"
+            aria-controls="mobile-library-panel"
+            :aria-expanded="mobilePanel === 'library'"
+            @click="toggleMobilePanel('library')"
+          >
+            Library
+          </button>
+          <button
+            type="button"
+            class="flex-1 min-h-[44px] rounded-full border text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            :class="[
+              mobilePanel === 'inspector'
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-transparent border-neutral-300 text-neutral-900 dark:text-white dark:border-neutral-700'
+            ]"
+            aria-controls="mobile-inspector-panel"
+            :aria-expanded="mobilePanel === 'inspector'"
+            @click="toggleMobilePanel('inspector')"
+          >
+            Inspector
+          </button>
+        </div>
+
         <!-- Toolbar -->
         <Toolbar/>
 
@@ -47,9 +128,9 @@
         </div>
       </main>
 
-      <!-- Right Sidebar -->
+      <!-- Desktop right sidebar -->
       <SidebarRight
-        class="w-full sm:w-[20%] min-w-[7.5rem] max-w-64 flex-shrink-0 border-t sm:border-t-0"
+        class="hidden sm:flex sm:w-[20%] min-w-[7.5rem] max-w-64 flex-shrink-0"
         v-bind="{
           selectedSource
         }"
@@ -76,7 +157,7 @@
 defineOptions({
   name: 'SoundRoomRoot',
 })
-import { ref, provide, onBeforeMount, onUnmounted } from 'vue'
+import { ref, provide, onBeforeMount, onMounted, onUnmounted, watch } from 'vue'
 
 // Shared constants
 const SOUND_NODE_PART_NAME = 'sound-node-part'
@@ -109,6 +190,10 @@ import { storeToRefs } from 'pinia'
 // State
 const selectedIndex = ref(null)
 const draggedSource = ref(null)
+const mobilePanel = ref(null)
+const isDesktopViewport = ref(false)
+let desktopViewportQuery
+let desktopViewportHandler
 
 const roomStore = useRoomStore()
 const listenerStore = useListenerStore()
@@ -198,6 +283,40 @@ onBeforeMount(async () => {
   roomStore.getSaveSnapshot({ markAsInitial: true }) // Initialize stored snapshots for save/empty comparisons
 })
 
+onMounted(() => {
+  if (typeof window === 'undefined' || !('matchMedia' in window)) {
+    return
+  }
+
+  desktopViewportQuery = window.matchMedia('(min-width: 640px)')
+
+  desktopViewportHandler = (event) => {
+    isDesktopViewport.value = event.matches
+    if (event.matches) {
+      mobilePanel.value = null
+      if (typeof document !== 'undefined') {
+        document.body.style.overflow = ''
+      }
+    }
+  }
+
+  desktopViewportHandler(desktopViewportQuery)
+  desktopViewportQuery.addEventListener('change', desktopViewportHandler)
+})
+
+watch(mobilePanel, (panel) => {
+  if (typeof document === 'undefined') return
+  if (isDesktopViewport.value) {
+    document.body.style.overflow = ''
+    return
+  }
+  document.body.style.overflow = panel ? 'hidden' : ''
+})
+
+function toggleMobilePanel(panel) {
+  mobilePanel.value = mobilePanel.value === panel ? null : panel
+}
+
 onUnmounted(() => {
   unregisterSoundRoomActions()
   audioEngine.value.dispose()
@@ -205,5 +324,24 @@ onUnmounted(() => {
   cacheStore.audioCacheManager.clearMemoryCache()
   // Uncomment to also wipe IndexedDB cache if long-term storage isn't desired
   // void cacheStore.audioCacheManager.clearPersistentCache()
+  if (desktopViewportQuery && desktopViewportHandler) {
+    desktopViewportQuery.removeEventListener('change', desktopViewportHandler)
+  }
+  if (typeof document !== 'undefined') {
+    document.body.style.overflow = ''
+  }
 })
 </script>
+
+<style scoped>
+.mobile-panel-enter-active,
+.mobile-panel-leave-active {
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.mobile-panel-enter-from,
+.mobile-panel-leave-to {
+  opacity: 0;
+  transform: translateY(1rem);
+}
+</style>

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -2,7 +2,7 @@
   <div class="h-full bg-white text-neutral-900 dark:bg-neutral-950 dark:text-white flex flex-col">
     <Transition name="mobile-panel">
       <div
-        v-if="mobilePanel"
+        v-if="isMobile && mobilePanel"
         class="sm:hidden fixed inset-0 z-40 flex flex-col justify-end pointer-events-none"
       >
         <button
@@ -66,7 +66,10 @@
       <!-- Canvas + Controls -->
       <main class="flex-1 flex flex-col min-h-[20rem]">
         <!-- Mobile panel toggles -->
-        <div class="sm:hidden border-b border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 px-4 py-3 flex gap-3 sticky top-0 z-10">
+        <div
+          v-if="isMobile"
+          class="sm:hidden border-b border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 px-4 py-3 flex gap-3 sticky top-0 z-10"
+        >
           <button
             type="button"
             class="flex-1 min-h-[44px] rounded-full border text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
@@ -170,6 +173,7 @@ import MainCanvasStage from '@/components/SoundRoom/MainCanvasStage/MainCanvasSt
 import FooterBar from '@/components/SoundRoom/FooterBar.vue'
 import PulsingOverlay from '@/components/ui/overlays/PulsingOverlay.vue'
 import WelcomeOverlay from '@/components/ui/overlays/WelcomeOverlay.vue'
+import { isMobileBrowser } from '@/utils/device'
 
 // Store
 import { useRoomStore } from '@/stores/useRoomStore'
@@ -194,6 +198,7 @@ const mobilePanel = ref(null)
 const isDesktopViewport = ref(false)
 let desktopViewportQuery
 let desktopViewportHandler
+const isMobile = isMobileBrowser()
 
 const roomStore = useRoomStore()
 const listenerStore = useListenerStore()
@@ -284,7 +289,7 @@ onBeforeMount(async () => {
 })
 
 onMounted(() => {
-  if (typeof window === 'undefined' || !('matchMedia' in window)) {
+  if (!isMobile || typeof window === 'undefined' || !('matchMedia' in window)) {
     return
   }
 
@@ -305,7 +310,7 @@ onMounted(() => {
 })
 
 watch(mobilePanel, (panel) => {
-  if (typeof document === 'undefined') return
+  if (!isMobile || typeof document === 'undefined') return
   if (isDesktopViewport.value) {
     document.body.style.overflow = ''
     return
@@ -314,6 +319,7 @@ watch(mobilePanel, (panel) => {
 })
 
 function toggleMobilePanel(panel) {
+  if (!isMobile) return
   mobilePanel.value = mobilePanel.value === panel ? null : panel
 }
 
@@ -324,11 +330,13 @@ onUnmounted(() => {
   cacheStore.audioCacheManager.clearMemoryCache()
   // Uncomment to also wipe IndexedDB cache if long-term storage isn't desired
   // void cacheStore.audioCacheManager.clearPersistentCache()
-  if (desktopViewportQuery && desktopViewportHandler) {
-    desktopViewportQuery.removeEventListener('change', desktopViewportHandler)
-  }
-  if (typeof document !== 'undefined') {
-    document.body.style.overflow = ''
+  if (isMobile) {
+    if (desktopViewportQuery && desktopViewportHandler) {
+      desktopViewportQuery.removeEventListener('change', desktopViewportHandler)
+    }
+    if (typeof document !== 'undefined') {
+      document.body.style.overflow = ''
+    }
   }
 })
 </script>


### PR DESCRIPTION
## Summary
- make the SoundRoom layout stack vertically on small screens and add scrollable canvas padding so panels no longer overlap
- enlarge key controls (toolbar, footer) and add touch-friendly spacing plus mobile fallbacks for the sidebars and canvas stage
- add touch event handling for sound source dragging/rotation so interactions continue to work on touch devices

## Testing
- `npm run build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c14306594832fa0ca77a4a91fad82)