### PR TITLE
Improve light mode contrast and styling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,11 +7,11 @@
     <div class="flex-1 min-h-0 flex flex-col">
       <div
         v-if="globalError"
-        class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-white text-neutral-900 dark:bg-black dark:text-white"
+        class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-neutral-100 text-neutral-800 dark:bg-black dark:text-white"
       >
         <p class="text-sm uppercase tracking-[0.2em] text-rose-500 mb-3">Navigation error</p>
         <h2 class="text-2xl font-semibold mb-3">We couldn't load that page.</h2>
-        <p class="max-w-md text-gray-600 dark:text-gray-400 mb-8">
+        <p class="max-w-md text-neutral-700 dark:text-gray-400 mb-8">
           {{ globalError.message }}
         </p>
         <div class="flex flex-wrap items-center justify-center gap-3">
@@ -20,7 +20,7 @@
           </BaseButton>
           <BaseButton
             variant="naked"
-            class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 text-sm font-medium"
+            class="text-blue-700 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 text-sm font-medium"
             @click="returnHome"
           >
             Go back home
@@ -37,10 +37,10 @@
             </ErrorBoundary>
           </template>
           <template #fallback>
-            <div class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-white text-neutral-900 dark:bg-black dark:text-white">
+            <div class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-neutral-100 text-neutral-800 dark:bg-black dark:text-white">
               <p class="text-sm uppercase tracking-[0.2em] text-blue-500 mb-3">Loading</p>
               <h2 class="text-2xl font-semibold mb-3">Preparing SoundRoom…</h2>
-              <p class="max-w-md text-gray-600 dark:text-gray-400">
+              <p class="max-w-md text-neutral-700 dark:text-gray-400">
                 Hang tight while we load the experience.
               </p>
             </div>

--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -21,7 +21,7 @@
   />
 
   <!-- Footer Buttons -->
-  <div class="relative flex items-center justify-between h-15 p-2">
+  <div class="relative flex items-center justify-between h-15 p-2 bg-neutral-200 dark:bg-transparent border-t border-neutral-300/60 dark:border-neutral-800 shadow-[0_-3px_12px_rgba(0,0,0,0.08)]">
     <div class="flex space-x-3">
       <BaseButton
         @click="showSaveConfirm = true"

--- a/src/components/SoundRoom/HeaderBar.vue
+++ b/src/components/SoundRoom/HeaderBar.vue
@@ -1,6 +1,6 @@
 <template>
   <PulsingOverlay v-if="isLoggingOut" :duration="2000" :text="'Logging out...'" @done="isLoggingOut = false" />
-  <header class="px-6 py-4 border-b border-neutral-300 dark:border-neutral-800 dark:bg-black flex items-center justify-between relative">
+  <header class="px-6 py-4 border-b border-neutral-300/70 dark:border-neutral-800 bg-neutral-200 dark:bg-black flex items-center justify-between relative">
     <h1 class="text-xl font-bold tracking-wide dark:text-gray-300"><RouterLink to="/" style="text-decoration: none; color: inherit;">SoundRoom</RouterLink></h1>
     
     <div v-if="shouldShowNavButtons" class="relative">
@@ -20,7 +20,7 @@
           v-if="isMenuOpen"
           @mouseleave="closeMenu"
           ref="menuPanel"
-          class="absolute right-0 mt-2 w-44 rounded-lg shadow-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 py-2 z-50 flex flex-col divide-y divide-neutral-200 dark:divide-neutral-800 overflow-hidden"
+          class="absolute right-0 mt-2 w-44 rounded-lg shadow-lg border border-neutral-200 dark:border-neutral-800 bg-neutral-100 dark:bg-neutral-900 py-2 z-50 flex flex-col divide-y divide-neutral-200 dark:divide-neutral-800 overflow-hidden"
         >
           <template v-for="button in visibleButtons" :key="button.label">
             <button

--- a/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
@@ -10,22 +10,22 @@
     <!-- Anchor Glow -->
     <v-circle
       :radius="22"
-      fill="rgba(59, 130, 246, 0.08)"
-      shadowColor="rgba(59, 130, 246, 0.3)"
-      shadowBlur="18"
-      shadowOpacity="0.35"
+      :fill="anchorGlowFill"
+      :shadowColor="anchorShadowColor"
+      :shadowBlur="anchorShadowBlur"
+      :shadowOpacity="anchorShadowOpacity"
       listening="false"
     />
 
     <!-- Listener Body -->
     <v-circle
       :radius="14"
