### PR TITLE
Add background grid to SoundRoom canvas

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -4,7 +4,7 @@
     role="application"
     tabindex="0"
     aria-label="SoundRoom 2D audio environment. Use keyboard or mouse to interact with sound nodes."
-    class="border-2 border-neutral-400 dark:border-neutral-700 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+    class="canvas-grid border-2 border-neutral-400 dark:border-neutral-700 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
     :class="`w-[${room.width}px] h-[${room.height}px]`"
     @dragover.prevent
     @drop="handleDrop"
@@ -118,3 +118,19 @@ const soundNodeTitleCoords = computed(() => {
 
 
 </script>
+
+<style scoped>
+/* Grid spacing and line opacity can be tuned here to adjust density/visibility */
+.canvas-grid {
+  background-size: 40px 40px; /* Adjust spacing between grid lines */
+  background-image:
+    linear-gradient(to right, rgba(0, 0, 0, 0.06) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(0, 0, 0, 0.06) 1px, transparent 1px); /* Adjust line opacity */
+}
+
+:global(.dark) .canvas-grid {
+  background-image:
+    linear-gradient(to right, rgba(255, 255, 255, 0.08) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.08) 1px, transparent 1px); /* Adjust dark mode opacity separately */
+}
+</style>

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -128,9 +128,11 @@ const soundNodeTitleCoords = computed(() => {
     linear-gradient(to bottom, rgba(0, 0, 0, 0.06) 1px, transparent 1px); /* Adjust line opacity */
 }
 
-:global(.dark) .canvas-grid {
-  background-image:
-    linear-gradient(to right, rgba(255, 255, 255, 0.08) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(255, 255, 255, 0.08) 1px, transparent 1px); /* Adjust dark mode opacity separately */
+@media (prefers-color-scheme: dark) {
+  .canvas-grid {
+    background-image:
+      linear-gradient(to right, rgba(255, 255, 255, 0.08) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.08) 1px, transparent 1px); /* Adjust dark mode opacity separately */
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- add a low-contrast grid background to the SoundRoom canvas container that adapts to theme
- document adjustable grid spacing and opacity within scoped styles

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69216cf1a304832fbf1e046df84dc1e8)