### PR TITLE
Fix sound library item refresh and duration display

### DIFF
--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -7,7 +7,7 @@
     <div ref="gridScroll" class="mt-5 place-content-start p-6 pt-20 overflow-y-auto h-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
       <SoundGridItem
         v-for="sound in sounds"
-        :key="sound.id"
+        :key="sound.libraryId || sound.id"
         :sound="sound"
         :userSound="activeCategory === 'your-sounds'"
         v-bind="{ waiting, soundLibrarySources, currentlyPlayingId }"

--- a/src/components/ui/modals/SoundLibrary/SoundPreviewCircle.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundPreviewCircle.vue
@@ -91,10 +91,14 @@ function formatSecondsToTime(totalSeconds = 0) {
     : `${minutes}:${seconds.toString().padStart(2, '0')}`
 }
 
-onMounted(async () => {
+function syncDurationFromProps() {
   const durationSeconds = props.soundData?.duration_seconds ?? 0
   audioDuration.value = formatSecondsToTime(durationSeconds)
-  duration.value = Math.min(duration.value, durationSeconds || duration.value)
+  duration.value = Math.min(15, durationSeconds || 15)
+}
+
+onMounted(async () => {
+  syncDurationFromProps()
 
   nextTick(() => {
     if (circleRef.value) {
@@ -103,6 +107,13 @@ onMounted(async () => {
     }
   })
 })
+
+watch(
+  () => props.soundData?.duration_seconds,
+  () => {
+    syncDurationFromProps()
+  }
+)
 
 async function togglePlay() {
   if (props.locked) {


### PR DESCRIPTION
## Summary
- ensure sound library grid items use stable keys so components remount correctly when switching categories
- refresh sound preview durations whenever the underlying sound data changes to keep timestamps accurate

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e7ad01be0832fa49d014ad7e26f17)