### PR TITLE
Use sound IDs for admin ingest storage keys

### DIFF
--- a/admin_ingest/src/AdminIngest.vue
+++ b/admin_ingest/src/AdminIngest.vue
@@ -239,8 +239,6 @@ async function uploadCurrent() {
     await uploadFileAndInsert({
       file: fileEntry.file,
       userId: user.value.id,
-      planTier: metadata.plan_tier,
-      bucket: metadata.bucket,
       metadata
     })
     fileEntry.uploaded = true

--- a/admin_ingest/src/utils/SoundUploader.js
+++ b/admin_ingest/src/utils/SoundUploader.js
@@ -2,17 +2,26 @@ import { supabase } from './supabaseClient'
 import { requestPreviewGeneration } from '@app/utils/previewGeneration'
 import { buildApiUrl } from '@app/utils/apiBase'
 
+function getFileExtension(filename = '') {
+  const lastDot = filename.lastIndexOf('.')
+  if (lastDot === -1 || lastDot === filename.length - 1) return ''
+  return filename.slice(lastDot + 1).toLowerCase()
+}
+
+function buildStorageKey(soundId, extension) {
+  const extSegment = extension ? `.${extension}` : ''
+  return `${soundId}${extSegment}`
+}
+
 /**
  * Fetch a signed upload URL using the exact flow the customer-facing uploader uses.
  * Admin ingest writes to {planTier}/{bucket}/{generatedKey} while retaining the user
  * fallback for customer uploads.
  */
-async function getSignedUploadUrl({ userId, filename, planTier, bucket }) {
-  const params = new URLSearchParams({ filename })
-
-  if (userId) params.set('userId', userId)
-  if (planTier) params.set('planTier', planTier)
-  if (bucket) params.set('bucket', bucket)
+async function getSignedUploadUrl({ key, filename }) {
+  const params = new URLSearchParams()
+  if (filename) params.set('filename', filename)
+  if (key) params.set('key', key)
 
   const endpoint = buildApiUrl(`/api/get-upload-url?${params.toString()}`)
   const response = await fetch(endpoint)
@@ -74,35 +83,44 @@ function uploadViaXhr(file, signedUrl) {
  * @param {string} options.bucket
  * @param {Object} options.metadata - payload destined for public.sound_files
  */
-export async function uploadFileAndInsert({ file, userId, planTier, bucket, metadata }) {
+export async function uploadFileAndInsert({ file, userId, metadata }) {
   if (!userId) {
     throw new Error('Supabase user is required before uploading')
   }
 
-  const { signedUrl, key, base, bucket: bucketSegment } = await getSignedUploadUrl({
-    userId,
-    filename: file.name,
-    planTier,
-    bucket
-  })
-  await uploadViaXhr(file, signedUrl)
-
-  const payload = {
+  const extension = getFileExtension(file.name)
+  const insertPayload = {
     ...metadata,
-    path: key,
     size: file.size,
     mime_type: file.type,
     preview_url: null
   }
 
-  const { data, error } = await supabase.from('sound_files').insert(payload).select('id').single()
-  if (error) {
-    throw error
+  const { data: created, error: insertError } = await supabase
+    .from('sound_files')
+    .insert(insertPayload)
+    .select('id')
+    .single()
+
+  if (insertError) {
+    throw insertError
   }
 
-  if (data?.id) {
-    await requestPreviewGeneration({ key, base, bucket: bucketSegment ?? bucket, soundId: data.id })
+  const storageKey = buildStorageKey(created.id, extension)
+
+  const { signedUrl } = await getSignedUploadUrl({ key: storageKey, filename: file.name })
+  await uploadViaXhr(file, signedUrl)
+
+  const { error: updateError } = await supabase
+    .from('sound_files')
+    .update({ path: storageKey })
+    .eq('id', created.id)
+
+  if (updateError) {
+    throw updateError
   }
 
-  return { key }
+  await requestPreviewGeneration({ key: storageKey, soundId: created.id })
+
+  return { key: storageKey, soundId: created.id }
 }

--- a/api/generate-preview.js
+++ b/api/generate-preview.js
@@ -30,16 +30,6 @@ function loadEnv() {
   }
 }
 
-function safeSegment(value) {
-  if (!value) return ''
-  return value
-    .toString()
-    .trim()
-    .replace(/[^a-zA-Z0-9_-]+/g, '-')
-    .replace(/-{2,}/g, '-')
-    .replace(/^-|-$/g, '')
-}
-
 function createR2Client({ accessKeyId, secretAccessKey, accountId }) {
   return new S3Client({
     region: 'auto',
@@ -111,29 +101,28 @@ export async function POST(request) {
       )
     }
 
-    const { key, base, bucket, soundId } = await request.json()
+    const { key, soundId } = await request.json()
 
-    if (!key || !bucket || !soundId) {
+    if (!key || !soundId) {
       return new Response(
         JSON.stringify({
           error: 'Missing required fields',
-          message: 'key, bucket, and soundId are required to generate a preview.'
+          message: 'key and soundId are required to generate a preview.'
         }),
         { status: 400, headers: { 'Content-Type': 'application/json' } }
       )
     }
 
-    const safeBase = safeSegment(base) || 'users'
-    const safeBucket = safeSegment(bucket)
-    if (!safeBucket) {
+    const sanitizedKey = key.toString().replace(/\s+/g, '').replace(/\/+/g, '')
+    if (!sanitizedKey || sanitizedKey.includes('..') || sanitizedKey.includes('/')) {
       return new Response(
-        JSON.stringify({ error: 'Invalid bucket identifier' }),
+        JSON.stringify({ error: 'Invalid object key provided' }),
         { status: 400, headers: { 'Content-Type': 'application/json' } }
       )
     }
 
     const r2 = createR2Client(env)
-    const originalKey = `${safeBase}/${safeBucket}/${key}`
+    const originalKey = sanitizedKey
 
     const tmpDir = os.tmpdir()
     const inputPath = path.join(tmpDir, `${randomUUID()}-source`)

--- a/api/get-upload-url.js
+++ b/api/get-upload-url.js
@@ -66,19 +66,6 @@ function createRandomId() {
   return Math.random().toString(36).slice(2);
 }
 
-function sanitizeSegment(value) {
-  if (!value) return ''
-  return value
-    .toString()
-    .trim()
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-zA-Z0-9_-]+/g, '-')
-    .replace(/-{2,}/g, '-')
-    .replace(/^-|-$/g, '')
-    .toLowerCase()
-}
-
 function generateObjectKey(filename) {
   const timestamp = Date.now().toString(36);
   const randomId = createRandomId().slice(0, 16);
@@ -158,14 +145,12 @@ export async function GET(request) {
     });
 
     const { searchParams } = new URL(request.url);
-    const userId = searchParams.get("userId");
     const filename = searchParams.get("filename");
-    const planTier = searchParams.get("planTier");
-    const bucket = searchParams.get("bucket");
+    const providedKey = searchParams.get("key");
 
-    if (!filename) {
+    if (!filename && !providedKey) {
       return new Response(
-        JSON.stringify({ error: "Missing 'filename' query param" }),
+        JSON.stringify({ error: "Missing 'filename' or 'key' query param" }),
         {
           status: 400,
           headers: {
@@ -176,30 +161,12 @@ export async function GET(request) {
       );
     }
 
-    const safeBase = sanitizeSegment(planTier);
-    const safeBucket = sanitizeSegment(bucket);
+    const sanitizedKey = providedKey
+      ? sanitizeFilename(providedKey.replace(/\//g, ""))
+      : generateObjectKey(filename);
 
-    let storagePrefix = "";
-    if (safeBase && safeBucket) {
-      storagePrefix = `${safeBase}/${safeBucket}`;
-    } else if (userId) {
-      storagePrefix = `users/${userId}`;
-    } else {
-      return new Response(
-        JSON.stringify({ error: "Missing 'planTier'/'bucket' or 'userId' query params" }),
-        {
-          status: 400,
-          headers: {
-            ...corsHeaders,
-            "Content-Type": "application/json",
-          },
-        }
-      );
-    }
-
-    const generatedKey = generateObjectKey(filename);
     const url = new URL(
-      `https://${bucketName}.${accountId}.r2.cloudflarestorage.com/${storagePrefix}/${generatedKey}`
+      `https://${bucketName}.${accountId}.r2.cloudflarestorage.com/${sanitizedKey}`
     );
     url.searchParams.set("X-Amz-Expires", "120");
 
@@ -210,10 +177,8 @@ export async function GET(request) {
     return new Response(
       JSON.stringify({
         signedUrl: signed.url,
-        key: generatedKey,
-        displayName: filename,
-        base: safeBase || "users",
-        bucket: safeBucket || userId,
+        key: sanitizedKey,
+        displayName: filename || sanitizedKey,
       }),
       {
         status: 200,

--- a/src/components/ui/modals/SoundLibrary/UploadPanel.vue
+++ b/src/components/ui/modals/SoundLibrary/UploadPanel.vue
@@ -162,7 +162,7 @@ async function uploadAll() {
 
   const uploadPromises = files.value.map(file =>
     limit(async () => {
-      const { key: storageKey, base, bucket } = await uploadAudio(file.raw, user.value.id, (percent) => {
+      const { key: storageKey } = await uploadAudio(file.raw, user.value.id, (percent) => {
         file.progress = percent
       })
       const duration = await getFileDuration(file.raw)
@@ -188,8 +188,6 @@ async function uploadAll() {
       if (data?.id) {
         await requestPreviewGeneration({
           key: storageKey,
-          base,
-          bucket,
           soundId: data.id
         })
       }

--- a/src/utils/uploadAudio.js
+++ b/src/utils/uploadAudio.js
@@ -48,7 +48,7 @@ async function getSignedUploadUrl(userId, displayName) {
  * @returns {Promise<string>} key of the uploaded file
  */
 export default async function uploadAudio(file, userId, onProgress) {
-  const { signedUrl, key, base, bucket } = await getSignedUploadUrl(userId, file.name);
+  const { signedUrl, key } = await getSignedUploadUrl(userId, file.name);
 
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
@@ -62,7 +62,7 @@ export default async function uploadAudio(file, userId, onProgress) {
 
     xhr.onload = () => {
       if (xhr.status >= 200 && xhr.status < 300) {
-        resolve({ key, base, bucket });
+        resolve({ key });
       } else {
         reject(new Error(`Upload failed with status ${xhr.status}`));
       }


### PR DESCRIPTION
## Summary
- sign R2 uploads using provided object keys and remove bucket/tier folder handling
- derive admin ingest upload filenames from the inserted sound ID and update Supabase with the flat key
- generate previews from flat keys and align UI upload flows with the simplified API

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69214a7abe48832f8fa4c129f107e2e1)