### PR TITLE
Refresh sound source node visuals

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
@@ -7,46 +7,73 @@
     @dragmove="onListenerDragMove"
   >
 
+    <!-- Anchor Glow -->
+    <v-circle
+      :radius="22"
+      fill="rgba(59, 130, 246, 0.08)"
+      shadowColor="rgba(59, 130, 246, 0.3)"
+      shadowBlur="18"
+      shadowOpacity="0.35"
+      listening="false"
+    />
+
     <!-- Listener Body -->
     <v-circle
-      :radius="12"
-      fill="rgba(59, 130, 246, 0.1)"
-      stroke="rgba(59, 130, 246, 0.8)"
-      :strokeWidth="2"
-      shadowColor="rgba(0, 0, 0, 0.15)"
-      shadowBlur="6"
-      shadowOffsetY="2"
+      :radius="14"
+      fill="rgba(59, 130, 246, 0.15)"
+      stroke="rgba(96, 165, 250, 0.9)"
+      :strokeWidth="2.5"
+      shadowColor="rgba(0, 0, 0, 0.2)"
+      shadowBlur="10"
+      shadowOpacity="0.55"
       @mousedown="onListenerMouseDown"
       @mouseup="onListenerMouseUp"
       @mouseover="setCursor($event, 'pointer')"
       @mouseout="setCursor($event, 'default')"
     />
     <v-circle
-      :radius="6"
-      fill="rgba(15, 23, 42, 0.85)"
-      stroke="rgba(59, 130, 246, 0.85)"
-      :strokeWidth="1"
+      :radius="8"
+      fill="rgba(15, 23, 42, 0.9)"
+      stroke="rgba(191, 219, 254, 0.85)"
+      :strokeWidth="1.25"
+      shadowColor="rgba(59, 130, 246, 0.35)"
+      shadowBlur="8"
+      shadowOpacity="0.45"
       @mousedown="onListenerMouseDown"
       @mouseup="onListenerMouseUp"
       @mouseover="setCursor($event, 'pointer')"
       @mouseout="setCursor($event, 'default')"
+    />
+    <v-circle
+      :radius="4"
+      fill="rgba(255, 255, 255, 0.75)"
+      stroke="rgba(255, 255, 255, 0.2)"
+      :strokeWidth="0.5"
+      shadowColor="rgba(255, 255, 255, 0.35)"
+      shadowBlur="6"
+      shadowOpacity="0.5"
+      listening="false"
     />
 
     <!-- Directional Marker -->
     <v-shape
       :sceneFunc="(ctx, shape) => {
         ctx.beginPath()
-        ctx.moveTo(0, 16)
-        ctx.lineTo(9, -4)
-        ctx.lineTo(-9, -4)
+        ctx.moveTo(0, 18)
+        ctx.lineTo(9.5, -3.5)
+        ctx.quadraticCurveTo(0, -7, -9.5, -3.5)
         ctx.closePath()
         ctx.fillStrokeShape(shape)
       }"
       :rotation="listener.angle"
-      fill="rgba(59, 130, 246, 0.9)"
-      stroke="rgba(15, 23, 42, 0.9)"
-      :strokeWidth="1.5"
-      opacity="0.95"
+      :fillLinearGradientStartPoint="{ x: -12, y: 12 }"
+      :fillLinearGradientEndPoint="{ x: 12, y: -10 }"
+      :fillLinearGradientColorStops="[0, 'rgba(191, 219, 254, 0.18)', 1, 'rgba(59, 130, 246, 0.85)']"
+      stroke="rgba(15, 23, 42, 0.85)"
+      :strokeWidth="1.25"
+      shadowColor="rgba(59, 130, 246, 0.35)"
+      shadowBlur="6"
+      opacity="0.96"
       @mousedown="onListenerMouseDown"
       @mouseup="onListenerMouseUp"
       @mouseover="setCursor($event, 'pointer')"

--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -3,6 +3,8 @@
     :x="source.instance.state.x"
     :y="source.instance.state.y"
     @dragmove="onSourceDragMove"
+    :scaleX="selectedScale"
+    :scaleY="selectedScale"
   >
     <!-- Outer Cone -->
     <v-wedge
@@ -10,9 +12,11 @@
       :angle="coneOuter"
       :rotation="(-coneOuter / 2) + source.instance.state.angle"
       :radius="50"
-      fill="rgba(255, 100, 100, 0.2)"
-      shadowColor="rgba(255, 100, 100, 0.7)"
-      :shadowBlur="12"
+      fill="rgba(255, 137, 137, 0.16)"
+      :stroke="'rgba(255, 137, 137, 0.28)'"
+      :strokeWidth="1.5"
+      shadowColor="rgba(255, 120, 120, 0.65)"
+      :shadowBlur="18"
       :listening="false"
     />
 
@@ -22,14 +26,33 @@
       :angle="coneInner"
       :rotation="(-coneInner / 2) + source.instance.state.angle"
       :radius="50"
-      fill="rgba(255, 120, 120, 0.2)"
+      fill="rgba(255, 180, 180, 0.18)"
+      :stroke="'rgba(255, 180, 180, 0.35)'"
+      :strokeWidth="1"
       :listening="false"
     />
 
     <!-- Source Dot -->
     <v-circle
+      v-if="props.selected"
+      :radius="16"
+      :stroke="selectionGlowColor"
+      :strokeWidth="3"
+      :opacity="0.75"
+      shadowForStrokeEnabled="true"
+      :shadowColor="selectionGlowColor"
+      :shadowBlur="14"
+      :listening="false"
+    />
+    <v-circle
       :radius="10"
       :fill="getFillColor"
+      :stroke="dotStrokeColor"
+      :strokeWidth="2"
+      :shadowColor="getFillColor"
+      :shadowBlur="10"
+      :shadowOpacity="0.65"
+      shadowForStrokeEnabled="false"
       name="sound-node-part"
       @mousedown="onSourceMouseDown"
       @mouseup="onSourceMouseUp"
@@ -58,9 +81,13 @@
         ctx.fillStrokeShape(shape);
       }"
       :rotation="source.instance.state.angle - 90"
-      fill="#fff"
-      stroke="#000"
-      :strokeWidth="1"
+      :fillLinearGradientStartPoint="{ x: 0, y: 0 }"
+      :fillLinearGradientEndPoint="{ x: 0, y: 25 }"
+      :fillLinearGradientColorStops="[0, 'rgba(255,255,255,0.95)', 1, 'rgba(255,255,255,0.65)']"
+      stroke="rgba(0, 0, 0, 0.6)"
+      :strokeWidth="1.25"
+      :shadowColor="'rgba(0,0,0,0.35)'"
+      :shadowBlur="4"
       @mousedown="onSourceMouseDown"
       @mouseup="onSourceMouseUp"
       @mouseover="setCursor($event, 'pointer')"
@@ -114,6 +141,10 @@ const getFillColor = computed(() => {
   if (props.selected) return '#ff0' // Yellow for selected node
   return isScheduled.value ? '#2e90fa' : '#f44336' // Red for unscheduled/looping
 })
+
+const dotStrokeColor = computed(() => (props.selected ? '#ffffff' : 'rgba(255, 255, 255, 0.9)'))
+const selectionGlowColor = '#6fd7ff'
+const selectedScale = computed(() => (props.selected ? 1.05 : 1))
 
 
 


### PR DESCRIPTION
## Summary
- enhance cone styling with softer gradients and strokes for clarity
- add a selected-state glow ring and slight scale emphasis
- restyle source dot and direction diamond for a modern, readable appearance

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692218dbbac0832fa673916dab952af8)