### PR TITLE
Add vignette styling to canvas area

### DIFF
--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -202,12 +202,28 @@ onUnmounted(() => {
 
 <style scoped>
 .canvas-vignette {
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0.04) 40%, rgba(0, 0, 0, 0.25) 100%);
-  box-shadow: inset 0 0 80px rgba(0, 0, 0, 0.25);
+  --vignette-inner: rgba(255, 255, 255, 0.12);
+  --vignette-middle: rgba(255, 255, 255, 0.05);
+  --vignette-outer: rgba(0, 0, 0, 0.23);
+  --vignette-shadow: inset 0 0 90px rgba(0, 0, 0, 0.24);
+
+  background: radial-gradient(circle at center, var(--vignette-inner) 0%, var(--vignette-middle) 38%, var(--vignette-outer) 100%);
+  box-shadow: var(--vignette-shadow);
 }
 
 :global(.dark) .canvas-vignette {
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.1) 0%, rgba(255, 255, 255, 0.02) 38%, rgba(0, 0, 0, 0.45) 100%);
-  box-shadow: inset 0 0 120px rgba(0, 0, 0, 0.4);
+  --vignette-inner: rgba(255, 255, 255, 0.1);
+  --vignette-middle: rgba(255, 255, 255, 0.03);
+  --vignette-outer: rgba(0, 0, 0, 0.48);
+  --vignette-shadow: inset 0 0 140px rgba(0, 0, 0, 0.42);
+}
+
+@media (prefers-color-scheme: dark) {
+  .canvas-vignette {
+    --vignette-inner: rgba(255, 255, 255, 0.1);
+    --vignette-middle: rgba(255, 255, 255, 0.03);
+    --vignette-outer: rgba(0, 0, 0, 0.48);
+    --vignette-shadow: inset 0 0 140px rgba(0, 0, 0, 0.42);
+  }
 }
 </style>

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -17,7 +17,8 @@
         <Toolbar/>
 
         <!-- Canvas Area -->
-        <div class="flex-1 bg-neutral-200 dark:bg-black flex items-center justify-center">
+        <div class="flex-1 relative overflow-hidden bg-neutral-100 dark:bg-neutral-900 flex items-center justify-center">
+          <div class="pointer-events-none absolute inset-0 canvas-vignette" aria-hidden="true"></div>
           <MainCanvasStage
             v-bind="{
               handleDrop,
@@ -198,3 +199,15 @@ onUnmounted(() => {
   // void cacheStore.audioCacheManager.clearPersistentCache()
 })
 </script>
+
+<style scoped>
+.canvas-vignette {
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0.04) 40%, rgba(0, 0, 0, 0.25) 100%);
+  box-shadow: inset 0 0 80px rgba(0, 0, 0, 0.25);
+}
+
+:global(.dark) .canvas-vignette {
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.1) 0%, rgba(255, 255, 255, 0.02) 38%, rgba(0, 0, 0, 0.45) 100%);
+  box-shadow: inset 0 0 120px rgba(0, 0, 0, 0.4);
+}
+</style>

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -211,16 +211,9 @@ onUnmounted(() => {
   box-shadow: var(--vignette-shadow);
 }
 
-:global(.dark) .canvas-vignette {
-  --vignette-inner: rgba(255, 255, 255, 0.1);
-  --vignette-middle: rgba(255, 255, 255, 0.03);
-  --vignette-outer: rgba(0, 0, 0, 0.48);
-  --vignette-shadow: inset 0 0 140px rgba(0, 0, 0, 0.42);
-}
-
 @media (prefers-color-scheme: dark) {
   .canvas-vignette {
-    --vignette-inner: rgba(255, 255, 255, 0.1);
+    --vignette-inner: rgba(224, 224, 224, 0.1);
     --vignette-middle: rgba(255, 255, 255, 0.03);
     --vignette-outer: rgba(0, 0, 0, 0.48);
     --vignette-shadow: inset 0 0 140px rgba(0, 0, 0, 0.42);


### PR DESCRIPTION
## Summary
- add a subtle vignette overlay to the canvas container to visually separate it from the surrounding layout
- adjust the canvas background tone for light and dark themes to feel distinct from the app chrome

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69217150c684832f9f2f23a441e64656)