-      fill="rgba(59, 130, 246, 0.15)"
-      stroke="rgba(96, 165, 250, 0.9)"
+      :fill="listenerBodyFill"
+      :stroke="listenerBodyStroke"
       :strokeWidth="2.5"
-      shadowColor="rgba(0, 0, 0, 0.2)"
-      shadowBlur="10"
-      shadowOpacity="0.55"
+      :shadowColor="listenerBodyShadow"
+      :shadowBlur="listenerBodyShadowBlur"
+      :shadowOpacity="listenerBodyShadowOpacity"
       @mousedown="onListenerMouseDown"
       @mouseup="onListenerMouseUp"
       @mouseover="setCursor($event, 'pointer')"
@@ -36,9 +36,9 @@
       fill="rgba(15, 23, 42, 0.9)"
       stroke="rgba(191, 219, 254, 0.85)"
       :strokeWidth="1.25"
-      shadowColor="rgba(59, 130, 246, 0.35)"
-      shadowBlur="8"
-      shadowOpacity="0.45"
+      :shadowColor="innerShadowColor"
+      :shadowBlur="innerShadowBlur"
+      :shadowOpacity="innerShadowOpacity"
       @mousedown="onListenerMouseDown"
       @mouseup="onListenerMouseUp"
       @mouseover="setCursor($event, 'pointer')"
@@ -68,11 +68,11 @@
       :rotation="listener.angle"
       :fillLinearGradientStartPoint="{ x: -12, y: 12 }"
       :fillLinearGradientEndPoint="{ x: 12, y: -10 }"
-      :fillLinearGradientColorStops="[0, 'rgba(191, 219, 254, 0.18)', 1, 'rgba(59, 130, 246, 0.85)']"
-      stroke="rgba(15, 23, 42, 0.85)"
+      :fillLinearGradientColorStops="[0, 'rgba(191, 219, 254, 0.18)', 1, directionGradientEnd]"
+      :stroke="directionStroke"
       :strokeWidth="1.25"
-      shadowColor="rgba(59, 130, 246, 0.35)"
-      shadowBlur="6"
+      :shadowColor="directionShadow"
+      :shadowBlur="6"
       opacity="0.96"
       @mousedown="onListenerMouseDown"
       @mouseup="onListenerMouseUp"
@@ -98,7 +98,7 @@
 </template>
 
 <script setup>
-import { ref, onBeforeUnmount } from 'vue';
+import { ref, onBeforeUnmount, computed } from 'vue';
 import { useListenerStore } from '@/stores/useListenerStore';
 import { useActionManagerStore } from '@/stores/useActionManagerStore';
 import { useRoomStore } from '@/stores/useRoomStore';
@@ -108,6 +108,8 @@ import { storeToRefs } from 'pinia';
 const { listener } = storeToRefs(useListenerStore())
 const { actionManager } = storeToRefs(useActionManagerStore())
 const { room } = storeToRefs(useRoomStore())
+const isDarkMode = document.documentElement.classList.contains('dark') ||
+  (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches)
 
 let moveListenerPayload = null
 let initialMouseAngle = null
@@ -117,6 +119,22 @@ let mouseMoveListener = null
 
 let dragStartPos = null
 const listenerGroup = ref(null)
