### PR TITLE
Hide tier highlight for accessible library sounds

### DIFF
--- a/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
@@ -67,7 +67,13 @@ const normalizedTier = computed(() => {
   return typeof tier === 'string' ? tier.toLowerCase() : ''
 })
 
-const highlightClass = computed(() => getSoundHighlightClass(normalizedTier.value))
+const highlightClass = computed(() => {
+  if (!props.sound.locked || props.sound.accessReason !== 'tier') {
+    return ''
+  }
+
+  return getSoundHighlightClass(normalizedTier.value)
+})
 
 const badgeClass = computed(() => {
   if (props.sound.accessReason === 'ownership') {


### PR DESCRIPTION
## Summary
- show the tier highlight ring only when a library sound is locked due to plan requirements

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e7d2289dc832fbb379c4918131283)