### PR TITLE
Add listener overlay icon component

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
@@ -9,29 +9,11 @@
     @dragmove="onListenerDragMove"
   >
 
-    <!-- Listener Dot -->
+    <!-- Invisible listener hit area (visual handled by overlay icon) -->
     <v-circle
-      :radius="10"
-      fill="#00f"
-      @mousedown="onListenerMouseDown"
-      @mouseup="onListenerMouseUp"
-    />
-
-    <!-- Direction Diamond -->
-    <v-shape
-      :sceneFunc="(ctx, shape) => {
-        ctx.beginPath()
-        ctx.moveTo(0, 0)
-        ctx.lineTo(7, 5)
-        ctx.lineTo(0, 25)
-        ctx.lineTo(-7, 5)
-        ctx.closePath()
-        ctx.fillStrokeShape(shape)
-      }"
-      :rotation="listener.angle"
-      fill="#fff"
-      stroke="#000"
-      :strokeWidth="1"
+      :radius="12"
+      fill="transparent"
+      :opacity="0"
       @mousedown="onListenerMouseDown"
       @mouseup="onListenerMouseUp"
     />
@@ -57,6 +39,9 @@ import { useListenerStore } from '@/stores/useListenerStore';
 import { useActionManagerStore } from '@/stores/useActionManagerStore';
 import { useRoomStore } from '@/stores/useRoomStore';
 import { storeToRefs } from 'pinia';
+
+
+const emit = defineEmits(['active-change'])
 
 
 const { listener } = storeToRefs(useListenerStore())
@@ -89,6 +74,8 @@ function setCursor(e, type) {
 
 function onListenerMouseDown(e) {
   if (e.button === 2) return // if right click, do nothing
+
+  emit('active-change', true)
 
   const stage = e.target.getStage()
   dragStartPos = stage.getPointerPosition()
@@ -152,12 +139,15 @@ function onListenerMouseUp(e) {
   }
 
   moveListenerPayload = null
+  emit('active-change', false)
 }
 
 
 // Rotation handling
 function onHandleMouseDown(e) {
   e.evt.stopPropagation()
+
+  emit('active-change', true)
 
   initialListenerAngle = listener.value.angle
 
@@ -200,6 +190,7 @@ function onHandleMouseUp() {
   }
 
   initialListenerAngle = null
+  emit('active-change', false)
 }
 
 onBeforeUnmount(() => {

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -36,9 +36,19 @@
           @select="$emit('selectNode', $event)"
           @contextmenu="showContextMenu"
         />
-        <ListenerNode/>
+        <ListenerNode @active-change="isListenerActive = $event" />
       </v-layer>
     </v-stage>
+
+    <ListenerIcon
+      class="absolute pointer-events-none -translate-x-1/2 -translate-y-1/2"
+      :style="{
+        left: `${listener.x}px`,
+        top: `${listener.y}px`,
+        transform: `translate(-50%, -50%) rotate(${listener.angle}deg)`,
+      }"
+      :is-active="isListenerActive"
+    />
 
     <!-- Labels — depends if they're meaningful or decorative -->
     <SoundSourceLabel
@@ -55,16 +65,19 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import ContextMenu from '@/components/ui/context/ContextMenu.vue'
 import SoundSourceNode from '@/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue'
 import ListenerNode from '@/components/SoundRoom/MainCanvasStage/ListenerNode.vue'
+import ListenerIcon from '@/components/icons/ListenerIcon.vue'
 
 import SoundSourceLabel from '@/components/ui/text/SoundSourceLabel.vue'
 
 import { useRoomStore } from '@/stores/useRoomStore'
 import { useAudioEngineStore } from '@/stores/useAudioEngineStore'
+import { useListenerStore } from '@/stores/useListenerStore'
 import { useCanvasStore } from '@/stores/useCanvasStore'
 import { storeToRefs } from 'pinia'
 
 const { room } = storeToRefs(useRoomStore())
 const { audioEngine } = storeToRefs(useAudioEngineStore())
+const { listener } = storeToRefs(useListenerStore())
 
 const props = defineProps({
   handleDrop: Function,
@@ -83,6 +96,7 @@ const stageDivRef = ref(null)
 const contextMenuRef = ref(null)
 const vStageRef = ref(null) // for Konva stage
 const coordsVersion = ref(0) // reactive bump trigger
+const isListenerActive = ref(false)
 
 onMounted(() => {
   window.addEventListener('resize', updateCoords)

--- a/src/components/icons/ListenerIcon.vue
+++ b/src/components/icons/ListenerIcon.vue
@@ -1,0 +1,43 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 32 32"
+    fill="none"
+    :class="[
+      'w-8 h-8 text-blue-400 transition duration-150 ease-out',
+      isActive ? 'scale-110 drop-shadow-[0_0_10px_rgba(96,165,250,0.7)]' : 'scale-100'
+    ]"
+    aria-hidden="true"
+  >
+    <circle
+      cx="16"
+      cy="16"
+      r="10"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+    />
+    <path
+      d="M16 4.8 19.5 9.8h-7z"
+      stroke="currentColor"
+      stroke-width="1.6"
+      stroke-linejoin="round"
+      stroke-linecap="round"
+    />
+    <path
+      d="M16 9.5v2.5"
+      stroke="currentColor"
+      stroke-width="1.6"
+      stroke-linecap="round"
+    />
+  </svg>
+</template>
+
+<script setup>
+const { isActive } = defineProps({
+  isActive: {
+    type: Boolean,
+    default: false,
+  },
+})
+</script>


### PR DESCRIPTION
## Summary
- create a reusable inline-SVG ListenerIcon component with stroke-based styling and active highlighting
- overlay the listener icon on the canvas while preserving existing Konva hit areas and directional rotation
- emit listener interaction state to trigger the active visual cue

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69217a97cd30832fa2472bddeb7a0967)