+
+const anchorGlowFill = computed(() => isDarkMode ? 'rgba(59, 130, 246, 0.08)' : 'rgba(59, 130, 246, 0.06)')
+const anchorShadowColor = computed(() => isDarkMode ? 'rgba(59, 130, 246, 0.3)' : 'rgba(59, 130, 246, 0.2)')
+const anchorShadowBlur = computed(() => isDarkMode ? 18 : 14)
+const anchorShadowOpacity = computed(() => isDarkMode ? 0.35 : 0.22)
+const listenerBodyFill = computed(() => isDarkMode ? 'rgba(59, 130, 246, 0.15)' : 'rgba(59, 130, 246, 0.12)')
+const listenerBodyStroke = computed(() => isDarkMode ? 'rgba(96, 165, 250, 0.9)' : 'rgba(96, 165, 250, 0.82)')
+const listenerBodyShadow = computed(() => isDarkMode ? 'rgba(0, 0, 0, 0.2)' : 'rgba(0, 0, 0, 0.12)')
+const listenerBodyShadowBlur = computed(() => isDarkMode ? 10 : 7)
+const listenerBodyShadowOpacity = computed(() => isDarkMode ? 0.55 : 0.36)
+const innerShadowColor = computed(() => isDarkMode ? 'rgba(59, 130, 246, 0.35)' : 'rgba(59, 130, 246, 0.22)')
+const innerShadowBlur = computed(() => isDarkMode ? 8 : 6)
+const innerShadowOpacity = computed(() => isDarkMode ? 0.45 : 0.28)
+const directionGradientEnd = computed(() => isDarkMode ? 'rgba(59, 130, 246, 0.85)' : 'rgba(59, 130, 246, 0.7)')
+const directionStroke = computed(() => isDarkMode ? 'rgba(15, 23, 42, 0.85)' : 'rgba(15, 23, 42, 0.65)')
+const directionShadow = computed(() => isDarkMode ? 'rgba(59, 130, 246, 0.35)' : 'rgba(59, 130, 246, 0.22)')
 
 // Utility functions
 function toRad(deg) {

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -4,7 +4,7 @@
     role="application"
     tabindex="0"
     aria-label="SoundRoom 2D audio environment. Use keyboard or mouse to interact with sound nodes."
-    class="canvas-grid relative border-2 border-neutral-400 dark:border-neutral-700 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+    class="canvas-grid relative border border-neutral-300/60 dark:border-neutral-700 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 shadow-[0_6px_20px_rgba(0,0,0,0.08)]"
     :class="`w-[${room.width}px] h-[${room.height}px]`"
     @dragover.prevent
     @drop="handleDrop"
@@ -121,8 +121,8 @@ const soundNodeTitleCoords = computed(() => {
 .canvas-grid {
   background-size: 40px 40px; /* Adjust spacing between grid lines */
   background-image:
-    linear-gradient(to right, rgba(0, 0, 0, 0.06) 2px, transparent 2px),
-    linear-gradient(to bottom, rgba(0, 0, 0, 0.06) 2px, transparent 2px); /* Adjust line opacity */
+    linear-gradient(to right, rgba(0, 0, 0, 0.05) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(0, 0, 0, 0.05) 1px, transparent 1px); /* Adjust line opacity */
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -12,11 +12,11 @@
       :angle="coneOuter"
       :rotation="(-coneOuter / 2) + source.instance.state.angle"
       :radius="50"
-      fill="rgba(255, 137, 137, 0.16)"
-      :stroke="'rgba(255, 137, 137, 0.28)'"
+      :fill="outerConeFill"
+      :stroke="outerConeStroke"
       :strokeWidth="1.5"
-      shadowColor="rgba(255, 120, 120, 0.65)"
-      :shadowBlur="18"
+      :shadowColor="outerConeShadow"
+      :shadowBlur="16"
       :listening="false"
     />
 
@@ -26,8 +26,8 @@
       :angle="coneInner"
       :rotation="(-coneInner / 2) + source.instance.state.angle"
       :radius="50"
-      fill="rgba(255, 180, 180, 0.18)"
-      :stroke="'rgba(255, 180, 180, 0.35)'"
+      :fill="innerConeFill"
+      :stroke="innerConeStroke"
       :strokeWidth="1"
       :listening="false"
     />
@@ -50,8 +50,8 @@
       :stroke="dotStrokeColor"
       :strokeWidth="2"
       :shadowColor="getFillColor"
-      :shadowBlur="10"
-      :shadowOpacity="0.65"
+      :shadowBlur="dotShadowBlur"
+      :shadowOpacity="dotShadowOpacity"
       shadowForStrokeEnabled="false"
       name="sound-node-part"
       @mousedown="onSourceMouseDown"
@@ -83,10 +83,10 @@
       :rotation="source.instance.state.angle - 90"
       :fillLinearGradientStartPoint="{ x: 0, y: 0 }"
       :fillLinearGradientEndPoint="{ x: 0, y: 25 }"
-      :fillLinearGradientColorStops="[0, 'rgba(255,255,255,0.95)', 1, 'rgba(255,255,255,0.65)']"
-      stroke="rgba(0, 0, 0, 0.6)"
+      :fillLinearGradientColorStops="[0, 'rgba(255,255,255,0.95)', 1, directionGradientEnd]"
+      :stroke="directionStroke"
       :strokeWidth="1.25"
-      :shadowColor="'rgba(0,0,0,0.35)'"
+      :shadowColor="directionShadow"
       :shadowBlur="4"
       @mousedown="onSourceMouseDown"
       @mouseup="onSourceMouseUp"
@@ -130,6 +130,8 @@ const props = defineProps({
 
 const { room } = storeToRefs(useRoomStore())
 const { actionManager } = storeToRefs(useActionManagerStore())
+const isDarkMode = document.documentElement.classList.contains('dark') ||
+  (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches)
 const emit = defineEmits(['select'])
 
 const sched = computed(() => props.source.instance.state.schedule)
@@ -145,6 +147,17 @@ const getFillColor = computed(() => {
 const dotStrokeColor = computed(() => (props.selected ? '#ffffff' : 'rgba(255, 255, 255, 0.9)'))
 const selectionGlowColor = '#6fd7ff'
 const selectedScale = computed(() => (props.selected ? 1.05 : 1))
+
+const outerConeFill = computed(() => isDarkMode ? 'rgba(255, 137, 137, 0.16)' : 'rgba(255, 137, 137, 0.11)')
+const outerConeStroke = computed(() => isDarkMode ? 'rgba(255, 137, 137, 0.28)' : 'rgba(255, 137, 137, 0.22)')
+const outerConeShadow = computed(() => isDarkMode ? 'rgba(255, 120, 120, 0.65)' : 'rgba(255, 120, 120, 0.42)')
+const innerConeFill = computed(() => isDarkMode ? 'rgba(255, 180, 180, 0.18)' : 'rgba(255, 180, 180, 0.14)')
+const innerConeStroke = computed(() => isDarkMode ? 'rgba(255, 180, 180, 0.35)' : 'rgba(255, 180, 180, 0.24)')
+const dotShadowBlur = computed(() => isDarkMode ? 10 : 7)
+const dotShadowOpacity = computed(() => isDarkMode ? 0.65 : 0.42)
+const directionGradientEnd = computed(() => isDarkMode ? 'rgba(255,255,255,0.65)' : 'rgba(255,255,255,0.52)')
+const directionStroke = computed(() => isDarkMode ? 'rgba(0, 0, 0, 0.6)' : 'rgba(0, 0, 0, 0.45)')
+const directionShadow = computed(() => isDarkMode ? 'rgba(0,0,0,0.35)' : 'rgba(0,0,0,0.25)')
 
 
 

--- a/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
+++ b/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-400 dark:border-neutral-800 p-4 space-y-6"
+    class="flex flex-col h-full bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-300/70 dark:border-neutral-800 p-4 space-y-6 shadow-[4px_0_12px_rgba(0,0,0,0.06)]"
     role="region"
     aria-labelledby="library-panel-label"
   >

--- a/src/components/SoundRoom/SidebarRight/SidebarRight.vue
+++ b/src/components/SoundRoom/SidebarRight/SidebarRight.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-neutral-100 dark:bg-neutral-900 border-l border-neutral-300 dark:border-neutral-800 p-4 space-y-4"
+    class="flex flex-col h-full bg-neutral-200 dark:bg-neutral-900 border-l border-neutral-300/70 dark:border-neutral-800 p-4 space-y-4 shadow-[-4px_0_12px_rgba(0,0,0,0.06)]"
     role="region"
     aria-labelledby="selected-sound-panel-label"
   >

--- a/src/components/SoundRoom/Toolbar.vue
+++ b/src/components/SoundRoom/Toolbar.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="flex items-center justify-between p-3 border-neutral-300 dark:border-neutral-800 bg-neutral-100 dark:bg-neutral-900 space-x-10 w-full">
+  <div class="flex items-center justify-between p-3 border-b border-neutral-300/70 dark:border-neutral-800 bg-neutral-200 dark:bg-neutral-900 space-x-10 w-full shadow-[0_3px_12px_rgba(0,0,0,0.08)]">
           
     <div class="flex space-x-2 w-1/3">
       <BaseButton
       :disabled="audioEngine.soundSources.value.length === 0"
       @click="isPlaying ? audioEngine.pauseAll() : audioEngine.playAll()"
-      class="px-3 py-1 rounded text-sm bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700"
+      class="px-3 py-1 rounded text-sm bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 border border-neutral-300/80 dark:border-neutral-700 shadow-[0_2px_8px_rgba(0,0,0,0.12)]"
       > 
         
         <component :is="isPlaying ? Pause : Play" class="h-4 w-4 fill-black dark:fill-white" />
@@ -13,14 +13,14 @@
       <BaseButton
         :disabled="actionStackEmpty || waiting"
         @click="actionManager.undoLastAction"
-        class="px-3 py-1 rounded text-sm bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700"
+        class="px-3 py-1 rounded text-sm bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 border border-neutral-300/80 dark:border-neutral-700 shadow-[0_2px_8px_rgba(0,0,0,0.12)]"
       >
         <UndoRedo class="h-4 w-4 fill-black dark:fill-white"/>
       </BaseButton>
       <BaseButton
         :disabled="redoStackEmpty || waiting"
         @click="actionManager.redoLastAction"
-        class="px-3 py-1 rounded text-sm bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700"
+        class="px-3 py-1 rounded text-sm bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700 border border-neutral-300/80 dark:border-neutral-700 shadow-[0_2px_8px_rgba(0,0,0,0.12)]"
       >
         <UndoRedo class="h-4 w-4 scale-x-[-1] fill-black dark:fill-white"/>
       </BaseButton>
@@ -34,7 +34,7 @@
     />
     <div class="flex items-center justify-center space-x-2 w-1/3">
      
-      <span class="text-xs text-neutral-500">Master</span>
+      <span class="text-xs text-neutral-700">Master</span>
       <VueSlider 
         v-model="audioEngine.masterVolume.value"
         :min="0" 

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full bg-white text-neutral-900 dark:bg-neutral-950 dark:text-white flex flex-col">
+  <div class="h-full bg-neutral-100 text-neutral-800 dark:bg-neutral-950 dark:text-white flex flex-col">
     <!-- Main Layout -->
     <div class="flex flex-1 overflow-hidden">
 
@@ -12,12 +12,12 @@
       />
 
       <!-- Canvas + Controls -->
-      <main class="flex-1 flex flex-col">
+      <main class="flex-1 flex flex-col bg-neutral-100 dark:bg-transparent">
         <!-- Toolbar -->
         <Toolbar/>
 
         <!-- Canvas Area -->
-        <div class="flex-1 relative overflow-hidden bg-neutral-100 dark:bg-neutral-900 flex items-center justify-center">
+        <div class="flex-1 relative overflow-hidden bg-neutral-200 dark:bg-neutral-900 flex items-center justify-center border-y border-neutral-300/50 dark:border-transparent shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
           <div class="pointer-events-none absolute inset-0 canvas-vignette" aria-hidden="true"></div>
           <MainCanvasStage
             v-bind="{
@@ -202,12 +202,12 @@ onUnmounted(() => {
 
 <style scoped>
 .canvas-vignette {
-  --vignette-inner: rgba(255, 255, 255, 0.12);
-  --vignette-middle: rgba(255, 255, 255, 0.05);
-  --vignette-outer: rgba(0, 0, 0, 0.23);
-  --vignette-shadow: inset 0 0 90px rgba(0, 0, 0, 0.24);
+  --vignette-inner: rgba(255, 255, 255, 0.08);
+  --vignette-middle: rgba(255, 255, 255, 0.03);
+  --vignette-outer: rgba(0, 0, 0, 0.14);
+  --vignette-shadow: inset 0 0 70px rgba(0, 0, 0, 0.14);
 
-  background: radial-gradient(circle at center, var(--vignette-inner) 0%, var(--vignette-middle) 38%, var(--vignette-outer) 100%);
+  background: radial-gradient(circle at center, var(--vignette-inner) 0%, var(--vignette-middle) 42%, var(--vignette-outer) 100%);
   box-shadow: var(--vignette-shadow);
 }
 


### PR DESCRIPTION
## Summary
- soften light mode backgrounds across shell, canvas, and panels while keeping dark mode intact
- reduce grid, vignette, cone, and listener glow intensity in light mode for subtler visuals
- add clearer borders, lighter shadows, and stronger text contrast for light mode controls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69221f9483f8832f83ed4b616eb1918e)