### PR TITLE
Add inline SVG listener icon overlay

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/ListenerIcon.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerIcon.vue
@@ -1,0 +1,39 @@
+<template>
+  <svg
+    viewBox="0 0 32 32"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    role="presentation"
+    :class="['transition duration-150 ease-out drop-shadow-sm', isActive ? 'scale-110 drop-shadow-[0_0_10px_rgba(96,165,250,0.65)]' : '']"
+  >
+    <circle
+      cx="16"
+      cy="16"
+      r="10"
+      stroke="currentColor"
+      stroke-width="2"
+    />
+    <path
+      d="M16 19 L20 13 H12 Z"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linejoin="round"
+      fill="none"
+    />
+    <path
+      d="M16 11 L16 19"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+    />
+  </svg>
+</template>
+
+<script setup>
+defineProps({
+  isActive: {
+    type: Boolean,
+    default: false,
+  }
+})
+</script>

--- a/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
@@ -12,12 +12,13 @@
     <!-- Listener Dot -->
     <v-circle
       :radius="10"
-      fill="#00f"
+      fill="rgba(0,0,0,0.001)"
+      strokeEnabled="false"
       @mousedown="onListenerMouseDown"
       @mouseup="onListenerMouseUp"
     />
 
-    <!-- Direction Diamond -->
+    <!-- Direction Diamond (hidden; keeps hit target consistent) -->
     <v-shape
       :sceneFunc="(ctx, shape) => {
         ctx.beginPath()
@@ -29,9 +30,7 @@
         ctx.fillStrokeShape(shape)
       }"
       :rotation="listener.angle"
-      fill="#fff"
-      stroke="#000"
-      :strokeWidth="1"
+      opacity="0"
       @mousedown="onListenerMouseDown"
       @mouseup="onListenerMouseUp"
     />
@@ -59,7 +58,8 @@ import { useRoomStore } from '@/stores/useRoomStore';
 import { storeToRefs } from 'pinia';
 
 
-const { listener } = storeToRefs(useListenerStore())
+const listenerStore = useListenerStore()
+const { listener } = storeToRefs(listenerStore)
 const { actionManager } = storeToRefs(useActionManagerStore())
 const { room } = storeToRefs(useRoomStore())
 
@@ -89,6 +89,8 @@ function setCursor(e, type) {
 
 function onListenerMouseDown(e) {
   if (e.button === 2) return // if right click, do nothing
+
+  listenerStore.setIsActive(true)
 
   const stage = e.target.getStage()
   dragStartPos = stage.getPointerPosition()
@@ -152,12 +154,15 @@ function onListenerMouseUp(e) {
   }
 
   moveListenerPayload = null
+  listenerStore.setIsActive(false)
 }
 
 
 // Rotation handling
 function onHandleMouseDown(e) {
   e.evt.stopPropagation()
+
+  listenerStore.setIsActive(true)
 
   initialListenerAngle = listener.value.angle
 
@@ -192,6 +197,8 @@ function onHandleMouseMove(e) {
 function onHandleMouseUp() {
   const finalAngle = listener.value.angle
 
+  listenerStore.setIsActive(false)
+
   if (initialListenerAngle !== null && initialListenerAngle !== finalAngle) {
     actionManager.value.doAction("rotate_listener_angle", {
       from: initialListenerAngle,
@@ -207,6 +214,7 @@ onBeforeUnmount(() => {
     window.removeEventListener('mousemove', mouseMoveListener)
     mouseMoveListener = null
   }
+  listenerStore.setIsActive(false)
 })
 
 </script>

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -40,6 +40,13 @@
       </v-layer>
     </v-stage>
 
+    <ListenerIcon
+      class="pointer-events-none absolute top-0 left-0 w-8 h-8 text-blue-400"
+      :style="listenerIconStyle"
+      :is-active="isListenerActive"
+      aria-hidden="true"
+    />
+
     <!-- Labels — depends if they're meaningful or decorative -->
     <SoundSourceLabel
       v-for="sntc in soundNodeTitleCoords"
@@ -55,16 +62,19 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import ContextMenu from '@/components/ui/context/ContextMenu.vue'
 import SoundSourceNode from '@/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue'
 import ListenerNode from '@/components/SoundRoom/MainCanvasStage/ListenerNode.vue'
+import ListenerIcon from '@/components/SoundRoom/MainCanvasStage/ListenerIcon.vue'
 
 import SoundSourceLabel from '@/components/ui/text/SoundSourceLabel.vue'
 
 import { useRoomStore } from '@/stores/useRoomStore'
 import { useAudioEngineStore } from '@/stores/useAudioEngineStore'
 import { useCanvasStore } from '@/stores/useCanvasStore'
+import { useListenerStore } from '@/stores/useListenerStore'
 import { storeToRefs } from 'pinia'
 
 const { room } = storeToRefs(useRoomStore())
 const { audioEngine } = storeToRefs(useAudioEngineStore())
+const { listener, isActive: isListenerActive } = storeToRefs(useListenerStore())
 
 const props = defineProps({
   handleDrop: Function,
@@ -97,6 +107,11 @@ onUnmounted(() => {
 function updateCoords() {
   coordsVersion.value++
 }
+
+const listenerIconStyle = computed(() => ({
+  transform: `translate(${listener.value.x}px, ${listener.value.y}px) translate(-50%, -50%) rotate(${listener.value.angle}deg)`,
+  transformOrigin: 'center',
+}))
 
 
 const soundNodeTitleCoords = computed(() => {

--- a/src/stores/useListenerStore.js
+++ b/src/stores/useListenerStore.js
@@ -8,6 +8,7 @@ import Listener from '@/lib/Listener'
 
 export const useListenerStore = defineStore('listener', () => {
   const listener = ref(new Listener())
+  const isActive = ref(false)
 
   /**
    * Hydrate the listener from serialized data.
@@ -17,6 +18,7 @@ export const useListenerStore = defineStore('listener', () => {
    */
   function loadListener(data) {
     listener.value = Listener.fromJSON(data)
+    isActive.value = false
   }
 
   /**
@@ -29,17 +31,29 @@ export const useListenerStore = defineStore('listener', () => {
   }
 
   /**
+   * Toggle the active state used for listener visuals.
+   *
+   * @param {boolean} state
+   */
+  function setIsActive(state) {
+    isActive.value = state
+  }
+
+  /**
    * Reset the listener to its initial state.
    */
   function resetListener() {
     listener.value.dispose()
     listener.value = new Listener()
+    isActive.value = false
   }
 
   return {
     listener,
+    isActive,
     loadListener,
     listenerToJSON,
-    resetListener
+    resetListener,
+    setIsActive
   }
 })


### PR DESCRIPTION
## Summary
- add a reusable inline SVG <ListenerIcon> component with active glow support
- overlay the new icon on the canvas while keeping Konva hit targets for listener interactions
- track listener active state in the store so visuals respond during drags and rotations

## Testing
- npm run lint (fails: Missing script "lint")

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69217e361ed4832fb3681542a72b4d9f)