### PR TITLE
Add responsive mobile layout for SoundRoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <!-- Primary Meta -->
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>SoundRoom</title>
   <meta name="description" content="Build immersive 3D soundscapes in your browser with SoundRoom. Drag, design, and save spatial audio scenes anytime." />
   <meta name="author" content="Zaria Burton" />

--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -21,8 +21,8 @@
   />
 
   <!-- Footer Buttons -->
-  <div class="relative flex items-center justify-between h-15 p-2">
-    <div class="flex space-x-3">
+  <div class="relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between border-t border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 px-4 py-3">
+    <div class="flex flex-wrap items-center justify-center gap-3 md:justify-start">
       <BaseButton
         @click="showSaveConfirm = true"
         :disabled="isSaving || !isRoomSaveable"
@@ -43,11 +43,15 @@
         New Room +
       </BaseButton>
     </div>
-    <div class="absolute left-1/2 -translate-x-1/2">
+    <div class="flex justify-center md:hidden">
       <IRSelect />
     </div>
 
-    <div v-if="isAuthenticated" class="ml-auto">
+    <div class="hidden md:block absolute left-1/2 -translate-x-1/2">
+      <IRSelect />
+    </div>
+
+    <div v-if="isAuthenticated" class="flex justify-center md:justify-end">
       <RouterLink
         to="/room-manager"
         aria-label="Open Room Manager"
@@ -58,7 +62,7 @@
       </RouterLink>
     </div>
   </div>
-  
+
 </template>
 
 <script setup>

--- a/src/components/SoundRoom/MobileToolbar.vue
+++ b/src/components/SoundRoom/MobileToolbar.vue
@@ -1,0 +1,61 @@
+<template>
+  <section class="w-full rounded-2xl bg-neutral-100/80 dark:bg-neutral-900/80 backdrop-blur border border-neutral-200 dark:border-neutral-800 p-4 shadow-sm space-y-4">
+    <div class="flex items-center justify-center gap-4 text-neutral-900 dark:text-white">
+      <BaseButton
+        :disabled="audioEngine.soundSources.value.length === 0"
+        @click="isPlaying ? audioEngine.pauseAll() : audioEngine.playAll()"
+        class="w-12 h-12 rounded-full bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 flex items-center justify-center"
+        :aria-label="isPlaying ? 'Pause playback' : 'Play all sources'"
+      >
+        <component :is="isPlaying ? Pause : Play" class="h-5 w-5 fill-black dark:fill-white" />
+      </BaseButton>
+
+      <BaseButton
+        :disabled="actionStackEmpty || waiting"
+        @click="actionManager.undoLastAction"
+        class="w-12 h-12 rounded-full bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 flex items-center justify-center"
+        aria-label="Undo last action"
+      >
+        <UndoRedo class="h-5 w-5 fill-black dark:fill-white" />
+      </BaseButton>
+
+      <BaseButton
+        :disabled="redoStackEmpty || waiting"
+        @click="actionManager.redoLastAction"
+        class="w-12 h-12 rounded-full bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 flex items-center justify-center"
+        aria-label="Redo last action"
+      >
+        <UndoRedo class="h-5 w-5 scale-x-[-1] fill-black dark:fill-white" />
+      </BaseButton>
+    </div>
+
+    <div class="space-y-2">
+      <label class="block text-xs uppercase tracking-wide text-neutral-500">Master Volume</label>
+      <VueSlider
+        v-model="audioEngine.masterVolume.value"
+        :min="0"
+        :max="1"
+        :interval="0.01"
+        :height="4"
+        tooltip="none"
+        class="w-full"
+      />
+    </div>
+  </section>
+</template>
+
+<script setup>
+import BaseButton from '@/components/ui/input/BaseButton.vue'
+import UndoRedo from '@/assets/icons/undo-redo.svg'
+import Pause from '@/assets/icons/pause.svg'
+import Play from '@/assets/icons/play.svg'
+import VueSlider from 'vue-3-slider-component'
+import { useAudioEngineStore } from '@/stores/useAudioEngineStore'
+import { useActionManagerStore } from '@/stores/useActionManagerStore'
+import { storeToRefs } from 'pinia'
+
+const engineStore = useAudioEngineStore()
+const actionStore = useActionManagerStore()
+const { audioEngine, isPlaying } = storeToRefs(engineStore)
+const { actionManager, actionStackEmpty, redoStackEmpty, waiting } = storeToRefs(actionStore)
+</script>

