### PR TITLE
Add background grid to canvas stage

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -4,7 +4,7 @@
     role="application"
     tabindex="0"
     aria-label="SoundRoom 2D audio environment. Use keyboard or mouse to interact with sound nodes."
-    class="relative flex items-center justify-center border border-neutral-300 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-900 canvas-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+    class="relative flex items-center justify-center border border-neutral-300 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-900 canvas-surface grid-theme-light dark:grid-theme-dark focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
     :class="`w-[${room.width}px] h-[${room.height}px]`"
     @dragover.prevent
     @drop="handleDrop"
@@ -123,8 +123,8 @@ const soundNodeTitleCoords = computed(() => {
 /* Subtle surface treatment: tweak variables below to adjust grid spacing, line opacity, or vignette strength. */
 .canvas-surface {
   --grid-size: 40px; /* change to tighten/loosen spacing */
-  --grid-line: rgba(0, 0, 0, 0.06); /* lighten/darken grid in light mode */
-  --vignette-edge: rgba(0, 0, 0, 0.16); /* increase for deeper edge falloff */
+  --grid-line: rgba(0, 0, 0, 0.08); /* light-mode grid visibility */
+  --vignette-edge: rgba(0, 0, 0, 0.18); /* increase for deeper edge falloff */
 
   background-image:
     radial-gradient(ellipse at center, rgba(255, 255, 255, 0) 45%, var(--vignette-edge) 100%),
@@ -136,8 +136,14 @@ const soundNodeTitleCoords = computed(() => {
     var(--grid-size) var(--grid-size);
 }
 
-:global(.dark) .canvas-surface {
-  --grid-line: rgba(255, 255, 255, 0.06);
-  --vignette-edge: rgba(0, 0, 0, 0.32);
+/* Theme-aware tokens applied via Tailwind dark: variant for guaranteed visibility. */
+.grid-theme-light {
+  --grid-line: rgba(0, 0, 0, 0.1); /* 10% opacity to ensure visibility on light bg */
+  --vignette-edge: rgba(0, 0, 0, 0.2);
+}
+
+.grid-theme-dark {
+  --grid-line: rgba(255, 255, 255, 0.12); /* brighter lines for dark mode */
+  --vignette-edge: rgba(0, 0, 0, 0.44);
 }
 </style>

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -4,7 +4,7 @@
     role="application"
     tabindex="0"
     aria-label="SoundRoom 2D audio environment. Use keyboard or mouse to interact with sound nodes."
-    class="border-2 border-neutral-400 dark:border-neutral-700 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+    class="relative border-2 border-neutral-400 dark:border-neutral-700 flex items-center justify-center bg-neutral-900 dark:bg-neutral-950 canvas-grid focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
     :class="`w-[${room.width}px] h-[${room.height}px]`"
     @dragover.prevent
     @drop="handleDrop"
@@ -118,3 +118,22 @@ const soundNodeTitleCoords = computed(() => {
 
 
 </script>
+
+<style scoped>
+/* Grid overlay behind the nodes; tweak rgba opacity to soften or sharpen the lines. */
+.canvas-grid {
+  background-image:
+    linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.06) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.06) 1px,
+      transparent 1px
+    );
+  /* Adjust the 40px size to change grid spacing. */
+  background-size: 40px 40px;
+}
+</style>

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -123,7 +123,7 @@ const soundNodeTitleCoords = computed(() => {
 /* Subtle surface treatment: tweak variables below to adjust grid spacing, line opacity, or vignette strength. */
 .canvas-surface {
   --grid-size: 40px; /* change to tighten/loosen spacing */
-  --grid-line: rgba(0, 0, 0, 0.08); /* light-mode grid visibility */
+  --grid-line: rgba(0, 0, 0, 0.12); /* dark grid lines for light mode */
   --vignette-edge: rgba(0, 0, 0, 0.18); /* increase for deeper edge falloff */
 
   background-image:
@@ -138,12 +138,12 @@ const soundNodeTitleCoords = computed(() => {
 
 /* Theme-aware tokens applied via Tailwind dark: variant for guaranteed visibility. */
 .grid-theme-light {
-  --grid-line: rgba(0, 0, 0, 0.1); /* 10% opacity to ensure visibility on light bg */
+  --grid-line: rgba(0, 0, 0, 0.12); /* slightly darker lines for light backgrounds */
   --vignette-edge: rgba(0, 0, 0, 0.2);
 }
 
 .grid-theme-dark {
-  --grid-line: rgba(255, 255, 255, 0.12); /* brighter lines for dark mode */
+  --grid-line: rgba(255, 255, 255, 0.14); /* lighter lines for dark mode */
   --vignette-edge: rgba(0, 0, 0, 0.44);
 }
 </style>

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -4,7 +4,7 @@
     role="application"
     tabindex="0"
     aria-label="SoundRoom 2D audio environment. Use keyboard or mouse to interact with sound nodes."
-    class="relative border-2 border-neutral-400 dark:border-neutral-700 flex items-center justify-center bg-neutral-900 dark:bg-neutral-950 canvas-grid focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+    class="relative flex items-center justify-center border border-neutral-300 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-900 canvas-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
     :class="`w-[${room.width}px] h-[${room.height}px]`"
     @dragover.prevent
     @drop="handleDrop"
@@ -120,20 +120,24 @@ const soundNodeTitleCoords = computed(() => {
 </script>
 
 <style scoped>
-/* Grid overlay behind the nodes; tweak rgba opacity to soften or sharpen the lines. */
-.canvas-grid {
+/* Subtle surface treatment: tweak variables below to adjust grid spacing, line opacity, or vignette strength. */
+.canvas-surface {
+  --grid-size: 40px; /* change to tighten/loosen spacing */
+  --grid-line: rgba(0, 0, 0, 0.06); /* lighten/darken grid in light mode */
+  --vignette-edge: rgba(0, 0, 0, 0.16); /* increase for deeper edge falloff */
+
   background-image:
-    linear-gradient(
-      to right,
-      rgba(255, 255, 255, 0.06) 1px,
-      transparent 1px
-    ),
-    linear-gradient(
-      to bottom,
-      rgba(255, 255, 255, 0.06) 1px,
-      transparent 1px
-    );
-  /* Adjust the 40px size to change grid spacing. */
-  background-size: 40px 40px;
+    radial-gradient(ellipse at center, rgba(255, 255, 255, 0) 45%, var(--vignette-edge) 100%),
+    linear-gradient(to right, var(--grid-line) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--grid-line) 1px, transparent 1px);
+  background-size:
+    auto,
+    var(--grid-size) var(--grid-size),
+    var(--grid-size) var(--grid-size);
+}
+
+:global(.dark) .canvas-surface {
+  --grid-line: rgba(255, 255, 255, 0.06);
+  --vignette-edge: rgba(0, 0, 0, 0.32);
 }
 </style>


### PR DESCRIPTION
## Summary
- add subtle dark grid background to the SoundRoom main canvas container
- document grid opacity and spacing for easy tuning

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692163d046a8832fb397ce424a2df058)