### PR TITLE
Redesign listener icon visuals

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
@@ -9,29 +9,42 @@
     @dragmove="onListenerDragMove"
   >
 
-    <!-- Listener Dot -->
+    <!-- Listener Body -->
     <v-circle
-      :radius="10"
-      fill="#00f"
+      :radius="12"
+      fill="rgba(59, 130, 246, 0.1)"
+      stroke="rgba(59, 130, 246, 0.8)"
+      :strokeWidth="2"
+      shadowColor="rgba(0, 0, 0, 0.15)"
+      shadowBlur="6"
+      shadowOffsetY="2"
+      @mousedown="onListenerMouseDown"
+      @mouseup="onListenerMouseUp"
+    />
+    <v-circle
+      :radius="6"
+      fill="rgba(15, 23, 42, 0.85)"
+      stroke="rgba(59, 130, 246, 0.85)"
+      :strokeWidth="1"
       @mousedown="onListenerMouseDown"
       @mouseup="onListenerMouseUp"
     />
 
-    <!-- Direction Diamond -->
+    <!-- Directional Marker -->
     <v-shape
       :sceneFunc="(ctx, shape) => {
         ctx.beginPath()
-        ctx.moveTo(0, 0)
-        ctx.lineTo(7, 5)
-        ctx.lineTo(0, 25)
-        ctx.lineTo(-7, 5)
+        ctx.moveTo(0, 16)
+        ctx.lineTo(9, -4)
+        ctx.lineTo(-9, -4)
         ctx.closePath()
         ctx.fillStrokeShape(shape)
       }"
       :rotation="listener.angle"
-      fill="#fff"
-      stroke="#000"
-      :strokeWidth="1"
+      fill="rgba(59, 130, 246, 0.9)"
+      stroke="rgba(15, 23, 42, 0.9)"
+      :strokeWidth="1.5"
+      opacity="0.95"
       @mousedown="onListenerMouseDown"
       @mouseup="onListenerMouseUp"
     />

--- a/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
@@ -60,7 +60,37 @@
       fill="transparent"
       @mousedown="onHandleMouseDown"
       @mouseup="onHandleMouseUp"
+      @mouseover="onHandleMouseOver"
+      @mouseout="onHandleMouseOut"
     />
+
+    <!-- Rotation Icon -->
+    <v-group
+      :x="Math.cos(toRad(listener.angle + 90)) * 7"
+      :y="Math.sin(toRad(listener.angle + 90)) * 7"
+      :rotation="listener.angle + 20"
+      :opacity="rotationHandleIconVisible ? 0.85 : 0"
+      listening="false"
+    >
+      <v-arc
+        :innerRadius="10"
+        :outerRadius="14"
+        :angle="220"
+        :rotation="-110"
+        stroke="rgba(59, 130, 246, 0.75)"
+        :strokeWidth="2"
+        lineCap="round"
+      />
+      <v-regular-polygon
+        :x="12"
+        :y="-2"
+        :sides="3"
+        :radius="4"
+        fill="rgba(59, 130, 246, 0.85)"
+        shadowColor="rgba(0, 0, 0, 0.15)"
+        shadowBlur="2"
+      />
+    </v-group>
   </v-group>
 </template>
 
@@ -80,6 +110,8 @@ let moveListenerPayload = null
 let initialMouseAngle = null
 let initialListenerAngle = null
 let mouseMoveListener = null
+
+const rotationHandleIconVisible = ref(false)
 
 
 let dragStartPos = null
@@ -186,6 +218,14 @@ function onHandleMouseDown(e) {
     stage.off("mousemove.listenerRotate")
     stage.off("mouseup.listenerRotate")
   })
+}
+
+function onHandleMouseOver() {
+  rotationHandleIconVisible.value = true
+}
+
+function onHandleMouseOut() {
+  rotationHandleIconVisible.value = false
 }
 
 function onHandleMouseMove(e) {


### PR DESCRIPTION
## Summary
- refresh the listener avatar with layered circles and a directional marker for clearer orientation
- preserve existing listener interaction and rotation bindings while updating styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69220daa4af8832f8831e6fb87b335e6)