--- a/src/components/SoundRoom/SelectedSourceDrawer.vue
+++ b/src/components/SoundRoom/SelectedSourceDrawer.vue
@@ -1,0 +1,48 @@
+<template>
+  <Transition
+    enter-active-class="transform transition ease-out duration-300"
+    enter-from-class="translate-y-full opacity-0"
+    enter-to-class="translate-y-0 opacity-100"
+    leave-active-class="transform transition ease-in duration-200"
+    leave-from-class="translate-y-0 opacity-100"
+    leave-to-class="translate-y-full opacity-0"
+  >
+    <div
+      v-if="selectedSource"
+      class="md:hidden fixed inset-x-0 bottom-24 z-30 px-4 pointer-events-none"
+      aria-live="polite"
+    >
+      <div class="pointer-events-auto rounded-3xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 shadow-xl overflow-hidden">
+        <div class="flex items-center justify-between px-4 py-3 border-b border-neutral-200 dark:border-neutral-800">
+          <span class="text-sm font-semibold">Selected Source</span>
+          <button
+            type="button"
+            class="text-xs text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-200"
+            @click="$emit('close')"
+          >
+            Close
+          </button>
+        </div>
+        <div class="max-h-[60vh] overflow-y-auto">
+          <SidebarRight
+            class="w-full"
+            v-bind="{ selectedSource }"
+          />
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<script setup>
+import SidebarRight from '@/components/SoundRoom/SidebarRight/SidebarRight.vue'
+
+defineProps({
+  selectedSource: {
+    type: Object,
+    default: null
+  }
+})
+
+defineEmits(['close'])
+</script>

--- a/src/components/SoundRoom/SourceDrawer.vue
+++ b/src/components/SoundRoom/SourceDrawer.vue
@@ -1,0 +1,54 @@
+<template>
+  <section class="w-full">
+    <button
+      type="button"
+      class="w-full flex items-center justify-between rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900 px-4 py-3 text-left font-medium"
+      :aria-expanded="open"
+      @click="toggleDrawer"
+    >
+      <span>Sound Sources</span>
+      <span class="text-xs text-neutral-500">{{ open ? 'Hide' : 'Show' }}</span>
+    </button>
+    <Transition
+      enter-active-class="transition-all duration-300 ease-out"
+      enter-from-class="opacity-0 -translate-y-2"
+      enter-to-class="opacity-100 translate-y-0"
+      leave-active-class="transition-all duration-200 ease-in"
+      leave-from-class="opacity-100 translate-y-0"
+      leave-to-class="opacity-0 -translate-y-2"
+    >
+      <div
+        v-if="open"
+        class="mt-3 rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 shadow-md overflow-hidden"
+      >
+        <div class="max-h-[55vh] overflow-y-auto">
+          <SidebarLeft
+            class="w-full"
+            v-bind="{
+              MAX_SOURCES,
+              handleDragStart,
+              listener
+            }"
+          />
+        </div>
+      </div>
+    </Transition>
+  </section>
+</template>
+
+<script setup>
+import SidebarLeft from '@/components/SoundRoom/SidebarLeft/SidebarLeft.vue'
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  MAX_SOURCES: { type: Number, required: true },
+  handleDragStart: { type: Function, required: true },
+  listener: { type: Object, default: null }
+})
+
+const emit = defineEmits(['update:open'])
+
+function toggleDrawer() {
+  emit('update:open', !props.open)
+}
+</script>

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="h-full bg-white text-neutral-900 dark:bg-neutral-950 dark:text-white flex flex-col">
     <!-- Main Layout -->
-    <div class="flex-1 flex flex-col overflow-hidden">
-      <div class="flex flex-1 flex-col md:flex-row overflow-hidden">
+    <div class="flex-1 flex flex-col overflow-y-auto md:overflow-hidden">
+      <div class="flex flex-col md:flex-row md:flex-1 md:overflow-hidden">
 
         <!-- Left Sidebar (Desktop) -->
         <SidebarLeft
@@ -13,14 +13,14 @@
         />
 
         <!-- Canvas + Controls -->
-        <main class="flex-1 flex flex-col order-2 md:order-none">
+        <main class="flex flex-col order-2 md:order-none md:flex-1">
           <!-- Toolbar (Desktop) -->
           <div class="hidden md:block">
             <Toolbar />
           </div>
 
           <!-- Canvas Area -->
-          <div class="relative flex-1 bg-neutral-200 dark:bg-black">
+          <div class="relative md:flex-1 bg-neutral-200 dark:bg-black">
             <div
               class="flex h-[80vh] min-h-[70vh] max-h-[90vh] w-full items-center justify-center overflow-auto touch-pan-y touch-pinch-zoom md:h-full md:min-h-0 md:max-h-none md:overflow-hidden"
             >

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -1,51 +1,80 @@
 <template>
   <div class="h-full bg-white text-neutral-900 dark:bg-neutral-950 dark:text-white flex flex-col">
     <!-- Main Layout -->
-    <div class="flex flex-1 overflow-hidden">
+    <div class="flex-1 flex flex-col overflow-hidden">
+      <div class="flex flex-1 flex-col md:flex-row overflow-hidden">
 
-      <!-- Left Sidebar -->
-      <SidebarLeft 
-        class="min-w-[7.5rem] max-w-64 w-[20%] flex-shrink"
-        :MAX_SOURCES="MAX_LIB_SOURCES"
-        :handleDragStart="handleDragStart"
-        :listener="listener"
-      />
+        <!-- Left Sidebar (Desktop) -->
+        <SidebarLeft
+          class="hidden md:flex min-w-[7.5rem] max-w-64 w-[20%] flex-shrink"
+          :MAX_SOURCES="MAX_LIB_SOURCES"
+          :handleDragStart="handleDragStart"
+          :listener="listener"
+        />
 
