### PR TITLE
Allow previewing gated library sounds

### DIFF
--- a/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
@@ -19,7 +19,7 @@
     <SoundPreviewCircle
       :soundData="sound"
       :currentlyPlayingId="currentlyPlayingId"
-      :locked="sound.locked && !isLoaded"
+      :locked="previewLocked"
       @updateCurrent="$emit('updateCurrent', $event)"
       @locked="$emit('locked', sound)"
     />
@@ -81,6 +81,8 @@ const badgeClass = computed(() => {
   }
   return getPlanBadgeClass(normalizedTier.value)
 })
+
+const previewLocked = computed(() => props.sound.accessReason === 'ownership')
 
 const buttonLabel = computed(() => {
   if (isLoaded.value) return 'Remove'


### PR DESCRIPTION
## Summary
- allow sound previews even when the sound is gated by plan tier
- keep ownership-locked sounds restricted while leaving add-to-canvas gating intact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69215fda08b0832f82d423d878603ff2)