### PR TITLE
Refine light mode contrast and readability

### DIFF
--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -21,12 +21,12 @@
   />
 
   <!-- Footer Buttons -->
-  <div class="relative flex items-center justify-between h-15 p-2">
+  <div class="relative flex items-center justify-between h-15 p-2 bg-neutral-200 border-t border-neutral-300/70 dark:border-neutral-800 shadow-[0_-4px_12px_rgba(0,0,0,0.1)] dark:shadow-none">
     <div class="flex space-x-3">
       <BaseButton
         @click="showSaveConfirm = true"
         :disabled="isSaving || !isRoomSaveable"
-        class="px-3 py-2 rounded bg-neutral-200 hover:bg-neutral-300 text-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        class="px-3 py-2 rounded bg-neutral-300 hover:bg-neutral-400 text-neutral-800 dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         type="button"
         aria-label="Open save room confirmation"
       >
@@ -36,7 +36,7 @@
       <BaseButton
         @click="showNewRoomConfirm = true"
         :disabled="isSaving || isRoomEmpty"
-        class="px-3 py-2 rounded bg-neutral-200 hover:bg-neutral-300 text-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        class="px-3 py-2 rounded bg-neutral-300 hover:bg-neutral-400 text-neutral-800 dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         type="button"
         aria-label="Open new room confirmation"
       >

--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -26,7 +26,7 @@
       <BaseButton
         @click="showSaveConfirm = true"
         :disabled="isSaving || !isRoomSaveable"
-        class="px-3 py-2 rounded bg-neutral-100 hover:bg-neutral-200 dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        class="px-3 py-2 rounded bg-neutral-200 hover:bg-neutral-300 text-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         type="button"
         aria-label="Open save room confirmation"
       >
@@ -36,7 +36,7 @@
       <BaseButton
         @click="showNewRoomConfirm = true"
         :disabled="isSaving || isRoomEmpty"
-        class="px-3 py-2 rounded bg-neutral-100 hover:bg-neutral-200 dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        class="px-3 py-2 rounded bg-neutral-200 hover:bg-neutral-300 text-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         type="button"
         aria-label="Open new room confirmation"
       >

--- a/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
@@ -10,22 +10,22 @@
     <!-- Anchor Glow -->
     <v-circle
       :radius="22"
-      fill="rgba(59, 130, 246, 0.08)"
-      shadowColor="rgba(59, 130, 246, 0.3)"
-      shadowBlur="18"
-      shadowOpacity="0.35"
+      :fill="anchorGlowFill"
+      :shadowColor="anchorShadowColor"
+      :shadowBlur="anchorShadowBlur"
+      :shadowOpacity="anchorShadowOpacity"
       listening="false"
     />
 
     <!-- Listener Body -->
     <v-circle
       :radius="14"
-      fill="rgba(59, 130, 246, 0.15)"
-      stroke="rgba(96, 165, 250, 0.9)"
+      :fill="bodyFill"
+      :stroke="bodyStroke"
       :strokeWidth="2.5"
-      shadowColor="rgba(0, 0, 0, 0.2)"
-      shadowBlur="10"
-      shadowOpacity="0.55"
+      :shadowColor="bodyShadowColor"
+      :shadowBlur="bodyShadowBlur"
+      :shadowOpacity="bodyShadowOpacity"
       @mousedown="onListenerMouseDown"
       @mouseup="onListenerMouseUp"
       @mouseover="setCursor($event, 'pointer')"
@@ -36,9 +36,9 @@
       fill="rgba(15, 23, 42, 0.9)"
       stroke="rgba(191, 219, 254, 0.85)"
       :strokeWidth="1.25"
-      shadowColor="rgba(59, 130, 246, 0.35)"
-      shadowBlur="8"
-      shadowOpacity="0.45"
+      :shadowColor="detailShadowColor"
+      :shadowBlur="detailShadowBlur"
+      :shadowOpacity="detailShadowOpacity"
       @mousedown="onListenerMouseDown"
       @mouseup="onListenerMouseUp"
       @mouseover="setCursor($event, 'pointer')"
@@ -49,9 +49,9 @@
       fill="rgba(255, 255, 255, 0.75)"
       stroke="rgba(255, 255, 255, 0.2)"
       :strokeWidth="0.5"
-      shadowColor="rgba(255, 255, 255, 0.35)"
+      :shadowColor="highlightShadowColor"
       shadowBlur="6"