-      <!-- Canvas + Controls -->
-      <main class="flex-1 flex flex-col">
-        <!-- Toolbar -->
-        <Toolbar/>
+        <!-- Canvas + Controls -->
+        <main class="flex-1 flex flex-col order-2 md:order-none">
+          <!-- Toolbar (Desktop) -->
+          <div class="hidden md:block">
+            <Toolbar />
+          </div>
 
-        <!-- Canvas Area -->
-        <div class="flex-1 bg-neutral-200 dark:bg-black flex items-center justify-center">
-          <MainCanvasStage
-            v-bind="{
-              handleDrop,
-              onKeyDown,
-              onKeyUp,
-              contextMenuActions,
-              showContextMenu,
-              selectedIndex,
-              handleStageClick
-            }"
-            @selectNode="e => { selectedIndex = e }"
-          />
-          <!-- Frosted Load/Save Overlay -->
-           <PulsingOverlay
-            v-if="isLoadingRoom || isSavingRoom"
-            :text="isLoadingRoom ? 'Loading your room...' : 'Saving your room...'"
+          <!-- Canvas Area -->
+          <div class="relative flex-1 bg-neutral-200 dark:bg-black">
+            <div
+              class="flex h-[80vh] min-h-[70vh] max-h-[90vh] w-full items-center justify-center overflow-auto touch-pan-y touch-pinch-zoom md:h-full md:min-h-0 md:max-h-none md:overflow-hidden"
+            >
+              <MainCanvasStage
+                v-bind="{
+                  handleDrop,
+                  onKeyDown,
+                  onKeyUp,
+                  contextMenuActions,
+                  showContextMenu,
+                  selectedIndex,
+                  handleStageClick
+                }"
+                @selectNode="e => {
+                  selectedIndex = e
+                }"
+              />
+            </div>
+            <!-- Frosted Load/Save Overlay -->
+            <PulsingOverlay
+              v-if="isLoadingRoom || isSavingRoom"
+              :text="isLoadingRoom ? 'Loading your room...' : 'Saving your room...'"
             />
-        </div>
-      </main>
+          </div>
 
-      <!-- Right Sidebar -->
-      <SidebarRight
-        class="min-w-[7.5rem] max-w-64 w-[20%] flex-shrink"
-        v-bind="{
-          selectedSource
-        }"
-      />
+          <!-- Mobile Controls -->
+          <div class="md:hidden flex flex-col gap-4 border-t border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 p-4">
+            <MobileToolbar />
+            <SourceDrawer
+              v-model:open="isSourceDrawerOpen"
+              :MAX_SOURCES="MAX_LIB_SOURCES"
+              :handleDragStart="handleDragStart"
+              :listener="listener"
+            />
+          </div>
+        </main>
+
+        <!-- Right Sidebar (Desktop) -->
+        <SidebarRight
+          class="hidden md:flex min-w-[7.5rem] max-w-64 w-[20%] flex-shrink"
+          v-bind="{
+            selectedSource
+          }"
+        />
+      </div>
     </div>
+
+    <SelectedSourceDrawer
+      v-if="selectedSource"
+      class="md:hidden"
+      :selected-source="selectedSource"
+      @close="selectedIndex = null"
+    />
+
     <FooterBar
       :on-save="saveRoom"
       v-bind="{ isSaving: isSavingRoom }"
@@ -74,8 +103,11 @@ const SOUND_NODE_PART_NAME = 'sound-node-part'
 
 // UI Components
 import Toolbar from '@/components/SoundRoom/Toolbar.vue'
+import MobileToolbar from '@/components/SoundRoom/MobileToolbar.vue'
 import SidebarLeft from '@/components/SoundRoom/SidebarLeft/SidebarLeft.vue'
 import SidebarRight from '@/components/SoundRoom/SidebarRight/SidebarRight.vue'
+import SourceDrawer from '@/components/SoundRoom/SourceDrawer.vue'
+import SelectedSourceDrawer from '@/components/SoundRoom/SelectedSourceDrawer.vue'
 import MainCanvasStage from '@/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue'
 import FooterBar from '@/components/SoundRoom/FooterBar.vue'
 import PulsingOverlay from '@/components/ui/overlays/PulsingOverlay.vue'
@@ -100,6 +132,7 @@ import { storeToRefs } from 'pinia'
 // State
 const selectedIndex = ref(null)
 const draggedSource = ref(null)
+const isSourceDrawerOpen = ref(false)
 
 const roomStore = useRoomStore()
 const listenerStore = useListenerStore()


### PR DESCRIPTION
## Summary
- restructure the SoundRoom view to use a mobile-first vertical stack while keeping the desktop grid intact at `md` breakpoints
- add dedicated MobileToolbar plus Source and Selected Source drawers with Tailwind transitions to deliver the required responsive interactions
- refresh the FooterBar styles so the bottom actions behave like a mobile action bar without changing the desktop layout

## Testing
- `npm run build` *(fails: missing optional dependency `@sentry/vite-plugin` in the build environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cbfa6fd18832fb08857c9d64a35ae)