### PR TITLE
Add listener icon component and overlay

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/ListenerIcon.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerIcon.vue
@@ -1,0 +1,27 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 32 32"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="transition-transform duration-150 ease-out"
+    :class="isActive ? 'scale-105 drop-shadow-[0_0_10px_rgba(59,130,246,0.35)]' : ''"
+    aria-hidden="true"
+  >
+    <circle cx="16" cy="16" r="10.5" />
+    <path d="M16 4.5 19.5 10h-7Z" />
+    <path d="M12.5 15.75a3.5 3.5 0 1 1 7 0c0 1.93-1.57 4-3.5 4s-3.5-2.07-3.5-4Z" />
+  </svg>
+</template>
+
+<script setup>
+defineProps({
+  isActive: {
+    type: Boolean,
+    default: false,
+  },
+})
+</script>

--- a/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
@@ -9,15 +9,15 @@
     @dragmove="onListenerDragMove"
   >
 
-    <!-- Listener Dot -->
+    <!-- Invisible hit targets (visual handled by ListenerIcon overlay) -->
     <v-circle
-      :radius="10"
-      fill="#00f"
+      :radius="12"
+      fill="rgba(0,0,255,0.2)"
+      opacity="0"
       @mousedown="onListenerMouseDown"
       @mouseup="onListenerMouseUp"
     />
 
-    <!-- Direction Diamond -->
     <v-shape
       :sceneFunc="(ctx, shape) => {
         ctx.beginPath()
@@ -32,6 +32,7 @@
       fill="#fff"
       stroke="#000"
       :strokeWidth="1"
+      opacity="0"
       @mousedown="onListenerMouseDown"
       @mouseup="onListenerMouseUp"
     />

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -4,7 +4,7 @@
     role="application"
     tabindex="0"
     aria-label="SoundRoom 2D audio environment. Use keyboard or mouse to interact with sound nodes."
-    class="canvas-grid border-2 border-neutral-400 dark:border-neutral-700 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+    class="canvas-grid border-2 border-neutral-400 dark:border-neutral-700 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 relative"
     :class="`w-[${room.width}px] h-[${room.height}px]`"
     @dragover.prevent
     @drop="handleDrop"
@@ -40,6 +40,21 @@
       </v-layer>
     </v-stage>
 
+    <div
+      v-if="listenerIconPosition"
+      class="pointer-events-none absolute"
+      :style="{
+        left: `${listenerIconPosition.x}px`,
+        top: `${listenerIconPosition.y}px`,
+        transform: `translate(-50%, -50%) rotate(${listenerIconPosition.angle}deg)`
+      }"
+    >
+      <ListenerIcon
+        :is-active="isPlaying"
+        class="w-10 h-10 text-blue-400 drop-shadow-md"
+      />
+    </div>
+
     <!-- Labels — depends if they're meaningful or decorative -->
     <SoundSourceLabel
       v-for="sntc in soundNodeTitleCoords"
@@ -55,16 +70,23 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import ContextMenu from '@/components/ui/context/ContextMenu.vue'
 import SoundSourceNode from '@/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue'
 import ListenerNode from '@/components/SoundRoom/MainCanvasStage/ListenerNode.vue'
+import ListenerIcon from '@/components/SoundRoom/MainCanvasStage/ListenerIcon.vue'
 
 import SoundSourceLabel from '@/components/ui/text/SoundSourceLabel.vue'
 
 import { useRoomStore } from '@/stores/useRoomStore'
 import { useAudioEngineStore } from '@/stores/useAudioEngineStore'
 import { useCanvasStore } from '@/stores/useCanvasStore'
+import { useListenerStore } from '@/stores/useListenerStore'
 import { storeToRefs } from 'pinia'
 
-const { room } = storeToRefs(useRoomStore())
-const { audioEngine } = storeToRefs(useAudioEngineStore())
+const roomStore = useRoomStore()
+const audioEngineStore = useAudioEngineStore()
+const listenerStore = useListenerStore()
+
+const { room } = storeToRefs(roomStore)
+const { audioEngine, isPlaying } = storeToRefs(audioEngineStore)
+const { listener } = storeToRefs(listenerStore)
 
 const props = defineProps({
   handleDrop: Function,
@@ -115,6 +137,13 @@ const soundNodeTitleCoords = computed(() => {
     name: sn.name,
   }))
 })
+
+
+const listenerIconPosition = computed(() => ({
+  x: listener.value.x,
+  y: listener.value.y,
+  angle: listener.value.angle,
+}))
 
 
 </script>

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -46,7 +46,7 @@
       :style="{
         left: `${listenerIconPosition.x}px`,
         top: `${listenerIconPosition.y}px`,
-        transform: `translate(-50%, -50%) rotate(${listenerIconPosition.angle}deg)`
+        transform: `translate(-50%, -50%) rotate(${listenerIconPosition.angle - 180}deg)`
       }"
     >
       <ListenerIcon


### PR DESCRIPTION
## Summary
- add a reusable ListenerIcon SVG component with active state styling
- replace the canvas listener graphic with the new icon overlay and hide legacy shapes
- hook the icon into playback state for subtle glow feedback

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921748ca380832f86f72978ba994ecc)