### PR TITLE
Add R2 flat namespace migration script

### DIFF
--- a/migrate_flat_r2.js
+++ b/migrate_flat_r2.js
@@ -65,20 +65,48 @@ function stripBucketPrefix(key, bucketName) {
   return normalizedKey
 }
 
-function resolveLegacyKey(sound) {
+function generateLegacyKeyCandidates(sound, bucketName) {
+  const candidates = new Set()
   const rawPath = normalizeKey(sound.path)
-  const base = normalizeKey(sound.plan_tier) || 'users'
-  const bucket = normalizeKey(sound.bucket || sound.owner_id)
+  const bucket = normalizeKey(sound.bucket)
+  const planTier = normalizeKey(sound.plan_tier)
+  const owner = normalizeKey(sound.owner_id)
+  const normalizedBucketName = normalizeKey(bucketName)
 
-  if (rawPath.includes('/')) {
-    return rawPath
+  if (rawPath) {
+    candidates.add(rawPath)
+
+    const withoutBucket = stripBucketPrefix(rawPath, normalizedBucketName)
+    candidates.add(withoutBucket)
+
+    const parts = rawPath.split('/')
+    if (parts[0] === normalizedBucketName && parts.length > 1) {
+      candidates.add(parts.slice(1).join('/'))
+    }
+
+    if (planTier && !rawPath.startsWith(`${planTier}/`)) {
+      candidates.add(`${planTier}/${rawPath}`)
+    }
   }
 
-  if (!bucket) {
-    return rawPath
+  // If the stored path is just a filename, try constructing common prefixes
+  const isFileOnly = rawPath && !rawPath.includes('/')
+  if (isFileOnly) {
+    if (planTier && bucket) {
+      candidates.add(`${planTier}/${bucket}/${rawPath}`)
+    }
+    if (bucket) {
+      candidates.add(`${bucket}/${rawPath}`)
+    }
+    if (planTier && owner) {
+      candidates.add(`${planTier}/${owner}/${rawPath}`)
+    }
+    if (planTier) {
+      candidates.add(`${planTier}/${rawPath}`)
+    }
   }
 
-  return [base, bucket, rawPath].filter(Boolean).join('/')
+  return Array.from(candidates).filter(Boolean)
 }
 
 function resolveExtension(sound, key) {
@@ -120,38 +148,58 @@ async function main() {
   await Promise.all(
     sounds.map((sound) =>
       limit(async () => {
-        const legacyKey = resolveLegacyKey(sound)
+        const candidates = generateLegacyKeyCandidates(sound, env.r2BucketName)
 
-        if (!legacyKey) {
+        if (!candidates.length) {
           console.warn(`Skipping sound ${sound.id}: missing path/bucket information`)
           return
         }
 
-        const cleanKey = normalizeKey(legacyKey)
-        const effectiveKey = stripBucketPrefix(cleanKey, env.r2BucketName)
-        const extension = resolveExtension(sound, effectiveKey)
+        let foundKey = null
+        let objectResponse = null
+
+        for (const candidate of candidates) {
+          try {
+            const response = await s3.send(
+              new GetObjectCommand({
+                Bucket: env.r2BucketName,
+                Key: candidate,
+              })
+            )
+            foundKey = candidate
+            objectResponse = response
+            break
+          } catch (err) {
+            if (err?.Code !== 'NoSuchKey') {
+              console.error(`Error fetching ${candidate} for sound ${sound.id}:`, err)
+            }
+          }
+        }
+
+        if (!foundKey || !objectResponse) {
+          console.error(
+            `Failed to locate object for sound ${sound.id}. Tried: ${candidates.join(', ')}`
+          )
+          return
+        }
+
+        const extension = resolveExtension(sound, foundKey)
         if (!extension) {
           console.error(
-            `Skipping sound ${sound.id}: could not determine file extension from key "${legacyKey}" or name "${sound.name}"`
+            `Skipping sound ${sound.id}: could not determine file extension from key "${foundKey}" or name "${sound.name}"`
           )
           return
         }
 
         const newKey = `${sound.id}${extension}`
 
-        if (effectiveKey === newKey) {
+        if (foundKey === newKey) {
           console.log(`Skipping sound ${sound.id}: already stored as ${newKey}`)
           return
         }
 
         try {
-          console.log(`Migrating sound ${sound.id}: ${legacyKey} → ${newKey}`)
-          const objectResponse = await s3.send(
-            new GetObjectCommand({
-              Bucket: env.r2BucketName,
-              Key: effectiveKey,
-            })
-          )
+          console.log(`Migrating sound ${sound.id}: ${foundKey} → ${newKey}`)
 
           const body = objectResponse.Body
           if (!body) {

--- a/migrate_flat_r2.js
+++ b/migrate_flat_r2.js
@@ -53,6 +53,30 @@ function normalizeKey(key) {
     .trim()
 }
 
+function resolveLegacyKey(sound) {
+  const rawPath = normalizeKey(sound.path)
+  const base = normalizeKey(sound.plan_tier) || 'users'
+  const bucket = normalizeKey(sound.bucket || sound.owner_id)
+
+  if (rawPath.includes('/')) {
+    return rawPath
+  }
+
+  if (!bucket) {
+    return rawPath
+  }
+
+  return [base, bucket, rawPath].filter(Boolean).join('/')
+}
+
+function resolveExtension(sound, key) {
+  const extFromKey = path.extname(key)
+  if (extFromKey) return extFromKey
+
+  const extFromName = path.extname(sound.name || '')
+  return extFromName
+}
+
 async function main() {
   const env = loadEnv()
 
@@ -68,7 +92,9 @@ async function main() {
   })
 
   console.log(`Fetching sounds from Supabase...`)
-  const { data: sounds, error } = await supabase.from('sounds').select('id, r2_object_key')
+  const { data: sounds, error } = await supabase
+    .from('sound_files')
+    .select('id, path, name, bucket, plan_tier, owner_id')
   if (error) {
     throw new Error(`Failed to fetch sounds: ${error.message}`)
   }
@@ -82,28 +108,31 @@ async function main() {
   await Promise.all(
     sounds.map((sound) =>
       limit(async () => {
-        const { id, r2_object_key: oldKey } = sound
-        if (!oldKey) {
-          console.warn(`Skipping sound ${id}: missing r2_object_key`)
+        const legacyKey = resolveLegacyKey(sound)
+
+        if (!legacyKey) {
+          console.warn(`Skipping sound ${sound.id}: missing path/bucket information`)
           return
         }
 
-        const cleanKey = normalizeKey(oldKey)
-        const extension = path.extname(cleanKey)
+        const cleanKey = normalizeKey(legacyKey)
+        const extension = resolveExtension(sound, cleanKey)
         if (!extension) {
-          console.error(`Skipping sound ${id}: could not determine file extension from key "${oldKey}"`)
+          console.error(
+            `Skipping sound ${sound.id}: could not determine file extension from key "${legacyKey}" or name "${sound.name}"`
+          )
           return
         }
 
-        const newKey = `${id}${extension}`
+        const newKey = `${sound.id}${extension}`
 
         if (cleanKey === newKey) {
-          console.log(`Skipping sound ${id}: already stored as ${newKey}`)
+          console.log(`Skipping sound ${sound.id}: already stored as ${newKey}`)
           return
         }
 
         try {
-          console.log(`Migrating sound ${id}: ${oldKey} → ${newKey}`)
+          console.log(`Migrating sound ${sound.id}: ${legacyKey} → ${newKey}`)
           const objectResponse = await s3.send(
             new GetObjectCommand({
               Bucket: env.r2BucketName,
@@ -128,9 +157,9 @@ async function main() {
           )
 
           const { error: updateError } = await supabase
-            .from('sounds')
-            .update({ r2_object_key: newKey })
-            .eq('id', id)
+            .from('sound_files')
+            .update({ path: newKey })
+            .eq('id', sound.id)
 
           if (updateError) {
             throw new Error(`Supabase update failed: ${updateError.message}`)
@@ -138,7 +167,7 @@ async function main() {
 
           console.log('Updated Supabase record')
         } catch (migrationError) {
-          console.error(`Failed to migrate sound ${id}:`, migrationError)
+          console.error(`Failed to migrate sound ${sound.id}:`, migrationError)
         }
       })
     )

--- a/migrate_flat_r2.js
+++ b/migrate_flat_r2.js
@@ -112,9 +112,11 @@ function generateLegacyKeyCandidates(sound, bucketName) {
     }
     if (planTier) {
       candidates.add(`${planTier}/${rawPath}`)
+      candidates.add(`${planTier}/misc/${rawPath}`)
     }
     for (const tier of knownTiers) {
       candidates.add(`${tier}/${rawPath}`)
+      candidates.add(`${tier}/misc/${rawPath}`)
     }
   }
 

--- a/migrate_flat_r2.js
+++ b/migrate_flat_r2.js
@@ -73,6 +73,8 @@ function generateLegacyKeyCandidates(sound, bucketName) {
   const owner = normalizeKey(sound.owner_id)
   const normalizedBucketName = normalizeKey(bucketName)
 
+  const knownTiers = ['free', 'basic', 'plus', 'pro']
+
   if (rawPath) {
     candidates.add(rawPath)
 
@@ -86,6 +88,13 @@ function generateLegacyKeyCandidates(sound, bucketName) {
 
     if (planTier && !rawPath.startsWith(`${planTier}/`)) {
       candidates.add(`${planTier}/${rawPath}`)
+    }
+
+    const leadingSegment = withoutBucket.split('/')[0]
+    if (leadingSegment && knownTiers.includes(leadingSegment)) {
+      for (const tier of knownTiers) {
+        candidates.add(`${tier}/${withoutBucket.split('/').slice(1).join('/')}`)
+      }
     }
   }
 
@@ -103,6 +112,9 @@ function generateLegacyKeyCandidates(sound, bucketName) {
     }
     if (planTier) {
       candidates.add(`${planTier}/${rawPath}`)
+    }
+    for (const tier of knownTiers) {
+      candidates.add(`${tier}/${rawPath}`)
     }
   }
 

--- a/migrate_flat_r2.js
+++ b/migrate_flat_r2.js
@@ -33,6 +33,19 @@ function loadEnv() {
   }
 }
 
+function normalizeSegment(value) {
+  if (!value) return ''
+  return value
+    .toString()
+    .trim()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9_-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase()
+}
+
 async function streamToBuffer(stream) {
   const chunks = []
   for await (const chunk of stream) {
@@ -65,62 +78,86 @@ function stripBucketPrefix(key, bucketName) {
   return normalizedKey
 }
 
+function buildStorageKey(base, bucket, path) {
+  const segments = [base, bucket, path]
+    .map((segment) => (segment ?? '').toString().replace(/^\/+|\/+$/g, ''))
+    .filter(Boolean)
+
+  return segments.join('/')
+}
+
 function generateLegacyKeyCandidates(sound, bucketName) {
-  const candidates = new Set()
+  const candidates = []
+  const seen = new Set()
   const rawPath = normalizeKey(sound.path)
-  const bucket = normalizeKey(sound.bucket)
-  const planTier = normalizeKey(sound.plan_tier)
-  const owner = normalizeKey(sound.owner_id)
+  const normalizedBucketSegment = normalizeSegment(sound.bucket)
+  const planTier = normalizeSegment(sound.plan_tier)
+  const owner = normalizeSegment(sound.owner_id)
   const normalizedBucketName = normalizeKey(bucketName)
 
   const knownTiers = ['free', 'basic', 'plus', 'pro']
+  const derivedBase = normalizeSegment(sound.base) || planTier || (owner ? 'users' : '')
 
-  if (rawPath) {
-    candidates.add(rawPath)
+  const addCandidate = (value) => {
+    const key = normalizeKey(value)
+    if (key && !seen.has(key)) {
+      seen.add(key)
+      candidates.push(key)
+    }
+  }
 
-    const withoutBucket = stripBucketPrefix(rawPath, normalizedBucketName)
-    candidates.add(withoutBucket)
+  const primaryPath = stripBucketPrefix(rawPath, normalizedBucketName)
+  const pathVariants = [primaryPath]
 
-    const parts = rawPath.split('/')
-    if (parts[0] === normalizedBucketName && parts.length > 1) {
-      candidates.add(parts.slice(1).join('/'))
+  if (rawPath && rawPath !== primaryPath) {
+    pathVariants.push(rawPath)
+  }
+
+  for (const variant of pathVariants.filter(Boolean)) {
+    addCandidate(variant)
+
+    if (normalizedBucketSegment) {
+      addCandidate(buildStorageKey('', normalizedBucketSegment, variant))
     }
 
-    if (planTier && !rawPath.startsWith(`${planTier}/`)) {
-      candidates.add(`${planTier}/${rawPath}`)
+    if (derivedBase) {
+      addCandidate(buildStorageKey(derivedBase, normalizedBucketSegment, variant))
+      addCandidate(buildStorageKey(derivedBase, '', variant))
     }
 
-    const leadingSegment = withoutBucket.split('/')[0]
+    const leadingSegment = variant.split('/')[0]
     if (leadingSegment && knownTiers.includes(leadingSegment)) {
+      const remainder = variant.split('/').slice(1).join('/')
       for (const tier of knownTiers) {
-        candidates.add(`${tier}/${withoutBucket.split('/').slice(1).join('/')}`)
+        addCandidate(buildStorageKey(tier, '', remainder))
+        addCandidate(buildStorageKey(tier, normalizedBucketSegment, remainder))
       }
     }
   }
 
-  // If the stored path is just a filename, try constructing common prefixes
-  const isFileOnly = rawPath && !rawPath.includes('/')
+  const isFileOnly = primaryPath && !primaryPath.includes('/')
   if (isFileOnly) {
-    if (planTier && bucket) {
-      candidates.add(`${planTier}/${bucket}/${rawPath}`)
+    if (planTier && normalizedBucketSegment) {
+      addCandidate(buildStorageKey(planTier, normalizedBucketSegment, primaryPath))
+      addCandidate(buildStorageKey(planTier, 'misc', primaryPath))
     }
-    if (bucket) {
-      candidates.add(`${bucket}/${rawPath}`)
+
+    if (normalizedBucketSegment) {
+      addCandidate(buildStorageKey('', normalizedBucketSegment, primaryPath))
+      addCandidate(buildStorageKey('misc', normalizedBucketSegment, primaryPath))
     }
+
     if (planTier && owner) {
-      candidates.add(`${planTier}/${owner}/${rawPath}`)
+      addCandidate(buildStorageKey(planTier, owner, primaryPath))
     }
-    if (planTier) {
-      candidates.add(`${planTier}/${rawPath}`)
-      candidates.add(`${planTier}/misc/${rawPath}`)
-    }
+
     for (const tier of knownTiers) {
-      candidates.add(`${tier}/${rawPath}`)
-      candidates.add(`${tier}/misc/${rawPath}`)
+      addCandidate(buildStorageKey(tier, normalizedBucketSegment, primaryPath))
+      addCandidate(buildStorageKey(tier, 'misc', primaryPath))
     }
   }
 
-  return Array.from(candidates).filter(Boolean)
+  return candidates
 }
 
 function resolveExtension(sound, key) {
@@ -148,7 +185,7 @@ async function main() {
   console.log(`Fetching sounds from Supabase...`)
   const { data: sounds, error } = await supabase
     .from('sound_files')
-    .select('id, path, name, bucket, plan_tier, owner_id')
+    .select('id, path, name, bucket, plan_tier, owner_id, base')
   if (error) {
     throw new Error(`Failed to fetch sounds: ${error.message}`)
   }

--- a/migrate_flat_r2.js
+++ b/migrate_flat_r2.js
@@ -6,40 +6,30 @@ import { createClient } from '@supabase/supabase-js'
 
 dotenv.config({ path: '.env.local' })
 
-function getEnv() {
-  const {
-    SUPABASE_URL,
-    SUPABASE_SERVICE_ROLE_KEY,
-    R2_ACCOUNT_ID,
-    R2_ACCESS_KEY_ID,
-    R2_SECRET_ACCESS_KEY,
-    R2_BUCKET_NAME,
-    MIGRATION_CONCURRENCY,
-  } = process.env
+const DEFAULT_CONCURRENCY = 5
 
-  const missing = [
-    ['SUPABASE_URL', SUPABASE_URL],
-    ['SUPABASE_SERVICE_ROLE_KEY', SUPABASE_SERVICE_ROLE_KEY],
-    ['R2_ACCOUNT_ID', R2_ACCOUNT_ID],
-    ['R2_ACCESS_KEY_ID', R2_ACCESS_KEY_ID],
-    ['R2_SECRET_ACCESS_KEY', R2_SECRET_ACCESS_KEY],
-    ['R2_BUCKET_NAME', R2_BUCKET_NAME],
-  ]
-    .filter(([, value]) => !value)
-    .map(([key]) => key)
-
-  if (missing.length) {
-    throw new Error(`Missing required environment variables: ${missing.join(', ')}`)
+function required(name, value) {
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`)
   }
+  return value
+}
+
+function loadEnv() {
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL
 
   return {
-    supabaseUrl: SUPABASE_URL,
-    supabaseServiceKey: SUPABASE_SERVICE_ROLE_KEY,
-    r2AccountId: R2_ACCOUNT_ID,
-    r2AccessKeyId: R2_ACCESS_KEY_ID,
-    r2SecretAccessKey: R2_SECRET_ACCESS_KEY,
-    r2BucketName: R2_BUCKET_NAME,
-    concurrency: Number(MIGRATION_CONCURRENCY || 5),
+    supabaseUrl: required('SUPABASE_URL', supabaseUrl),
+    supabaseServiceKey: required(
+      'SUPABASE_SERVICE_ROLE_KEY',
+      process.env.SUPABASE_SERVICE_ROLE_KEY
+    ),
+    r2AccountId: required('R2_ACCOUNT_ID', process.env.R2_ACCOUNT_ID),
+    r2AccessKeyId: required('R2_ACCESS_KEY_ID', process.env.R2_ACCESS_KEY_ID),
+    r2SecretAccessKey: required('R2_SECRET_ACCESS_KEY', process.env.R2_SECRET_ACCESS_KEY),
+    r2BucketName: required('R2_BUCKET_NAME', process.env.R2_BUCKET_NAME),
+    concurrency:
+      Number.parseInt(process.env.MIGRATION_CONCURRENCY || '', 10) || DEFAULT_CONCURRENCY,
   }
 }
 
@@ -51,10 +41,22 @@ async function streamToBuffer(stream) {
   return Buffer.concat(chunks)
 }
 
-async function main() {
-  const env = getEnv()
+function createSupabaseClient(url, serviceKey) {
+  return createClient(url, serviceKey, { auth: { persistSession: false } })
+}
 
-  const supabase = createClient(env.supabaseUrl, env.supabaseServiceKey)
+function normalizeKey(key) {
+  if (!key) return ''
+  return key
+    .split('?')[0]
+    .replace(/^\/+/, '')
+    .trim()
+}
+
+async function main() {
+  const env = loadEnv()
+
+  const supabase = createSupabaseClient(env.supabaseUrl, env.supabaseServiceKey)
 
   const s3 = new S3Client({
     region: 'auto',
@@ -86,7 +88,7 @@ async function main() {
           return
         }
 
-        const cleanKey = oldKey.split('?')[0]
+        const cleanKey = normalizeKey(oldKey)
         const extension = path.extname(cleanKey)
         if (!extension) {
           console.error(`Skipping sound ${id}: could not determine file extension from key "${oldKey}"`)

--- a/migrate_flat_r2.js
+++ b/migrate_flat_r2.js
@@ -1,0 +1,151 @@
+import dotenv from 'dotenv'
+import path from 'node:path'
+import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3'
+import pLimit from 'p-limit'
+import { createClient } from '@supabase/supabase-js'
+
+dotenv.config({ path: '.env.local' })
+
+function getEnv() {
+  const {
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
+    R2_ACCOUNT_ID,
+    R2_ACCESS_KEY_ID,
+    R2_SECRET_ACCESS_KEY,
+    R2_BUCKET_NAME,
+    MIGRATION_CONCURRENCY,
+  } = process.env
+
+  const missing = [
+    ['SUPABASE_URL', SUPABASE_URL],
+    ['SUPABASE_SERVICE_ROLE_KEY', SUPABASE_SERVICE_ROLE_KEY],
+    ['R2_ACCOUNT_ID', R2_ACCOUNT_ID],
+    ['R2_ACCESS_KEY_ID', R2_ACCESS_KEY_ID],
+    ['R2_SECRET_ACCESS_KEY', R2_SECRET_ACCESS_KEY],
+    ['R2_BUCKET_NAME', R2_BUCKET_NAME],
+  ]
+    .filter(([, value]) => !value)
+    .map(([key]) => key)
+
+  if (missing.length) {
+    throw new Error(`Missing required environment variables: ${missing.join(', ')}`)
+  }
+
+  return {
+    supabaseUrl: SUPABASE_URL,
+    supabaseServiceKey: SUPABASE_SERVICE_ROLE_KEY,
+    r2AccountId: R2_ACCOUNT_ID,
+    r2AccessKeyId: R2_ACCESS_KEY_ID,
+    r2SecretAccessKey: R2_SECRET_ACCESS_KEY,
+    r2BucketName: R2_BUCKET_NAME,
+    concurrency: Number(MIGRATION_CONCURRENCY || 5),
+  }
+}
+
+async function streamToBuffer(stream) {
+  const chunks = []
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks)
+}
+
+async function main() {
+  const env = getEnv()
+
+  const supabase = createClient(env.supabaseUrl, env.supabaseServiceKey)
+
+  const s3 = new S3Client({
+    region: 'auto',
+    endpoint: `https://${env.r2AccountId}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: env.r2AccessKeyId,
+      secretAccessKey: env.r2SecretAccessKey,
+    },
+  })
+
+  console.log(`Fetching sounds from Supabase...`)
+  const { data: sounds, error } = await supabase.from('sounds').select('id, r2_object_key')
+  if (error) {
+    throw new Error(`Failed to fetch sounds: ${error.message}`)
+  }
+  if (!sounds || sounds.length === 0) {
+    console.log('No sounds found to migrate.')
+    return
+  }
+
+  const limit = pLimit(env.concurrency)
+
+  await Promise.all(
+    sounds.map((sound) =>
+      limit(async () => {
+        const { id, r2_object_key: oldKey } = sound
+        if (!oldKey) {
+          console.warn(`Skipping sound ${id}: missing r2_object_key`)
+          return
+        }
+
+        const cleanKey = oldKey.split('?')[0]
+        const extension = path.extname(cleanKey)
+        if (!extension) {
+          console.error(`Skipping sound ${id}: could not determine file extension from key "${oldKey}"`)
+          return
+        }
+
+        const newKey = `${id}${extension}`
+
+        if (cleanKey === newKey) {
+          console.log(`Skipping sound ${id}: already stored as ${newKey}`)
+          return
+        }
+
+        try {
+          console.log(`Migrating sound ${id}: ${oldKey} → ${newKey}`)
+          const objectResponse = await s3.send(
+            new GetObjectCommand({
+              Bucket: env.r2BucketName,
+              Key: cleanKey,
+            })
+          )
+
+          const body = objectResponse.Body
+          if (!body) {
+            throw new Error('Empty object body received from R2')
+          }
+
+          const buffer = await streamToBuffer(body)
+
+          await s3.send(
+            new PutObjectCommand({
+              Bucket: env.r2BucketName,
+              Key: newKey,
+              Body: buffer,
+              ContentType: objectResponse.ContentType,
+            })
+          )
+
+          const { error: updateError } = await supabase
+            .from('sounds')
+            .update({ r2_object_key: newKey })
+            .eq('id', id)
+
+          if (updateError) {
+            throw new Error(`Supabase update failed: ${updateError.message}`)
+          }
+
+          console.log('Updated Supabase record')
+        } catch (migrationError) {
+          console.error(`Failed to migrate sound ${id}:`, migrationError)
+        }
+      })
+    )
+  )
+
+  console.log('Migration complete.')
+}
+
+main().catch((err) => {
+  console.error('Migration failed:', err)
+  process.exit(1)
+})

--- a/migrate_flat_r2.js
+++ b/migrate_flat_r2.js
@@ -53,6 +53,18 @@ function normalizeKey(key) {
     .trim()
 }
 
+function stripBucketPrefix(key, bucketName) {
+  if (!key || !bucketName) return key
+  const normalizedBucket = normalizeKey(bucketName)
+  const normalizedKey = normalizeKey(key)
+
+  if (normalizedKey.startsWith(`${normalizedBucket}/`)) {
+    return normalizedKey.slice(normalizedBucket.length + 1)
+  }
+
+  return normalizedKey
+}
+
 function resolveLegacyKey(sound) {
   const rawPath = normalizeKey(sound.path)
   const base = normalizeKey(sound.plan_tier) || 'users'
@@ -116,7 +128,8 @@ async function main() {
         }
 
         const cleanKey = normalizeKey(legacyKey)
-        const extension = resolveExtension(sound, cleanKey)
+        const effectiveKey = stripBucketPrefix(cleanKey, env.r2BucketName)
+        const extension = resolveExtension(sound, effectiveKey)
         if (!extension) {
           console.error(
             `Skipping sound ${sound.id}: could not determine file extension from key "${legacyKey}" or name "${sound.name}"`
@@ -126,7 +139,7 @@ async function main() {
 
         const newKey = `${sound.id}${extension}`
 
-        if (cleanKey === newKey) {
+        if (effectiveKey === newKey) {
           console.log(`Skipping sound ${sound.id}: already stored as ${newKey}`)
           return
         }
@@ -136,7 +149,7 @@ async function main() {
           const objectResponse = await s3.send(
             new GetObjectCommand({
               Bucket: env.r2BucketName,
-              Key: cleanKey,
+              Key: effectiveKey,
             })
           )
 


### PR DESCRIPTION
## Summary
- add a standalone Node.js script to migrate R2 objects into a flat `<id>.<ext>` namespace
- reupload each file to the bucket root and update the corresponding `sounds` record
- include concurrency limiting, .env.local support, and detailed logging

## Testing
- not run (utility script only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921121ce8c4832f8bcf604f351151e5)