-      shadowOpacity="0.5"
+      :shadowOpacity="highlightShadowOpacity"
       listening="false"
     />
 
@@ -68,10 +68,10 @@
       :rotation="listener.angle"
       :fillLinearGradientStartPoint="{ x: -12, y: 12 }"
       :fillLinearGradientEndPoint="{ x: 12, y: -10 }"
-      :fillLinearGradientColorStops="[0, 'rgba(191, 219, 254, 0.18)', 1, 'rgba(59, 130, 246, 0.85)']"
+      :fillLinearGradientColorStops="directionGradientStops"
       stroke="rgba(15, 23, 42, 0.85)"
       :strokeWidth="1.25"
-      shadowColor="rgba(59, 130, 246, 0.35)"
+      :shadowColor="directionShadowColor"
       shadowBlur="6"
       opacity="0.96"
       @mousedown="onListenerMouseDown"
@@ -87,7 +87,7 @@
       :innerRadius="0"
       :outerRadius="40"
       :angle="135"
-      fill="rgba(59, 130, 246, 0.1)"
+      :fill="rotationHandleFill"
       :rotation="listener.angle + 20"
       @mouseover="setCursor($event, 'grabbing')"
       @mouseout="setCursor($event, 'default')"
@@ -98,7 +98,7 @@
 </template>
 
 <script setup>
-import { ref, onBeforeUnmount } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useListenerStore } from '@/stores/useListenerStore';
 import { useActionManagerStore } from '@/stores/useActionManagerStore';
 import { useRoomStore } from '@/stores/useRoomStore';
@@ -108,6 +108,42 @@ import { storeToRefs } from 'pinia';
 const { listener } = storeToRefs(useListenerStore())
 const { actionManager } = storeToRefs(useActionManagerStore())
 const { room } = storeToRefs(useRoomStore())
+
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)')
+const isDarkMode = ref(prefersDark.matches)
+
+const syncTheme = (event) => {
+  isDarkMode.value = event.matches
+}
+
+onMounted(() => prefersDark.addEventListener('change', syncTheme))
+onBeforeUnmount(() => prefersDark.removeEventListener('change', syncTheme))
+
+const anchorGlowFill = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.08)' : 'rgba(59, 130, 246, 0.05)')
+const anchorShadowColor = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.3)' : 'rgba(59, 130, 246, 0.16)')
+const anchorShadowBlur = computed(() => isDarkMode.value ? 18 : 12)
+const anchorShadowOpacity = computed(() => isDarkMode.value ? 0.35 : 0.22)
+
+const bodyFill = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.15)' : 'rgba(59, 130, 246, 0.12)')
+const bodyStroke = computed(() => isDarkMode.value ? 'rgba(96, 165, 250, 0.9)' : 'rgba(59, 130, 246, 0.9)')
+const bodyShadowColor = computed(() => isDarkMode.value ? 'rgba(0, 0, 0, 0.2)' : 'rgba(0, 0, 0, 0.12)')
+const bodyShadowBlur = computed(() => isDarkMode.value ? 10 : 8)
+const bodyShadowOpacity = computed(() => isDarkMode.value ? 0.55 : 0.35)
+
+const detailShadowColor = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.35)' : 'rgba(59, 130, 246, 0.2)')
+const detailShadowBlur = computed(() => isDarkMode.value ? 8 : 6)
+const detailShadowOpacity = computed(() => isDarkMode.value ? 0.45 : 0.3)
+
+const highlightShadowColor = computed(() => isDarkMode.value ? 'rgba(255, 255, 255, 0.35)' : 'rgba(255, 255, 255, 0.22)')
+const highlightShadowOpacity = computed(() => isDarkMode.value ? 0.5 : 0.35)
+
+const directionGradientStops = computed(() => isDarkMode.value
+  ? [0, 'rgba(191, 219, 254, 0.18)', 1, 'rgba(59, 130, 246, 0.85)']
+  : [0, 'rgba(191, 219, 254, 0.14)', 1, 'rgba(59, 130, 246, 0.75)']
+)
+const directionShadowColor = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.35)' : 'rgba(59, 130, 246, 0.2)')
+
+const rotationHandleFill = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.1)' : 'rgba(59, 130, 246, 0.06)')
 
 let moveListenerPayload = null
 let initialMouseAngle = null

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -4,7 +4,7 @@
     role="application"
     tabindex="0"
     aria-label="SoundRoom 2D audio environment. Use keyboard or mouse to interact with sound nodes."
