### PR TITLE
Allow previewing sounds regardless of tier

### DIFF
--- a/src/components/ui/modals/SoundLibrary/SoundPreviewCircle.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundPreviewCircle.vue
@@ -116,10 +116,6 @@ watch(
 )
 
 async function togglePlay() {
-  if (props.locked) {
-    emit('locked')
-    return
-  }
   if (isLoading.value) return
   if (isPlaying.value) {
     stopPlayback()


### PR DESCRIPTION
## Summary
- allow sound previews to play without checking plan lock state

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69215cc04c20832f8e072ae6ef23b958)