### PR TITLE
Improve admin ingest upload readiness messaging

### DIFF
--- a/admin_ingest/src/AdminIngest.vue
+++ b/admin_ingest/src/AdminIngest.vue
@@ -18,6 +18,10 @@ const uploading = ref(false)
 const user = ref(null)
 const sessionChecked = ref(false)
 const directoryName = ref(null)
+const email = ref('')
+const password = ref('')
+const authLoading = ref(false)
+const authError = ref(null)
 
 function hydrateFromPersistence() {
   const stored = loadPersistedState()
@@ -66,6 +70,29 @@ async function initAuth() {
 }
 
 onMounted(initAuth)
+
+async function signIn() {
+  if (!email.value || !password.value || authLoading.value) return
+  authLoading.value = true
+  authError.value = null
+  try {
+    const { data, error } = await supabase.auth.signInWithPassword({
+      email: email.value,
+      password: password.value
+    })
+    if (error) throw error
+    user.value = data.user ?? data.session?.user ?? null
+  } catch (error) {
+    authError.value = error.message || 'Sign-in failed'
+  } finally {
+    authLoading.value = false
+  }
+}
+
+async function signOut() {
+  await supabase.auth.signOut()
+  user.value = null
+}
 
 function formatBytes(bytes) {
   if (!bytes && bytes !== 0) return '—'
@@ -215,10 +242,69 @@ const uploadedCount = computed(() => Object.values(uploadedMap.value || {}).filt
       <header class="space-y-2 pb-6 border-b border-gray-800">
         <h1 class="text-4xl font-bold tracking-tight">SoundRoom — Admin Ingest</h1>
         <p class="text-sm text-gray-400 leading-relaxed max-w-2xl">
-          Local-only tool for bulk ingestion of curated audio assets.  
+          Local-only tool for bulk ingestion of curated audio assets.
           Authentication is routed through Supabase. Uploads write to Cloudflare R2 following the production directory structure.
         </p>
       </header>
+
+      <!-- Auth helper -->
+      <section class="bg-gray-900 rounded-2xl border border-gray-800 shadow-lg p-8 space-y-4">
+        <div class="flex justify-between items-start gap-4 flex-col sm:flex-row sm:items-center">
+          <div class="space-y-1">
+            <h2 class="text-lg font-semibold text-gray-100">Supabase authentication</h2>
+            <p class="text-sm text-gray-400">
+              Sign in with the same credentials you use in Supabase Auth. The session is stored locally, so you only need to sign in once per browser.
+            </p>
+          </div>
+          <span class="text-sm text-gray-300 font-medium">{{ user ? `Signed in as ${user.email}` : 'Not signed in' }}</span>
+        </div>
+
+        <div v-if="!user" class="grid gap-4 sm:grid-cols-3">
+          <label class="space-y-1 text-sm text-gray-300 font-medium">
+            Email
+            <input
+              v-model="email"
+              type="email"
+              class="w-full bg-gray-800/70 border border-gray-700 rounded-md px-3 py-2 text-sm text-gray-100 focus:(outline-none ring-2 ring-emerald-500)"
+              placeholder="you@example.com"
+            />
+          </label>
+
+          <label class="space-y-1 text-sm text-gray-300 font-medium">
+            Password
+            <input
+              v-model="password"
+              type="password"
+              class="w-full bg-gray-800/70 border border-gray-700 rounded-md px-3 py-2 text-sm text-gray-100 focus:(outline-none ring-2 ring-emerald-500)"
+              placeholder="••••••••"
+            />
+          </label>
+
+          <div class="flex items-end">
+            <button
+              type="button"
+              class="w-full px-4 py-2 rounded-md bg-emerald-500 text-black font-semibold hover:bg-emerald-400 disabled:opacity-50"
+              :disabled="authLoading || !email || !password"
+              @click="signIn"
+            >
+              {{ authLoading ? 'Signing in…' : 'Sign in' }}
+            </button>
+          </div>
+        </div>
+
+        <div v-else class="flex items-center gap-3 text-sm text-gray-300">
+          <span class="px-3 py-1 rounded-full bg-emerald-500/10 text-emerald-300 border border-emerald-500/30">Authenticated</span>
+          <button
+            type="button"
+            class="px-3 py-1 rounded-md bg-gray-800 border border-gray-700 text-gray-200 hover:bg-gray-700"
+            @click="signOut"
+          >
+            Sign out
+          </button>
+        </div>
+
+        <p v-if="authError" class="text-sm text-red-300">{{ authError }}</p>
+      </section>
 
       <!-- Directory picker -->
       <section class="bg-gray-900 rounded-2xl border border-gray-800 shadow-lg p-8">

--- a/admin_ingest/src/AdminIngest.vue
+++ b/admin_ingest/src/AdminIngest.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import DirectoryPicker from './DirectoryPicker.vue'
 import FileReview from './FileReview.vue'
-import { CATEGORY_OPTIONS } from './utils/categoryList'
+import { BUCKET_OPTIONS } from './utils/categoryList'
 import { loadPersistedState, persistState } from './utils/localStore'
 import { uploadFileAndInsert } from './utils/SoundUploader'
 import { supabase } from './utils/supabaseClient'
@@ -119,7 +119,9 @@ function baseFileDraft(relativePath, file, index) {
     cone_inner: storedDraft.cone_inner ?? 30,
     cone_outer: storedDraft.cone_outer ?? 60,
     plan_tier: storedDraft.plan_tier || supportedPlanTiers.at(-1),
-    category: storedDraft.category || CATEGORY_OPTIONS[0],
+    bucket:
+      storedDraft.bucket || storedDraft.category ||
+      BUCKET_OPTIONS[0]?.value || '',
     duration_seconds: storedDraft.duration_seconds ?? null,
     relativePath,
     uploaded: Boolean(uploadedMap.value[relativePath]),
@@ -204,7 +206,12 @@ async function uploadCurrent() {
     cone_inner: fileEntry.cone_inner,
     cone_outer: fileEntry.cone_outer,
     plan_tier: fileEntry.plan_tier,
-    category: fileEntry.category
+    bucket: fileEntry.bucket
+  }
+
+  if (!metadata.bucket) {
+    showToast('Select a bucket before uploading.')
+    return
   }
 
   if (!metadata.duration_seconds) {
@@ -335,7 +342,7 @@ const uploadedCount = computed(() => Object.values(uploadedMap.value || {}).filt
           :index="currentIndex"
           :total="totalFiles"
           :plan-options="supportedPlanTiers"
-          :categories="CATEGORY_OPTIONS"
+          :buckets="BUCKET_OPTIONS"
           :uploading="uploading"
           :upload-blocked-reason="uploadBlockedReason"
           @update-field="updateField"

--- a/admin_ingest/src/AdminIngest.vue
+++ b/admin_ingest/src/AdminIngest.vue
@@ -121,6 +121,13 @@ function handleDirectoryLoaded(payload) {
 
 const currentFile = computed(() => files.value[currentIndex.value] ?? null)
 
+const uploadBlockedReason = computed(() => {
+  if (!currentFile.value) return null
+  if (!user.value) return 'Sign in via Supabase before uploading.'
+  if (!currentFile.value.duration_seconds) return 'Waiting for audio duration metadata.'
+  return null
+})
+
 function updateField({ field, value }) {
   if (!currentFile.value) return
   currentFile.value[field] = value
@@ -244,6 +251,7 @@ const uploadedCount = computed(() => Object.values(uploadedMap.value || {}).filt
           :plan-options="supportedPlanTiers"
           :categories="CATEGORY_OPTIONS"
           :uploading="uploading"
+          :upload-blocked-reason="uploadBlockedReason"
           @update-field="updateField"
           @duration-detected="handleDuration"
           @upload="uploadCurrent"

--- a/admin_ingest/src/AdminIngest.vue
+++ b/admin_ingest/src/AdminIngest.vue
@@ -9,6 +9,19 @@ import { supabase } from './utils/supabaseClient'
 import { PLANS } from '@app/constants/entitlements'
 
 const supportedPlanTiers = PLANS ?? ['free', 'basic', 'pro']
+
+function normalizeBucket(bucketValue) {
+  if (!bucketValue) return ''
+  return bucketValue
+    .toString()
+    .trim()
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-|-$/g, '')
+}
 const files = ref([])
 const currentIndex = ref(0)
 const uploadedMap = ref({})
@@ -120,7 +133,7 @@ function baseFileDraft(relativePath, file, index) {
     cone_outer: storedDraft.cone_outer ?? 60,
     plan_tier: storedDraft.plan_tier || supportedPlanTiers.at(-1),
     bucket:
-      storedDraft.bucket || storedDraft.category ||
+      normalizeBucket(storedDraft.bucket || storedDraft.category) ||
       BUCKET_OPTIONS[0]?.value || '',
     duration_seconds: storedDraft.duration_seconds ?? null,
     relativePath,
@@ -199,6 +212,8 @@ async function uploadCurrent() {
   }
 
   const fileEntry = currentFile.value
+  const normalizedBucket = normalizeBucket(fileEntry.bucket)
+
   const metadata = {
     name: fileEntry.name,
     tags: fileEntry.tags,
@@ -206,7 +221,7 @@ async function uploadCurrent() {
     cone_inner: fileEntry.cone_inner,
     cone_outer: fileEntry.cone_outer,
     plan_tier: fileEntry.plan_tier,
-    bucket: fileEntry.bucket
+    bucket: normalizedBucket
   }
 
   if (!metadata.bucket) {
@@ -224,6 +239,8 @@ async function uploadCurrent() {
     await uploadFileAndInsert({
       file: fileEntry.file,
       userId: user.value.id,
+      planTier: metadata.plan_tier,
+      bucket: metadata.bucket,
       metadata
     })
     fileEntry.uploaded = true

--- a/admin_ingest/src/FileReview.vue
+++ b/admin_ingest/src/FileReview.vue
@@ -18,7 +18,7 @@ const props = defineProps({
     type: Array,
     default: () => []
   },
-  categories: {
+  buckets: {
     type: Array,
     default: () => []
   },
@@ -115,16 +115,22 @@ function handleEnter(event) {
           />
         </div>
 
-        <!-- Category -->
+        <!-- Bucket -->
         <div class="space-y-1.5">
-          <label class="text-sm text-gray-300 font-medium">Category</label>
+          <label class="text-sm text-gray-300 font-medium">Bucket</label>
           <select
             class="w-full bg-gray-800 border border-gray-700 rounded-md px-3 py-2 text-sm text-gray-100 focus:(outline-none ring-2 ring-emerald-500)"
-            :value="fileEntry.category"
-            @change="emitField('category', $event.target.value)"
+            :value="fileEntry.bucket"
+            @change="emitField('bucket', $event.target.value)"
           >
-            <option disabled value="">Select category</option>
-            <option v-for="c in categories" :key="c" :value="c">{{ c }}</option>
+            <option disabled value="">Select bucket</option>
+            <option
+              v-for="bucket in buckets"
+              :key="bucket.value"
+              :value="bucket.value"
+            >
+              {{ bucket.value }} — {{ bucket.description }}
+            </option>
           </select>
         </div>
 

--- a/admin_ingest/src/FileReview.vue
+++ b/admin_ingest/src/FileReview.vue
@@ -22,7 +22,11 @@ const props = defineProps({
     type: Array,
     default: () => []
   },
-  uploading: Boolean
+  uploading: Boolean,
+  uploadBlockedReason: {
+    type: String,
+    default: null
+  }
 })
 
 const emit = defineEmits([
@@ -34,6 +38,9 @@ const emit = defineEmits([
 ])
 
 const tagString = ref(props.fileEntry.tags?.join(', ') ?? '')
+const uploadDisabled = computed(
+  () => props.uploading || props.fileEntry.uploaded || Boolean(props.uploadBlockedReason)
+)
 
 watch(
   () => props.fileEntry,
@@ -229,14 +236,19 @@ function handleEnter(event) {
             Next
           </button>
 
-          <button
-            type="button"
-            class="ml-auto px-4 py-2 rounded-md bg-emerald-500 text-black font-semibold hover:bg-emerald-400 disabled:opacity-40"
-            @click="emit('upload')"
-            :disabled="uploading || fileEntry.uploaded"
-          >
-            {{ fileEntry.uploaded ? 'Uploaded' : uploading ? 'Uploading…' : 'Upload' }}
-          </button>
+          <div class="ml-auto flex flex-col items-end gap-2">
+            <button
+              type="button"
+              class="px-4 py-2 rounded-md bg-emerald-500 text-black font-semibold hover:bg-emerald-400 disabled:opacity-40"
+              @click="emit('upload')"
+              :disabled="uploadDisabled"
+            >
+              {{ fileEntry.uploaded ? 'Uploaded' : uploading ? 'Uploading…' : 'Upload' }}
+            </button>
+            <p v-if="uploadBlockedReason" class="text-xs text-gray-400">
+              {{ uploadBlockedReason }}
+            </p>
+          </div>
         </div>
       </div>
     </div>

--- a/admin_ingest/src/FileReview.vue
+++ b/admin_ingest/src/FileReview.vue
@@ -129,7 +129,7 @@ function handleEnter(event) {
               :key="bucket.value"
               :value="bucket.value"
             >
-              {{ bucket.value }} — {{ bucket.description }}
+              {{ bucket.label || bucket.value }} — {{ bucket.description }}
             </option>
           </select>
         </div>

--- a/admin_ingest/src/utils/SoundUploader.js
+++ b/admin_ingest/src/utils/SoundUploader.js
@@ -67,7 +67,6 @@ export async function uploadFileAndInsert({ file, userId, metadata }) {
   const payload = {
     ...metadata,
     path: key,
-    bucket: userId,
     owner_id: userId,
     size: file.size,
     mime_type: file.type

--- a/admin_ingest/src/utils/SoundUploader.js
+++ b/admin_ingest/src/utils/SoundUploader.js
@@ -2,10 +2,15 @@ import { supabase } from './supabaseClient'
 
 /**
  * Fetch a signed upload URL using the exact flow the customer-facing uploader uses.
- * This keeps the folder structure identical (users/{userId}/{generatedKey}).
+ * Admin ingest writes to {planTier}/{bucket}/{generatedKey} while retaining the user
+ * fallback for customer uploads.
  */
-async function getSignedUploadUrl(userId, filename) {
-  const params = new URLSearchParams({ userId, filename })
+async function getSignedUploadUrl({ userId, filename, planTier, bucket }) {
+  const params = new URLSearchParams({ filename })
+
+  if (userId) params.set('userId', userId)
+  if (planTier) params.set('planTier', planTier)
+  if (bucket) params.set('bucket', bucket)
   const response = await fetch(`/api/get-upload-url?${params.toString()}`)
 
   const rawBody = await response.text().catch(() => '')
@@ -54,14 +59,21 @@ function uploadViaXhr(file, signedUrl) {
  * @param {Object} options
  * @param {File} options.file
  * @param {string} options.userId
+ * @param {string} options.planTier
+ * @param {string} options.bucket
  * @param {Object} options.metadata - payload destined for public.sound_files
  */
-export async function uploadFileAndInsert({ file, userId, metadata }) {
+export async function uploadFileAndInsert({ file, userId, planTier, bucket, metadata }) {
   if (!userId) {
     throw new Error('Supabase user is required before uploading')
   }
 
-  const { signedUrl, key } = await getSignedUploadUrl(userId, file.name)
+  const { signedUrl, key } = await getSignedUploadUrl({
+    userId,
+    filename: file.name,
+    planTier,
+    bucket
+  })
   await uploadViaXhr(file, signedUrl)
 
   const payload = {

--- a/admin_ingest/src/utils/SoundUploader.js
+++ b/admin_ingest/src/utils/SoundUploader.js
@@ -8,12 +8,22 @@ async function getSignedUploadUrl(userId, filename) {
   const params = new URLSearchParams({ userId, filename })
   const response = await fetch(`/api/get-upload-url?${params.toString()}`)
 
+  const rawBody = await response.text().catch(() => '')
+
   if (!response.ok) {
-    const body = await response.text().catch(() => '')
-    throw new Error(body || 'Unable to get signed Cloudflare R2 URL')
+    throw new Error(rawBody || 'Unable to get signed Cloudflare R2 URL')
   }
 
-  const payload = await response.json()
+  let payload
+  try {
+    payload = JSON.parse(rawBody)
+  } catch (_err) {
+    const snippet = rawBody?.slice(0, 240)
+    throw new Error(
+      `Unexpected response from /api/get-upload-url (status ${response.status}): ${snippet || 'Empty body'}`
+    )
+  }
+
   if (!payload?.signedUrl || !payload?.key) {
     throw new Error('Signed upload URL response was missing "signedUrl" or "key"')
   }

--- a/admin_ingest/src/utils/categoryList.js
+++ b/admin_ingest/src/utils/categoryList.js
@@ -1,17 +1,30 @@
-export const CATEGORY_OPTIONS = [
-  'nature',
-  'urban',
-  'weather',
-  'transportation',
-  'interior',
-  'voices',
-  'foley',
-  'music',
-  'loops',
-  'experimental',
-  'sci-fi',
-  'fantasy',
-  'alerts',
-  'ui',
-  'custom'
+export const BUCKET_OPTIONS = [
+  {
+    value: 'Nature',
+    description: 'Rain, water, fire, birds, wind, forests, storms, insects, foliage, rivers.'
+  },
+  {
+    value: 'Atmosphere',
+    description: 'Ambience, drones, tonal beds, soft textures, abstract pads, whitespace, reverb beds.'
+  },
+  {
+    value: 'Work/Focus',
+    description: 'White noise, brown noise, fans, HVAC hums, soft machinery, steady-state loops.'
+  },
+  {
+    value: 'Human',
+    description: 'Voices, breath, murmurs, crowds, footsteps, typing, cloth movement, people stuff.'
+  },
+  {
+    value: 'Musical',
+    description: 'Notes, riffs, loops, pads, chords, percussive hits, tonal accents — anything made with an instrument/synth.'
+  },
+  {
+    value: 'Urban/Mechanical',
+    description: 'Engines, traffic, metal, clanks, industrial ambience, train sounds, switches, gears.'
+  },
+  {
+    value: 'Misc',
+    description: 'Everything weird, unclassifiable, experimental, glitchy, or “what the hell is that?”'
+  }
 ]

--- a/admin_ingest/src/utils/categoryList.js
+++ b/admin_ingest/src/utils/categoryList.js
@@ -10,7 +10,7 @@ export const BUCKET_OPTIONS = [
     description: 'Ambience, drones, tonal beds, soft textures, abstract pads, whitespace, reverb beds.'
   },
   {
-    value: 'work-focus',
+    value: 'tools',
     label: 'Work/Focus',
     description: 'White noise, brown noise, fans, HVAC hums, soft machinery, steady-state loops.'
   },

--- a/admin_ingest/src/utils/categoryList.js
+++ b/admin_ingest/src/utils/categoryList.js
@@ -1,30 +1,37 @@
 export const BUCKET_OPTIONS = [
   {
-    value: 'Nature',
+    value: 'nature',
+    label: 'Nature',
     description: 'Rain, water, fire, birds, wind, forests, storms, insects, foliage, rivers.'
   },
   {
-    value: 'Atmosphere',
+    value: 'atmosphere',
+    label: 'Atmosphere',
     description: 'Ambience, drones, tonal beds, soft textures, abstract pads, whitespace, reverb beds.'
   },
   {
-    value: 'Work/Focus',
+    value: 'work-focus',
+    label: 'Work/Focus',
     description: 'White noise, brown noise, fans, HVAC hums, soft machinery, steady-state loops.'
   },
   {
-    value: 'Human',
+    value: 'human',
+    label: 'Human',
     description: 'Voices, breath, murmurs, crowds, footsteps, typing, cloth movement, people stuff.'
   },
   {
-    value: 'Musical',
+    value: 'musical',
+    label: 'Musical',
     description: 'Notes, riffs, loops, pads, chords, percussive hits, tonal accents — anything made with an instrument/synth.'
   },
   {
-    value: 'Urban/Mechanical',
+    value: 'urban-mechanical',
+    label: 'Urban/Mechanical',
     description: 'Engines, traffic, metal, clanks, industrial ambience, train sounds, switches, gears.'
   },
   {
-    value: 'Misc',
+    value: 'misc',
+    label: 'Misc',
     description: 'Everything weird, unclassifiable, experimental, glitchy, or “what the hell is that?”'
   }
 ]

--- a/api/get-upload-url.js
+++ b/api/get-upload-url.js
@@ -66,6 +66,19 @@ function createRandomId() {
   return Math.random().toString(36).slice(2);
 }
 
+function sanitizeSegment(value) {
+  if (!value) return ''
+  return value
+    .toString()
+    .trim()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9_-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase()
+}
+
 function generateObjectKey(filename) {
   const timestamp = Date.now().toString(36);
   const randomId = createRandomId().slice(0, 16);
@@ -147,10 +160,33 @@ export async function GET(request) {
     const { searchParams } = new URL(request.url);
     const userId = searchParams.get("userId");
     const filename = searchParams.get("filename");
+    const planTier = searchParams.get("planTier");
+    const bucket = searchParams.get("bucket");
 
-    if (!userId || !filename) {
+    if (!filename) {
       return new Response(
-        JSON.stringify({ error: "Missing 'userId' or 'filename' query param" }),
+        JSON.stringify({ error: "Missing 'filename' query param" }),
+        {
+          status: 400,
+          headers: {
+            ...corsHeaders,
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    }
+
+    const safeBase = sanitizeSegment(planTier);
+    const safeBucket = sanitizeSegment(bucket);
+
+    let storagePrefix = "";
+    if (safeBase && safeBucket) {
+      storagePrefix = `${safeBase}/${safeBucket}`;
+    } else if (userId) {
+      storagePrefix = `users/${userId}`;
+    } else {
+      return new Response(
+        JSON.stringify({ error: "Missing 'planTier'/'bucket' or 'userId' query params" }),
         {
           status: 400,
           headers: {
@@ -163,7 +199,7 @@ export async function GET(request) {
 
     const generatedKey = generateObjectKey(filename);
     const url = new URL(
-      `https://${bucketName}.${accountId}.r2.cloudflarestorage.com/users/${userId}/${generatedKey}`
+      `https://${bucketName}.${accountId}.r2.cloudflarestorage.com/${storagePrefix}/${generatedKey}`
     );
     url.searchParams.set("X-Amz-Expires", "120");
 
@@ -176,6 +212,8 @@ export async function GET(request) {
         signedUrl: signed.url,
         key: generatedKey,
         displayName: filename,
+        base: safeBase || "users",
+        bucket: safeBucket || userId,
       }),
       {
         status: 200,

--- a/vite.admin.config.js
+++ b/vite.admin.config.js
@@ -17,7 +17,12 @@ export default defineConfig({
   envDir: __dirname,
   server: {
     port: 4175,
-    strictPort: false
+    strictPort: false,
+    proxy: {
+      // When running `vercel dev` (port 3000) alongside the Vite admin ingest dev server
+      // (port 4175), forward API requests to the backend so relative /api calls work.
+      '/api': 'http://localhost:3000'
+    }
   },
   build: {
     outDir: path.resolve(ADMIN_ROOT, 'dist'),


### PR DESCRIPTION
## Summary
- show inline reasons when admin-ingest uploads are blocked by missing auth or duration metadata
- disable the upload button while blocked to make the state explicit

## Testing
- npm -C admin_ingest run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e24f5ecdc832faa0edd49c6d014c6)