-    class="canvas-grid relative border-2 border-neutral-400 dark:border-neutral-700 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+    class="canvas-grid relative border border-neutral-300/60 dark:border-neutral-700 dark:border-2 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 shadow-[0_4px_12px_rgba(0,0,0,0.12)] dark:shadow-none"
     :class="`w-[${room.width}px] h-[${room.height}px]`"
     @dragover.prevent
     @drop="handleDrop"
@@ -121,8 +121,8 @@ const soundNodeTitleCoords = computed(() => {
 .canvas-grid {
   background-size: 40px 40px; /* Adjust spacing between grid lines */
   background-image:
-    linear-gradient(to right, rgba(0, 0, 0, 0.06) 2px, transparent 2px),
-    linear-gradient(to bottom, rgba(0, 0, 0, 0.06) 2px, transparent 2px); /* Adjust line opacity */
+    linear-gradient(to right, rgba(0, 0, 0, 0.07) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(0, 0, 0, 0.07) 1px, transparent 1px); /* Adjust line opacity */
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -4,7 +4,7 @@
     role="application"
     tabindex="0"
     aria-label="SoundRoom 2D audio environment. Use keyboard or mouse to interact with sound nodes."
-    class="canvas-grid relative border border-neutral-300/60 dark:border-neutral-700 dark:border-2 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 shadow-[0_4px_12px_rgba(0,0,0,0.12)] dark:shadow-none"
+    class="canvas-grid relative border border-neutral-400/60 dark:border-neutral-700 dark:border-2 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 shadow-[0_4px_10px_rgba(0,0,0,0.12)] dark:shadow-none bg-neutral-200"
     :class="`w-[${room.width}px] h-[${room.height}px]`"
     @dragover.prevent
     @drop="handleDrop"
@@ -121,8 +121,8 @@ const soundNodeTitleCoords = computed(() => {
 .canvas-grid {
   background-size: 40px 40px; /* Adjust spacing between grid lines */
   background-image:
-    linear-gradient(to right, rgba(0, 0, 0, 0.07) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(0, 0, 0, 0.07) 1px, transparent 1px); /* Adjust line opacity */
+    linear-gradient(to right, rgba(0, 0, 0, 0.06) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(0, 0, 0, 0.06) 1px, transparent 1px); /* Adjust line opacity */
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -12,11 +12,11 @@
       :angle="coneOuter"
       :rotation="(-coneOuter / 2) + source.instance.state.angle"
       :radius="50"
-      fill="rgba(255, 137, 137, 0.16)"
-      :stroke="'rgba(255, 137, 137, 0.28)'"
+      :fill="outerConeFill"
+      :stroke="outerConeStroke"
       :strokeWidth="1.5"
-      shadowColor="rgba(255, 120, 120, 0.65)"
-      :shadowBlur="18"
+      :shadowColor="outerConeShadowColor"
+      :shadowBlur="outerConeShadowBlur"
       :listening="false"
     />
 
@@ -26,8 +26,8 @@
       :angle="coneInner"
       :rotation="(-coneInner / 2) + source.instance.state.angle"
       :radius="50"
-      fill="rgba(255, 180, 180, 0.18)"
-      :stroke="'rgba(255, 180, 180, 0.35)'"
+      :fill="innerConeFill"
+      :stroke="innerConeStroke"
       :strokeWidth="1"
       :listening="false"
     />
@@ -38,10 +38,10 @@
       :radius="16"
       :stroke="selectionGlowColor"
       :strokeWidth="3"
-      :opacity="0.75"
+      :opacity="selectionGlowOpacity"
       shadowForStrokeEnabled="true"
       :shadowColor="selectionGlowColor"
-      :shadowBlur="14"
+      :shadowBlur="selectionGlowBlur"
       :listening="false"
     />
     <v-circle
@@ -50,8 +50,8 @@
       :stroke="dotStrokeColor"
       :strokeWidth="2"
       :shadowColor="getFillColor"
-      :shadowBlur="10"
-      :shadowOpacity="0.65"
+      :shadowBlur="nodeShadowBlur"
+      :shadowOpacity="nodeShadowOpacity"
       shadowForStrokeEnabled="false"
       name="sound-node-part"
       @mousedown="onSourceMouseDown"
@@ -115,7 +115,7 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useRoomStore } from '@/stores/useRoomStore'
 import { useActionManagerStore } from '@/stores/useActionManagerStore'
 import { storeToRefs } from 'pinia'
@@ -132,6 +132,16 @@ const { room } = storeToRefs(useRoomStore())
 const { actionManager } = storeToRefs(useActionManagerStore())
 const emit = defineEmits(['select'])
 
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)')
+const isDarkMode = ref(prefersDark.matches)
+
+const syncTheme = (event) => {
+  isDarkMode.value = event.matches
+}
+
+onMounted(() => prefersDark.addEventListener('change', syncTheme))
+onBeforeUnmount(() => prefersDark.removeEventListener('change', syncTheme))
+
 const sched = computed(() => props.source.instance.state.schedule)
 const isScheduled = computed(() => sched.value?.enabled)
 const isScheduledPlaying = computed(() => sched.value?.isPlaying)
@@ -145,6 +155,20 @@ const getFillColor = computed(() => {
 const dotStrokeColor = computed(() => (props.selected ? '#ffffff' : 'rgba(255, 255, 255, 0.9)'))
 const selectionGlowColor = '#6fd7ff'
 const selectedScale = computed(() => (props.selected ? 1.05 : 1))
+
+const outerConeFill = computed(() => isDarkMode.value ? 'rgba(255, 137, 137, 0.16)' : 'rgba(255, 137, 137, 0.11)')
+const outerConeStroke = computed(() => isDarkMode.value ? 'rgba(255, 137, 137, 0.28)' : 'rgba(255, 137, 137, 0.18)')
+const outerConeShadowColor = computed(() => isDarkMode.value ? 'rgba(255, 120, 120, 0.65)' : 'rgba(255, 120, 120, 0.35)')
+const outerConeShadowBlur = computed(() => isDarkMode.value ? 18 : 12)
+
+const innerConeFill = computed(() => isDarkMode.value ? 'rgba(255, 180, 180, 0.18)' : 'rgba(255, 180, 180, 0.13)')
+const innerConeStroke = computed(() => isDarkMode.value ? 'rgba(255, 180, 180, 0.35)' : 'rgba(255, 180, 180, 0.22)')
+
+const selectionGlowOpacity = computed(() => isDarkMode.value ? 0.75 : 0.55)
+const selectionGlowBlur = computed(() => isDarkMode.value ? 14 : 10)
+
+const nodeShadowBlur = computed(() => isDarkMode.value ? 10 : 8)
+const nodeShadowOpacity = computed(() => isDarkMode.value ? 0.65 : 0.35)
 
 
 

--- a/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
+++ b/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-300/70 dark:border-neutral-800 p-4 space-y-6"
+    class="flex flex-col h-full bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-400/60 dark:border-neutral-800 p-4 space-y-6"
     role="region"
     aria-labelledby="library-panel-label"
   >

--- a/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
+++ b/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-400 dark:border-neutral-800 p-4 space-y-6"
+    class="flex flex-col h-full bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-300/70 dark:border-neutral-800 p-4 space-y-6"
     role="region"
     aria-labelledby="library-panel-label"
   >

--- a/src/components/SoundRoom/SidebarRight/SidebarRight.vue
+++ b/src/components/SoundRoom/SidebarRight/SidebarRight.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-neutral-100 dark:bg-neutral-900 border-l border-neutral-300 dark:border-neutral-800 p-4 space-y-4"
+    class="flex flex-col h-full bg-neutral-200 dark:bg-neutral-900 border-l border-neutral-300/70 dark:border-neutral-800 p-4 space-y-4"
     role="region"
     aria-labelledby="selected-sound-panel-label"
   >

--- a/src/components/SoundRoom/SidebarRight/SidebarRight.vue
+++ b/src/components/SoundRoom/SidebarRight/SidebarRight.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-neutral-200 dark:bg-neutral-900 border-l border-neutral-300/70 dark:border-neutral-800 p-4 space-y-4"
+    class="flex flex-col h-full bg-neutral-200 dark:bg-neutral-900 border-l border-neutral-400/60 dark:border-neutral-800 p-4 space-y-4"
     role="region"
     aria-labelledby="selected-sound-panel-label"
   >

--- a/src/components/SoundRoom/Toolbar.vue
+++ b/src/components/SoundRoom/Toolbar.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="flex items-center justify-between p-3 border-neutral-300 dark:border-neutral-800 bg-neutral-100 dark:bg-neutral-900 space-x-10 w-full">
+  <div class="flex items-center justify-between p-3 border-neutral-300/70 dark:border-neutral-800 bg-neutral-200 dark:bg-neutral-900 space-x-10 w-full shadow-[0_2px_10px_rgba(0,0,0,0.08)] dark:shadow-none">
           
     <div class="flex space-x-2 w-1/3">
       <BaseButton
       :disabled="audioEngine.soundSources.value.length === 0"
       @click="isPlaying ? audioEngine.pauseAll() : audioEngine.playAll()"
-      class="px-3 py-1 rounded text-sm bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700"
+      class="px-3 py-1 rounded text-sm bg-neutral-200 hover:bg-neutral-300 text-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700"
       > 
         
         <component :is="isPlaying ? Pause : Play" class="h-4 w-4 fill-black dark:fill-white" />
@@ -13,14 +13,14 @@
       <BaseButton
         :disabled="actionStackEmpty || waiting"
         @click="actionManager.undoLastAction"
-        class="px-3 py-1 rounded text-sm bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700"
+        class="px-3 py-1 rounded text-sm bg-neutral-200 hover:bg-neutral-300 text-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700"
       >
         <UndoRedo class="h-4 w-4 fill-black dark:fill-white"/>
       </BaseButton>
       <BaseButton
         :disabled="redoStackEmpty || waiting"
         @click="actionManager.redoLastAction"
-        class="px-3 py-1 rounded text-sm bg-neutral-200 dark:bg-neutral-800 hover:bg-neutral-300 dark:hover:bg-neutral-700"
+        class="px-3 py-1 rounded text-sm bg-neutral-200 hover:bg-neutral-300 text-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700"
       >
         <UndoRedo class="h-4 w-4 scale-x-[-1] fill-black dark:fill-white"/>
       </BaseButton>
@@ -34,7 +34,7 @@
     />
     <div class="flex items-center justify-center space-x-2 w-1/3">
      
-      <span class="text-xs text-neutral-500">Master</span>
+      <span class="text-xs text-neutral-600">Master</span>
       <VueSlider 
         v-model="audioEngine.masterVolume.value"
         :min="0" 

--- a/src/components/SoundRoom/Toolbar.vue
+++ b/src/components/SoundRoom/Toolbar.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="flex items-center justify-between p-3 border-neutral-300/70 dark:border-neutral-800 bg-neutral-200 dark:bg-neutral-900 space-x-10 w-full shadow-[0_2px_10px_rgba(0,0,0,0.08)] dark:shadow-none">
+  <div class="flex items-center justify-between p-3 border-neutral-400/70 dark:border-neutral-800 bg-neutral-300 dark:bg-neutral-900 space-x-10 w-full shadow-[0_3px_10px_rgba(0,0,0,0.1)] dark:shadow-none">
           
     <div class="flex space-x-2 w-1/3">
       <BaseButton
       :disabled="audioEngine.soundSources.value.length === 0"
       @click="isPlaying ? audioEngine.pauseAll() : audioEngine.playAll()"
-      class="px-3 py-1 rounded text-sm bg-neutral-200 hover:bg-neutral-300 text-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+      class="px-3 py-1 rounded text-sm bg-neutral-300 hover:bg-neutral-400 text-neutral-800 dark:bg-neutral-800 dark:hover:bg-neutral-700"
       > 
         
         <component :is="isPlaying ? Pause : Play" class="h-4 w-4 fill-black dark:fill-white" />
@@ -13,14 +13,14 @@
       <BaseButton
         :disabled="actionStackEmpty || waiting"
         @click="actionManager.undoLastAction"
-        class="px-3 py-1 rounded text-sm bg-neutral-200 hover:bg-neutral-300 text-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+        class="px-3 py-1 rounded text-sm bg-neutral-300 hover:bg-neutral-400 text-neutral-800 dark:bg-neutral-800 dark:hover:bg-neutral-700"
       >
         <UndoRedo class="h-4 w-4 fill-black dark:fill-white"/>
       </BaseButton>
       <BaseButton
         :disabled="redoStackEmpty || waiting"
         @click="actionManager.redoLastAction"
-        class="px-3 py-1 rounded text-sm bg-neutral-200 hover:bg-neutral-300 text-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+        class="px-3 py-1 rounded text-sm bg-neutral-300 hover:bg-neutral-400 text-neutral-800 dark:bg-neutral-800 dark:hover:bg-neutral-700"
       >
         <UndoRedo class="h-4 w-4 scale-x-[-1] fill-black dark:fill-white"/>
       </BaseButton>
@@ -34,7 +34,7 @@
     />
     <div class="flex items-center justify-center space-x-2 w-1/3">
      
-      <span class="text-xs text-neutral-600">Master</span>
+      <span class="text-xs text-neutral-700">Master</span>
       <VueSlider 
         v-model="audioEngine.masterVolume.value"
         :min="0" 

--- a/src/components/ui/modals/SoundLibrary/CategoryList.vue
+++ b/src/components/ui/modals/SoundLibrary/CategoryList.vue
@@ -1,6 +1,6 @@
 <template>
-  <aside class="w-60 bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-300 dark:border-neutral-800 p-4 space-y-3 overflow-y-auto">
-    <h2 class="font-bold text-sm mb-2">Categories</h2>
+  <aside class="w-60 bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-300/80 dark:border-neutral-800 p-4 space-y-3 overflow-y-auto text-neutral-800 dark:text-neutral-200">
+    <h2 class="font-bold text-sm mb-2 text-neutral-800 dark:text-neutral-100">Categories</h2>
     <BaseButton
       v-if="isAuthenticated"
       :key="'your-sounds'"
@@ -12,7 +12,7 @@
         <span v-if="!canUpload" class="badge">Pro</span>
       </span>
     </BaseButton>
-    <hr v-if="isAuthenticated" class="text-neutral-300 dark:text-neutral-800"/>
+    <hr v-if="isAuthenticated" class="border-neutral-300/80 dark:border-neutral-800"/>
     <BaseButton
       v-for="cat in categories"
       :key="cat.id"

--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex-1 relative overflow-hidden">
-    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-white/50 dark:bg-neutral-950/50 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800">
-      <h2 class="text-2xl font-bold">SoundLibrary</h2>
+    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-neutral-100/90 dark:bg-neutral-950/50 backdrop-blur-md border-b border-neutral-300/80 dark:border-neutral-800">
+      <h2 class="text-2xl font-bold text-neutral-800 dark:text-neutral-50">SoundLibrary</h2>
       <BaseButton class="text-sm" @click="$emit('close')">Close</BaseButton>
     </div>
     <div ref="gridScroll" class="mt-5 place-content-start p-6 pt-20 overflow-y-auto h-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
@@ -17,15 +17,15 @@
         @locked="$emit('locked', $event)"
         />
       <template v-if="canUpload && activeCategory === 'your-sounds' && sounds.length === 0">
-          <div class="col-span-full text-center text-neutral-400 mt-32">
-            <div class="text-xl font-semibold mb-2">Nothing to hear!</div>
-            <div class="mb-4">Upload your first sound below and it'll show up here.</div>
+          <div class="col-span-full text-center text-neutral-600 mt-32">
+            <div class="text-xl font-semibold mb-2 text-neutral-800">Nothing to hear!</div>
+            <div class="mb-4 text-neutral-700">Upload your first sound below and it'll show up here.</div>
           </div>
         </template>
     </div>
      <div
         v-if="isAuthenticated && activeCategory === 'your-sounds'"
-        class="absolute bottom-0 left-0 right-0 p-4 bg-white dark:bg-neutral-950 border-t border-neutral-300 dark:border-neutral-800"
+        class="absolute bottom-0 left-0 right-0 p-4 bg-neutral-100 dark:bg-neutral-950 border-t border-neutral-300/80 dark:border-neutral-800 shadow-[0_-8px_18px_rgba(0,0,0,0.08)]"
       >
         <div class="flex items-center justify-between gap-3">
           <button

--- a/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
@@ -3,7 +3,7 @@
     :class="[
       'relative aspect-square flex flex-col items-center justify-between p-4 rounded-xl bg-neutral-100 dark:bg-neutral-800 shadow border transition-shadow duration-200',
       highlightClass,
-      { 'border-neutral-300 dark:border-neutral-700': !highlightClass }
+      { 'border-neutral-300/80 dark:border-neutral-700 shadow-[0_8px_18px_rgba(0,0,0,0.12)] text-neutral-800 dark:text-neutral-100': !highlightClass }
     ]"
   >
 

--- a/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
@@ -3,7 +3,7 @@
     @click.self="router.push('/')"
     class="modal-backdrop"
   >
-    <div class="modal-panel flex">
+    <div class="modal-panel flex !bg-neutral-100 border border-neutral-300/70 text-neutral-800 shadow-[0_16px_36px_rgba(0,0,0,0.16)] dark:bg-neutral-950 dark:border-neutral-800 dark:text-neutral-100">
       <CategoryList
         :categories="categories"
         :active="activeCategory"

--- a/src/components/ui/modals/SoundLibrary/SoundPreviewCircle.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundPreviewCircle.vue
@@ -3,7 +3,7 @@
   <div
     class="mb-3 w-8 h-8 rounded-full border-2 relative flex items-center justify-center cursor-pointer hover:scale-105 transition-transform"
     :class="[
-      isPlaying ? 'border-blue-600' : 'border-neutral-500',
+      isPlaying ? 'border-blue-600' : 'border-neutral-600',
       isLoading ? 'opacity-50 cursor-wait' : 'cursor-pointer hover:scale-105'
     ]"
     @click="togglePlay"
@@ -36,7 +36,7 @@
   </div>
 
   <!-- Duration -->
-  <span class="text-xs text-neutral-500 mt-2">{{ audioDuration }}</span>
+  <span class="text-xs text-neutral-600 mt-2">{{ audioDuration }}</span>
 </template>
 
 <script setup>

--- a/src/components/ui/modals/SoundLibrary/UploadPanel.vue
+++ b/src/components/ui/modals/SoundLibrary/UploadPanel.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="modal-backdrop z-50" @click.self="$emit('close')">
-    <div class="modal-panel max-w-3xl mx-auto p-6 bg-white dark:bg-neutral-950 rounded-xl shadow-lg overflow-y-auto max-h-[90vh]">
-      <h2 class="text-xl font-bold mb-4">Upload Your Sounds</h2>
+    <div class="modal-panel max-w-3xl mx-auto p-6 !bg-neutral-100 border border-neutral-300/80 text-neutral-800 shadow-[0_16px_36px_rgba(0,0,0,0.16)] dark:bg-neutral-950 dark:border-neutral-800 rounded-xl overflow-y-auto max-h-[90vh]">
+      <h2 class="text-xl font-bold mb-4 text-neutral-800 dark:text-neutral-50">Upload Your Sounds</h2>
 
-      <div class="border border-dashed border-neutral-400 dark:border-neutral-700 rounded-lg p-6 text-center mb-6">
+      <div class="border border-dashed border-neutral-400/80 dark:border-neutral-700 rounded-lg p-6 text-center mb-6 bg-neutral-50">
         <input
           type="file"
           accept="audio/*"
@@ -13,15 +13,15 @@
           @change="handleFileSelect"
         />
         <BaseButton @click="fileInput.click()">Select Audio Files</BaseButton>
-        <p class="text-sm text-neutral-500 mt-2">Max 10MB per file</p>
+        <p class="text-sm text-neutral-600 mt-2">Max 10MB per file</p>
       </div>
 
       <div v-if="files.length > 0" class="space-y-4">
-        <div v-for="file in files" :key="file.id" class="bg-neutral-100 dark:bg-neutral-900 rounded-md p-4 flex flex-col gap-2">
+        <div v-for="file in files" :key="file.id" class="bg-neutral-100 dark:bg-neutral-900 rounded-md p-4 flex flex-col gap-2 border border-neutral-300/60 dark:border-neutral-800">
           <div class="flex justify-between items-center">
             <input
               v-model="file.name"
-              class="flex-1 p-1 text-base border border-neutral-300 dark:border-neutral-700 rounded-md bg-white dark:bg-neutral-800"
+              class="flex-1 p-1 text-base border border-neutral-300 dark:border-neutral-700 rounded-md bg-neutral-50 dark:bg-neutral-800 text-neutral-800 dark:text-neutral-100"
             />
             <BaseButton class="ml-2" @click="autoTag(file)" :disabled="file.tagging">
               <template v-if="file.tagging">
@@ -37,7 +37,7 @@
           <div class="flex items-center gap-2">
             <audio :src="file.previewUrl" controls class="w-full" />
           </div>
-          <div class="h-2 bg-neutral-300 dark:bg-neutral-700 rounded overflow-hidden" v-if="uploading">
+          <div class="h-2 bg-neutral-300/80 dark:bg-neutral-700 rounded overflow-hidden" v-if="uploading">
             <div
               class="h-full bg-green-500 transition-all duration-300"
               :style="{ width: `${file.progress}%` }"
@@ -48,7 +48,7 @@
           <span
             v-for="(tag, index) in file.tags"
             :key="tag"
-            class="flex items-center bg-neutral-200 dark:bg-neutral-800 text-xs px-2 rounded"
+            class="flex items-center bg-neutral-200 dark:bg-neutral-800 text-xs px-2 rounded text-neutral-800 dark:text-neutral-200 border border-neutral-300/70 dark:border-neutral-700"
           >
             {{ tag }}
             <label
@@ -69,7 +69,7 @@
             @keydown="','"
             @blur="addTag(file)"
             placeholder="Add tag..."
-            class="text-sm p-1 rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 w-25"
+            class="text-sm p-1 rounded border border-neutral-300 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800 w-25 text-neutral-800 dark:text-neutral-100"
           />
         </div>
 

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full bg-neutral-100 text-neutral-800 dark:bg-neutral-950 dark:text-white flex flex-col">
+  <div class="h-full bg-neutral-200 text-neutral-900 dark:bg-neutral-950 dark:text-white flex flex-col">
     <!-- Main Layout -->
     <div class="flex flex-1 overflow-hidden">
 
@@ -17,7 +17,7 @@
         <Toolbar/>
 
         <!-- Canvas Area -->
-        <div class="flex-1 relative overflow-hidden bg-neutral-200 dark:bg-neutral-900 flex items-center justify-center border-t border-neutral-300/60 dark:border-0">
+        <div class="flex-1 relative overflow-hidden bg-neutral-300 dark:bg-neutral-900 flex items-center justify-center border-t border-neutral-400/60 dark:border-0">
           <div class="pointer-events-none absolute inset-0 canvas-vignette" aria-hidden="true"></div>
           <MainCanvasStage
             v-bind="{
@@ -202,10 +202,10 @@ onUnmounted(() => {
 
 <style scoped>
 .canvas-vignette {
-  --vignette-inner: rgba(255, 255, 255, 0.08);
-  --vignette-middle: rgba(255, 255, 255, 0.04);
-  --vignette-outer: rgba(0, 0, 0, 0.16);
-  --vignette-shadow: inset 0 0 70px rgba(0, 0, 0, 0.18);
+  --vignette-inner: rgba(255, 255, 255, 0.05);
+  --vignette-middle: rgba(255, 255, 255, 0.025);
+  --vignette-outer: rgba(0, 0, 0, 0.14);
+  --vignette-shadow: inset 0 0 60px rgba(0, 0, 0, 0.16);
 
   background: radial-gradient(circle at center, var(--vignette-inner) 0%, var(--vignette-middle) 38%, var(--vignette-outer) 100%);
   box-shadow: var(--vignette-shadow);

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full bg-white text-neutral-900 dark:bg-neutral-950 dark:text-white flex flex-col">
+  <div class="h-full bg-neutral-100 text-neutral-800 dark:bg-neutral-950 dark:text-white flex flex-col">
     <!-- Main Layout -->
     <div class="flex flex-1 overflow-hidden">
 
@@ -17,7 +17,7 @@
         <Toolbar/>
 
         <!-- Canvas Area -->
-        <div class="flex-1 relative overflow-hidden bg-neutral-100 dark:bg-neutral-900 flex items-center justify-center">
+        <div class="flex-1 relative overflow-hidden bg-neutral-200 dark:bg-neutral-900 flex items-center justify-center border-t border-neutral-300/60 dark:border-0">
           <div class="pointer-events-none absolute inset-0 canvas-vignette" aria-hidden="true"></div>
           <MainCanvasStage
             v-bind="{
@@ -202,10 +202,10 @@ onUnmounted(() => {
 
 <style scoped>
 .canvas-vignette {
-  --vignette-inner: rgba(255, 255, 255, 0.12);
-  --vignette-middle: rgba(255, 255, 255, 0.05);
-  --vignette-outer: rgba(0, 0, 0, 0.23);
-  --vignette-shadow: inset 0 0 90px rgba(0, 0, 0, 0.24);
+  --vignette-inner: rgba(255, 255, 255, 0.08);
+  --vignette-middle: rgba(255, 255, 255, 0.04);
+  --vignette-outer: rgba(0, 0, 0, 0.16);
+  --vignette-shadow: inset 0 0 70px rgba(0, 0, 0, 0.18);
 
   background: radial-gradient(circle at center, var(--vignette-inner) 0%, var(--vignette-middle) 38%, var(--vignette-outer) 100%);
   box-shadow: var(--vignette-shadow);


### PR DESCRIPTION
## Summary
- soften light-mode surfaces, borders, and controls across the SoundRoom layout, toolbar, sidebars, and footer
- reduce canvas vignette and grid contrast while keeping dark-mode styling intact
- ease light-mode cone fills and listener/source glows using theme-aware colors for better readability

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692221a8cf38832faf1ce7345a0294cb)