### PR TITLE
Refine light mode with grayscale theme

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,11 +7,11 @@
     <div class="flex-1 min-h-0 flex flex-col">
       <div
         v-if="globalError"
-        class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-white text-neutral-900 dark:bg-black dark:text-white"
+        class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-[var(--lm-bg-0)] text-[var(--lm-text-0)] dark:bg-black dark:text-white"
       >
         <p class="text-sm uppercase tracking-[0.2em] text-rose-500 mb-3">Navigation error</p>
         <h2 class="text-2xl font-semibold mb-3">We couldn't load that page.</h2>
-        <p class="max-w-md text-gray-600 dark:text-gray-400 mb-8">
+        <p class="max-w-md text-[var(--lm-text-1)] dark:text-gray-400 mb-8">
           {{ globalError.message }}
         </p>
         <div class="flex flex-wrap items-center justify-center gap-3">
@@ -20,7 +20,7 @@
           </BaseButton>
           <BaseButton
             variant="naked"
-            class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 text-sm font-medium"
+            class="text-neutral-700 hover:text-neutral-800 dark:text-blue-400 dark:hover:text-blue-300 text-sm font-medium"
             @click="returnHome"
           >
             Go back home
@@ -37,10 +37,10 @@
             </ErrorBoundary>
           </template>
           <template #fallback>
-            <div class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-white text-neutral-900 dark:bg-black dark:text-white">
+            <div class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-[var(--lm-bg-0)] text-[var(--lm-text-0)] dark:bg-black dark:text-white">
               <p class="text-sm uppercase tracking-[0.2em] text-blue-500 mb-3">Loading</p>
               <h2 class="text-2xl font-semibold mb-3">Preparing SoundRoom…</h2>
-              <p class="max-w-md text-gray-600 dark:text-gray-400">
+              <p class="max-w-md text-[var(--lm-text-1)] dark:text-gray-400">
                 Hang tight while we load the experience.
               </p>
             </div>

--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -26,7 +26,7 @@
       <BaseButton
         @click="showSaveConfirm = true"
         :disabled="isSaving || !isRoomSaveable"
-        class="px-3 py-2 rounded bg-neutral-200 hover:bg-neutral-300 text-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        class="px-3 py-2 rounded bg-[var(--lm-bg-1)] hover:bg-[var(--lm-bg-0)] text-[var(--lm-text-0)] border border-[var(--lm-border)] dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         type="button"
         aria-label="Open save room confirmation"
       >
@@ -36,7 +36,7 @@
       <BaseButton
         @click="showNewRoomConfirm = true"
         :disabled="isSaving || isRoomEmpty"
-        class="px-3 py-2 rounded bg-neutral-200 hover:bg-neutral-300 text-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        class="px-3 py-2 rounded bg-[var(--lm-bg-1)] hover:bg-[var(--lm-bg-0)] text-[var(--lm-text-0)] border border-[var(--lm-border)] dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         type="button"
         aria-label="Open new room confirmation"
       >

--- a/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
@@ -33,8 +33,8 @@
     />
     <v-circle
       :radius="8"
-      fill="rgba(15, 23, 42, 0.9)"
-      stroke="rgba(191, 219, 254, 0.85)"
+      :fill="detailFill"
+      :stroke="detailStroke"
       :strokeWidth="1.25"
       :shadowColor="detailShadowColor"
       :shadowBlur="detailShadowBlur"
@@ -46,8 +46,8 @@
     />
     <v-circle
       :radius="4"
-      fill="rgba(255, 255, 255, 0.75)"
-      stroke="rgba(255, 255, 255, 0.2)"
+      :fill="centerHighlightFill"
+      :stroke="centerHighlightStroke"
       :strokeWidth="0.5"
       :shadowColor="highlightShadowColor"
       shadowBlur="6"
@@ -69,7 +69,7 @@
       :fillLinearGradientStartPoint="{ x: -12, y: 12 }"
       :fillLinearGradientEndPoint="{ x: 12, y: -10 }"
       :fillLinearGradientColorStops="directionGradientStops"
-      stroke="rgba(15, 23, 42, 0.85)"
+      :stroke="directionStroke"
       :strokeWidth="1.25"
       :shadowColor="directionShadowColor"
       shadowBlur="6"
@@ -119,31 +119,37 @@ const syncTheme = (event) => {
 onMounted(() => prefersDark.addEventListener('change', syncTheme))
 onBeforeUnmount(() => prefersDark.removeEventListener('change', syncTheme))
 
-const anchorGlowFill = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.08)' : 'rgba(59, 130, 246, 0.05)')
-const anchorShadowColor = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.3)' : 'rgba(59, 130, 246, 0.16)')
-const anchorShadowBlur = computed(() => isDarkMode.value ? 18 : 12)
-const anchorShadowOpacity = computed(() => isDarkMode.value ? 0.35 : 0.22)
+const anchorGlowFill = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.08)' : 'rgba(0, 0, 0, 0.06)')
+const anchorShadowColor = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.3)' : 'rgba(0, 0, 0, 0.1)')
+const anchorShadowBlur = computed(() => isDarkMode.value ? 18 : 10)
+const anchorShadowOpacity = computed(() => isDarkMode.value ? 0.35 : 0.18)
 
-const bodyFill = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.15)' : 'rgba(59, 130, 246, 0.12)')
-const bodyStroke = computed(() => isDarkMode.value ? 'rgba(96, 165, 250, 0.9)' : 'rgba(59, 130, 246, 0.9)')
-const bodyShadowColor = computed(() => isDarkMode.value ? 'rgba(0, 0, 0, 0.2)' : 'rgba(0, 0, 0, 0.12)')
+const bodyFill = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.15)' : 'rgba(150, 165, 185, 0.35)')
+const bodyStroke = computed(() => isDarkMode.value ? 'rgba(96, 165, 250, 0.9)' : '#2f3a4a')
+const bodyShadowColor = computed(() => isDarkMode.value ? 'rgba(0, 0, 0, 0.2)' : 'rgba(0, 0, 0, 0.08)')
 const bodyShadowBlur = computed(() => isDarkMode.value ? 10 : 8)
-const bodyShadowOpacity = computed(() => isDarkMode.value ? 0.55 : 0.35)
+const bodyShadowOpacity = computed(() => isDarkMode.value ? 0.55 : 0.18)
 
-const detailShadowColor = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.35)' : 'rgba(59, 130, 246, 0.2)')
+const detailFill = computed(() => isDarkMode.value ? 'rgba(15, 23, 42, 0.9)' : 'rgba(70, 80, 95, 0.85)')
+const detailStroke = computed(() => isDarkMode.value ? 'rgba(191, 219, 254, 0.85)' : 'rgba(60, 70, 85, 0.6)')
+
+const detailShadowColor = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.35)' : 'rgba(0, 0, 0, 0.08)')
 const detailShadowBlur = computed(() => isDarkMode.value ? 8 : 6)
-const detailShadowOpacity = computed(() => isDarkMode.value ? 0.45 : 0.3)
+const detailShadowOpacity = computed(() => isDarkMode.value ? 0.45 : 0.2)
 
-const highlightShadowColor = computed(() => isDarkMode.value ? 'rgba(255, 255, 255, 0.35)' : 'rgba(255, 255, 255, 0.22)')
-const highlightShadowOpacity = computed(() => isDarkMode.value ? 0.5 : 0.35)
+const centerHighlightFill = computed(() => isDarkMode.value ? 'rgba(255, 255, 255, 0.75)' : 'rgba(255, 255, 255, 0.6)')
+const centerHighlightStroke = computed(() => isDarkMode.value ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.08)')
+const highlightShadowColor = computed(() => isDarkMode.value ? 'rgba(255, 255, 255, 0.35)' : 'rgba(0, 0, 0, 0.06)')
+const highlightShadowOpacity = computed(() => isDarkMode.value ? 0.5 : 0.28)
 
 const directionGradientStops = computed(() => isDarkMode.value
   ? [0, 'rgba(191, 219, 254, 0.18)', 1, 'rgba(59, 130, 246, 0.85)']
-  : [0, 'rgba(191, 219, 254, 0.14)', 1, 'rgba(59, 130, 246, 0.75)']
+  : [0, 'rgba(140, 150, 165, 0.2)', 1, 'rgba(60, 70, 85, 0.8)']
 )
-const directionShadowColor = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.35)' : 'rgba(59, 130, 246, 0.2)')
+const directionStroke = computed(() => isDarkMode.value ? 'rgba(15, 23, 42, 0.85)' : '#222222')
+const directionShadowColor = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.35)' : 'rgba(0, 0, 0, 0.1)')
 
-const rotationHandleFill = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.1)' : 'rgba(59, 130, 246, 0.06)')
+const rotationHandleFill = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.1)' : 'rgba(0, 0, 0, 0.06)')
 
 let moveListenerPayload = null
 let initialMouseAngle = null

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -126,11 +126,10 @@ const soundNodeTitleCoords = computed(() => {
     linear-gradient(to bottom, var(--lm-grid-line) 1px, transparent 1px); /* Adjust line opacity */
 }
 
-@media (prefers-color-scheme: dark) {
-  .canvas-grid {
-    background-image:
-      linear-gradient(to right, rgba(255, 255, 255, 0.08) 2px, transparent 2px),
-      linear-gradient(to bottom, rgba(255, 255, 255, 0.08) 2px, transparent 2px); /* Adjust dark mode opacity separately */
-  }
+:global(.dark) .canvas-grid {
+  background-color: #121212;
+  background-image:
+    linear-gradient(to right, rgba(255, 255, 255, 0.08) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.08) 1px, transparent 1px); /* Adjust dark mode opacity separately */
 }
 </style>

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -4,7 +4,7 @@
     role="application"
     tabindex="0"
     aria-label="SoundRoom 2D audio environment. Use keyboard or mouse to interact with sound nodes."
-    class="canvas-grid relative border border-neutral-300/60 dark:border-neutral-700 dark:border-2 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 shadow-[0_4px_12px_rgba(0,0,0,0.12)] dark:shadow-none"
+    class="canvas-grid relative border border-[var(--lm-border)] dark:border-neutral-700 dark:border-2 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 shadow-[var(--lm-shadow)] dark:shadow-none"
     :class="`w-[${room.width}px] h-[${room.height}px]`"
     @dragover.prevent
     @drop="handleDrop"
@@ -120,9 +120,10 @@ const soundNodeTitleCoords = computed(() => {
 /* Grid spacing and line opacity can be tuned here to adjust density/visibility */
 .canvas-grid {
   background-size: 40px 40px; /* Adjust spacing between grid lines */
+  background-color: var(--lm-bg-1);
   background-image:
-    linear-gradient(to right, rgba(0, 0, 0, 0.07) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(0, 0, 0, 0.07) 1px, transparent 1px); /* Adjust line opacity */
+    linear-gradient(to right, var(--lm-grid-line) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--lm-grid-line) 1px, transparent 1px); /* Adjust line opacity */
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -147,31 +147,47 @@ const isScheduled = computed(() => sched.value?.enabled)
 const isScheduledPlaying = computed(() => sched.value?.isPlaying)
 const sourceIsPlaying = computed(() => props.source.instance.playing);
 
+const lightPalette = computed(() => {
+  const styles = getComputedStyle(document.documentElement)
+  return {
+    bg2: styles.getPropertyValue('--lm-bg-2')?.trim() || '#dcdcdc',
+    nodeRed: styles.getPropertyValue('--lm-node-red')?.trim() || '#d45a5a',
+    nodeBlue: styles.getPropertyValue('--lm-node-blue')?.trim() || '#6c8edb',
+    coneRed: styles.getPropertyValue('--lm-cone-red')?.trim() || 'rgba(212, 90, 90, 0.1)',
+    coneBlue: styles.getPropertyValue('--lm-cone-blue')?.trim() || 'rgba(108, 142, 219, 0.12)'
+  }
+})
+
 const getFillColor = computed(() => {
   if (isDarkMode.value) {
     if (props.selected) return '#ff0' // Yellow for selected node
     return isScheduled.value ? '#2e90fa' : '#f44336' // Red for unscheduled/looping
   }
-  if (props.selected) return 'var(--lm-bg-2)'
-  return isScheduled.value ? 'var(--lm-node-blue)' : 'var(--lm-node-red)'
+  const colors = lightPalette.value
+  if (props.selected) return colors.bg2
+  return isScheduled.value ? colors.nodeBlue : colors.nodeRed
 })
 
 const dotStrokeColor = computed(() => (isDarkMode.value ? (props.selected ? '#ffffff' : 'rgba(255, 255, 255, 0.9)') : '#333333'))
 const selectionGlowColor = computed(() => (isDarkMode.value ? '#6fd7ff' : 'rgba(0, 0, 0, 0.05)'))
 const selectedScale = computed(() => (props.selected ? 1.05 : 1))
 
-const outerConeFill = computed(() => isDarkMode.value
-  ? 'rgba(255, 137, 137, 0.16)'
-  : (isScheduled.value ? 'var(--lm-cone-blue)' : 'var(--lm-cone-red)'))
+const outerConeFill = computed(() => {
+  if (isDarkMode.value) return 'rgba(255, 137, 137, 0.16)'
+  const colors = lightPalette.value
+  return isScheduled.value ? colors.coneBlue : colors.coneRed
+})
 const outerConeStroke = computed(() => isDarkMode.value
   ? 'rgba(255, 137, 137, 0.28)'
   : (isScheduled.value ? 'rgba(108, 142, 219, 0.24)' : 'rgba(212, 90, 90, 0.2)'))
 const outerConeShadowColor = computed(() => isDarkMode.value ? 'rgba(255, 120, 120, 0.65)' : 'rgba(0, 0, 0, 0.12)')
 const outerConeShadowBlur = computed(() => isDarkMode.value ? 18 : 10)
 
-const innerConeFill = computed(() => isDarkMode.value
-  ? 'rgba(255, 180, 180, 0.18)'
-  : (isScheduled.value ? 'rgba(108, 142, 219, 0.18)' : 'rgba(212, 90, 90, 0.16)'))
+const innerConeFill = computed(() => {
+  if (isDarkMode.value) return 'rgba(255, 180, 180, 0.18)'
+  const colors = lightPalette.value
+  return isScheduled.value ? 'rgba(108, 142, 219, 0.18)' : 'rgba(212, 90, 90, 0.16)'
+})
 const innerConeStroke = computed(() => isDarkMode.value ? 'rgba(255, 180, 180, 0.35)' : 'rgba(0, 0, 0, 0.18)')
 
 const selectionGlowOpacity = computed(() => isDarkMode.value ? 0.75 : 0.22)

--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -83,10 +83,10 @@
       :rotation="source.instance.state.angle - 90"
       :fillLinearGradientStartPoint="{ x: 0, y: 0 }"
       :fillLinearGradientEndPoint="{ x: 0, y: 25 }"
-      :fillLinearGradientColorStops="[0, 'rgba(255,255,255,0.95)', 1, 'rgba(255,255,255,0.65)']"
-      stroke="rgba(0, 0, 0, 0.6)"
+      :fillLinearGradientColorStops="directionGradientStops"
+      :stroke="directionStroke"
       :strokeWidth="1.25"
-      :shadowColor="'rgba(0,0,0,0.35)'"
+      :shadowColor="directionShadowColor"
       :shadowBlur="4"
       @mousedown="onSourceMouseDown"
       @mouseup="onSourceMouseUp"
@@ -148,27 +148,44 @@ const isScheduledPlaying = computed(() => sched.value?.isPlaying)
 const sourceIsPlaying = computed(() => props.source.instance.playing);
 
 const getFillColor = computed(() => {
-  if (props.selected) return '#ff0' // Yellow for selected node
-  return isScheduled.value ? '#2e90fa' : '#f44336' // Red for unscheduled/looping
+  if (isDarkMode.value) {
+    if (props.selected) return '#ff0' // Yellow for selected node
+    return isScheduled.value ? '#2e90fa' : '#f44336' // Red for unscheduled/looping
+  }
+  if (props.selected) return 'var(--lm-bg-2)'
+  return isScheduled.value ? 'var(--lm-node-blue)' : 'var(--lm-node-red)'
 })
 
-const dotStrokeColor = computed(() => (props.selected ? '#ffffff' : 'rgba(255, 255, 255, 0.9)'))
-const selectionGlowColor = '#6fd7ff'
+const dotStrokeColor = computed(() => (isDarkMode.value ? (props.selected ? '#ffffff' : 'rgba(255, 255, 255, 0.9)') : '#333333'))
+const selectionGlowColor = computed(() => (isDarkMode.value ? '#6fd7ff' : 'rgba(0, 0, 0, 0.05)'))
 const selectedScale = computed(() => (props.selected ? 1.05 : 1))
 
-const outerConeFill = computed(() => isDarkMode.value ? 'rgba(255, 137, 137, 0.16)' : 'rgba(255, 137, 137, 0.11)')
-const outerConeStroke = computed(() => isDarkMode.value ? 'rgba(255, 137, 137, 0.28)' : 'rgba(255, 137, 137, 0.18)')
-const outerConeShadowColor = computed(() => isDarkMode.value ? 'rgba(255, 120, 120, 0.65)' : 'rgba(255, 120, 120, 0.35)')
-const outerConeShadowBlur = computed(() => isDarkMode.value ? 18 : 12)
+const outerConeFill = computed(() => isDarkMode.value
+  ? 'rgba(255, 137, 137, 0.16)'
+  : (isScheduled.value ? 'var(--lm-cone-blue)' : 'var(--lm-cone-red)'))
+const outerConeStroke = computed(() => isDarkMode.value
+  ? 'rgba(255, 137, 137, 0.28)'
+  : (isScheduled.value ? 'rgba(108, 142, 219, 0.24)' : 'rgba(212, 90, 90, 0.2)'))
+const outerConeShadowColor = computed(() => isDarkMode.value ? 'rgba(255, 120, 120, 0.65)' : 'rgba(0, 0, 0, 0.12)')
+const outerConeShadowBlur = computed(() => isDarkMode.value ? 18 : 10)
 
-const innerConeFill = computed(() => isDarkMode.value ? 'rgba(255, 180, 180, 0.18)' : 'rgba(255, 180, 180, 0.13)')
-const innerConeStroke = computed(() => isDarkMode.value ? 'rgba(255, 180, 180, 0.35)' : 'rgba(255, 180, 180, 0.22)')
+const innerConeFill = computed(() => isDarkMode.value
+  ? 'rgba(255, 180, 180, 0.18)'
+  : (isScheduled.value ? 'rgba(108, 142, 219, 0.18)' : 'rgba(212, 90, 90, 0.16)'))
+const innerConeStroke = computed(() => isDarkMode.value ? 'rgba(255, 180, 180, 0.35)' : 'rgba(0, 0, 0, 0.18)')
 
-const selectionGlowOpacity = computed(() => isDarkMode.value ? 0.75 : 0.55)
-const selectionGlowBlur = computed(() => isDarkMode.value ? 14 : 10)
+const selectionGlowOpacity = computed(() => isDarkMode.value ? 0.75 : 0.22)
+const selectionGlowBlur = computed(() => isDarkMode.value ? 14 : 8)
 
-const nodeShadowBlur = computed(() => isDarkMode.value ? 10 : 8)
-const nodeShadowOpacity = computed(() => isDarkMode.value ? 0.65 : 0.35)
+const nodeShadowBlur = computed(() => isDarkMode.value ? 10 : 6)
+const nodeShadowOpacity = computed(() => isDarkMode.value ? 0.65 : 0.08)
+
+const directionGradientStops = computed(() => isDarkMode.value
+  ? [0, 'rgba(255,255,255,0.95)', 1, 'rgba(255,255,255,0.65)']
+  : [0, 'rgba(255,255,255,0.7)', 1, 'rgba(0,0,0,0.12)']
+)
+const directionStroke = computed(() => isDarkMode.value ? 'rgba(0, 0, 0, 0.6)' : '#333333')
+const directionShadowColor = computed(() => isDarkMode.value ? 'rgba(0,0,0,0.35)' : 'rgba(0,0,0,0.12)')
 
 
 

--- a/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
@@ -2,11 +2,11 @@
   <section class="flex flex-col h-full">
   <ContextMenu ref="menuRef" :functionList="[{ label: 'Delete', function: deleteSound }]" />
 
-  <h5 class="text-sm font-semibold uppercase text-neutral-600 dark:text-neutral-400">
+  <h5 class="text-sm font-semibold uppercase text-[var(--lm-text-1)] dark:text-neutral-400">
     Sound Sources
   </h5>
 
-  <ul class="overflow-y-auto space-y-2 text-sm"
+  <ul class="overflow-y-auto space-y-2 text-sm text-[var(--lm-text-1)]"
   :class="{ 'flex-1 mt-4': soundLibrarySources.length > 0 }">
     <LibrarySource 
       v-for="s in soundLibrarySources"
@@ -20,7 +20,7 @@
   <button
     :disabled="soundLibrarySources.length == MAX_SOURCES"
     @click="() => { router.push('/sound-library') }"
-    class="w-full mt-4 bg-neutral-300 dark:bg-neutral-800 text-xs rounded hover:bg-neutral-400 dark:hover:bg-neutral-700"
+    class="w-full mt-4 bg-[var(--lm-bg-1)] dark:bg-neutral-800 text-xs rounded hover:bg-[var(--lm-bg-0)] dark:hover:bg-neutral-700 border border-[var(--lm-border)] dark:border-neutral-700 text-[var(--lm-text-0)]"
   >
     + Add Source
   </button>

--- a/src/components/SoundRoom/SidebarLeft/ListenerReadout.vue
+++ b/src/components/SoundRoom/SidebarLeft/ListenerReadout.vue
@@ -1,6 +1,6 @@
 <template>
-  <section>
-    <h5 class="text-sm font-semibold uppercase text-neutral-600 dark:text-neutral-400 mb-2">Listener</h5>
+  <section class="text-[var(--lm-text-1)]">
+    <h5 class="text-sm font-semibold uppercase text-[var(--lm-text-1)] dark:text-neutral-400 mb-2">Listener</h5>
     <div class="text-xs space-y-1">
       <p>X: {{ store.listener.x }}</p>
       <p>Y: {{ store.listener.y }}</p>

--- a/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
+++ b/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-neutral-200 dark:bg-neutral-900 border-r border-neutral-300/70 dark:border-neutral-800 p-4 space-y-6"
+    class="flex flex-col h-full bg-[var(--lm-bg-2)] dark:bg-neutral-900 border-r border-[var(--lm-border)] dark:border-neutral-800 p-4 space-y-6"
     role="region"
     aria-labelledby="library-panel-label"
   >

--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -1,12 +1,12 @@
 <template>
-  <section>
-    <h5 class="text-sm font-semibold uppercase text-neutral-500 dark:text-neutral-400 mb-2">
+  <section class="text-[var(--lm-text-0)]">
+    <h5 class="text-sm font-semibold uppercase text-[var(--lm-text-1)] dark:text-neutral-400 mb-2">
       Selected Source
     </h5>
 
     <div v-if="selectedSource" class="space-y-6 flex flex-col items-center">
       <!-- Readouts -->
-      <div class="space-y-1 text-xs">
+      <div class="space-y-1 text-xs text-[var(--lm-text-1)]">
         <h4>{{ selectedSource.name }}</h4>
         <p>X: {{ cleanSourceXY.x }}</p>
         <p>Y: {{ cleanSourceXY.y }}</p>
@@ -33,22 +33,22 @@
       <div class="w-full space-y-2">
         <button
           @click="playPauseSource"
-          class="w-full bg-red-600 text-xs rounded hover:bg-red-500"
+          class="w-full bg-[var(--lm-bg-1)] dark:bg-red-600 text-xs rounded hover:bg-[var(--lm-bg-0)] dark:hover:bg-red-500 border border-[var(--lm-border)] dark:border-red-700 text-[var(--lm-text-0)] dark:text-white"
         >
           {{ playPauseLabel }}
         </button>
         <button
           @click="deleteSource"
-          class="w-full bg-red-600 text-xs rounded hover:bg-red-500"
+          class="w-full bg-[var(--lm-bg-1)] dark:bg-red-600 text-xs rounded hover:bg-[var(--lm-bg-0)] dark:hover:bg-red-500 border border-[var(--lm-border)] dark:border-red-700 text-[var(--lm-text-0)] dark:text-white"
         >
           Delete
         </button>
       </div>
 
-      <hr class="w-full border-neutral-200 dark:border-neutral-700" />
+      <hr class="w-full border-[var(--lm-border)] dark:border-neutral-700" />
 
       <!-- Scheduling Toggle -->
-      <div class="w-full flex items-center space-x-2 text-left px-1">
+      <div class="w-full flex items-center space-x-2 text-left px-1 text-[var(--lm-text-1)]">
         <input
           type="checkbox"
           :checked="schedulingEnabled"
@@ -68,7 +68,7 @@
       <!-- Scheduling Settings -->
       <div
         v-if="schedulingEnabled && canUseTimedLoops"
-        class="space-y-4 w-full text-xs text-neutral-600 dark:text-neutral-300 px-1"
+        class="space-y-4 w-full text-xs text-[var(--lm-text-1)] dark:text-neutral-300 px-1"
       >
         <!-- Mode -->
         <div class="flex flex-col space-y-1">
@@ -77,7 +77,7 @@
             :value="schedule.mode"
             @change="handleScheduleModeChange"
             @blur="commitScheduleEdit"
-            class="px-2 py-1 rounded border dark:bg-neutral-800 dark:border-neutral-700">
+            class="px-2 py-1 rounded border border-[var(--lm-border)] dark:bg-neutral-800 dark:border-neutral-700">
             <option value="interval">Interval</option>
             <option v-if="canUseAdvancedScheduling" value="count">Count</option>
             <option v-if="canUseAdvancedScheduling" value="interval+count">Interval + Count</option>
@@ -99,7 +99,7 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border dark:bg-neutral-800 dark:border-neutral-700"
+              class="px-2 py-1 rounded border border-[var(--lm-border)] dark:bg-neutral-800 dark:border-neutral-700"
             />
           </div>
           <div class="flex flex-col space-y-1">
@@ -116,7 +116,7 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border dark:bg-neutral-800 dark:border-neutral-700"
+              class="px-2 py-1 rounded border border-[var(--lm-border)] dark:bg-neutral-800 dark:border-neutral-700"
             />
             <p v-if="schedule.gapMax < schedule.gapMin" class="text-red-500 text-xs">
               Gap Max cannot be smaller than Gap Min
@@ -140,7 +140,7 @@
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
               placeholder="Unlimited"
-              class="px-2 py-1 rounded border dark:bg-neutral-800 dark:border-neutral-700"
+              class="px-2 py-1 rounded border border-[var(--lm-border)] dark:bg-neutral-800 dark:border-neutral-700"
             />
           </div>
           <div class="flex flex-col space-y-1">
@@ -156,7 +156,7 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border dark:bg-neutral-800 dark:border-neutral-700"
+              class="px-2 py-1 rounded border border-[var(--lm-border)] dark:bg-neutral-800 dark:border-neutral-700"
             />
           </div>
           <div class="flex flex-col space-y-1">
@@ -171,7 +171,7 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border dark:bg-neutral-800 dark:border-neutral-700"
+              class="px-2 py-1 rounded border border-[var(--lm-border)] dark:bg-neutral-800 dark:border-neutral-700"
             />
           </div>
         </div>

--- a/src/components/SoundRoom/SidebarRight/SidebarRight.vue
+++ b/src/components/SoundRoom/SidebarRight/SidebarRight.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-neutral-200 dark:bg-neutral-900 border-l border-neutral-300/70 dark:border-neutral-800 p-4 space-y-4"
+    class="flex flex-col h-full bg-[var(--lm-bg-2)] dark:bg-neutral-900 border-l border-[var(--lm-border)] dark:border-neutral-800 p-4 space-y-4"
     role="region"
     aria-labelledby="selected-sound-panel-label"
   >

--- a/src/components/SoundRoom/Toolbar.vue
+++ b/src/components/SoundRoom/Toolbar.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="flex items-center justify-between p-3 border-neutral-300/70 dark:border-neutral-800 bg-neutral-200 dark:bg-neutral-900 space-x-10 w-full shadow-[0_2px_10px_rgba(0,0,0,0.08)] dark:shadow-none">
+  <div class="flex items-center justify-between p-3 border-[var(--lm-border)] dark:border-neutral-800 bg-[var(--lm-bg-2)] dark:bg-neutral-900 space-x-10 w-full shadow-[var(--lm-shadow)] dark:shadow-none">
           
     <div class="flex space-x-2 w-1/3">
       <BaseButton
       :disabled="audioEngine.soundSources.value.length === 0"
       @click="isPlaying ? audioEngine.pauseAll() : audioEngine.playAll()"
-      class="px-3 py-1 rounded text-sm bg-neutral-200 hover:bg-neutral-300 text-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+      class="px-3 py-1 rounded text-sm bg-[var(--lm-bg-1)] hover:bg-[var(--lm-bg-2)] text-[var(--lm-text-0)] dark:bg-neutral-800 dark:hover:bg-neutral-700"
       > 
         
         <component :is="isPlaying ? Pause : Play" class="h-4 w-4 fill-black dark:fill-white" />
@@ -13,14 +13,14 @@
       <BaseButton
         :disabled="actionStackEmpty || waiting"
         @click="actionManager.undoLastAction"
-        class="px-3 py-1 rounded text-sm bg-neutral-200 hover:bg-neutral-300 text-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+        class="px-3 py-1 rounded text-sm bg-[var(--lm-bg-1)] hover:bg-[var(--lm-bg-2)] text-[var(--lm-text-0)] dark:bg-neutral-800 dark:hover:bg-neutral-700"
       >
         <UndoRedo class="h-4 w-4 fill-black dark:fill-white"/>
       </BaseButton>
       <BaseButton
         :disabled="redoStackEmpty || waiting"
         @click="actionManager.redoLastAction"
-        class="px-3 py-1 rounded text-sm bg-neutral-200 hover:bg-neutral-300 text-neutral-700 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+        class="px-3 py-1 rounded text-sm bg-[var(--lm-bg-1)] hover:bg-[var(--lm-bg-2)] text-[var(--lm-text-0)] dark:bg-neutral-800 dark:hover:bg-neutral-700"
       >
         <UndoRedo class="h-4 w-4 scale-x-[-1] fill-black dark:fill-white"/>
       </BaseButton>
@@ -34,7 +34,7 @@
     />
     <div class="flex items-center justify-center space-x-2 w-1/3">
      
-      <span class="text-xs text-neutral-600">Master</span>
+      <span class="text-xs text-[var(--lm-text-1)]">Master</span>
       <VueSlider 
         v-model="audioEngine.masterVolume.value"
         :min="0" 

--- a/src/components/ui/overlays/PulsingOverlay.vue
+++ b/src/components/ui/overlays/PulsingOverlay.vue
@@ -2,10 +2,10 @@
   <transition name="fade" @after-leave="emit('done')">
     <div
       v-if="visible"
-      class="absolute inset-0 flex items-center justify-center backdrop-blur-sm bg-white/30 dark:bg-black/40 z-50"
+      class="absolute inset-0 flex items-center justify-center backdrop-blur-sm bg-[color-mix(in_srgb,var(--lm-bg-1)_70%,transparent)] dark:bg-black/40 z-50"
     >
       <div
-        class="text-xl font-medium tracking-wide text-neutral-800 dark:text-white animate-pulse"
+        class="text-xl font-medium tracking-wide text-[var(--lm-text-0)] dark:text-white animate-pulse"
       >
         {{ text }}
       </div>

--- a/src/components/ui/overlays/WelcomeOverlay.vue
+++ b/src/components/ui/overlays/WelcomeOverlay.vue
@@ -2,17 +2,17 @@
   <transition name="fade">
     <div
       v-if="visible"
-      class="absolute inset-0 z-50 flex items-center justify-center backdrop-blur-md bg-white/30 dark:bg-black/50"
+      class="absolute inset-0 z-50 flex items-center justify-center backdrop-blur-md bg-[color-mix(in_srgb,var(--lm-bg-1)_70%,transparent)] dark:bg-black/50"
     >
       <div class="text-center space-y-4">
         <h1
-          class="text-5xl lg:text-6xl font-semibold tracking-tight bg-gradient-to-b from-gray-300 via-gray-500 to-gray-200 dark:from-neutral-200 dark:via-neutral-400 dark:to-neutral-100 bg-clip-text text-transparent drop-shadow-md"
+          class="text-5xl lg:text-6xl font-semibold tracking-tight bg-gradient-to-b from-neutral-500 via-neutral-600 to-neutral-400 dark:from-neutral-200 dark:via-neutral-400 dark:to-neutral-100 bg-clip-text text-transparent drop-shadow-md"
         >
           {{ text }}
         </h1>
         <p
           v-if="subtext"
-          class="text-lg text-neutral-700 dark:text-neutral-300 opacity-80"
+          class="text-lg text-[var(--lm-text-1)] dark:text-neutral-300 opacity-80"
         >
           {{ subtext }}
         </p>

--- a/src/components/ui/text/SoundSourceLabel.vue
+++ b/src/components/ui/text/SoundSourceLabel.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="absolute pointer-events-none w-20 overflow-hidden text-xs text-neutral-700 dark:text-neutral-300"
+    class="absolute pointer-events-none w-20 overflow-hidden text-xs text-[var(--lm-text-1)] dark:text-neutral-300"
     :style="{
       top: `${y}px`,
       left: `${x}px`,

--- a/src/style.css
+++ b/src/style.css
@@ -5,8 +5,21 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: var(--lm-text-0);
+  background-color: var(--lm-bg-0);
+
+  --lm-bg-0: #f5f5f5;
+  --lm-bg-1: #ebebeb;
+  --lm-bg-2: #dcdcdc;
+  --lm-border: #c8c8c8;
+  --lm-text-0: #222222;
+  --lm-text-1: #555555;
+  --lm-grid-line: rgba(0, 0, 0, 0.08);
+  --lm-node-red: #d45a5a;
+  --lm-node-blue: #6c8edb;
+  --lm-cone-red: rgba(212, 90, 90, 0.1);
+  --lm-cone-blue: rgba(108, 142, 219, 0.12);
+  --lm-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -16,11 +29,11 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--lm-text-0);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--lm-text-1);
 }
 
 body {
@@ -29,6 +42,8 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  color: var(--lm-text-0);
+  background: var(--lm-bg-0);
 }
 
 h1 {
@@ -43,14 +58,14 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  
+
   cursor: pointer;
   transition: border-color 0.25s;
 
-  @apply bg-[#d3d3d3e1] dark:bg-[#1a1a1a];
+  @apply bg-[var(--lm-bg-1)] dark:bg-[#1a1a1a] text-[var(--lm-text-0)];
 }
 button:hover {
-  border-color: #646cff;
+  border-color: var(--lm-border);
 }
 button:focus,
 button:focus-visible {
@@ -78,11 +93,11 @@ button:disabled {
 input[type="text"],
 input[type="email"],
 input[type="password"] {
-  @apply w-full p-3 border-none rounded-lg dark:bg-[#333] bg-neutral-200 dark:text-white;
+  @apply w-full p-3 border border-[var(--lm-border)] rounded-lg dark:bg-[#333] bg-[var(--lm-bg-2)] dark:text-white text-[var(--lm-text-0)];
 }
 
 input:disabled {
-  @apply dark:bg-neutral-700 dark:text-neutral-400 opacity-50 cursor-not-allowed bg-neutral-200 text-neutral-800;
+  @apply dark:bg-neutral-700 dark:text-neutral-400 opacity-50 cursor-not-allowed bg-[var(--lm-bg-2)] text-[var(--lm-text-1)];
 }
 
 
@@ -91,17 +106,17 @@ input:disabled {
 }
 
 .modal-panel {
-  @apply bg-white dark:bg-neutral-950 rounded-2xl w-[80vw] h-[80vh] shadow-2xl border border-neutral-300 dark:border-neutral-800 overflow-hidden;
+  @apply bg-[var(--lm-bg-0)] dark:bg-neutral-950 rounded-2xl w-[80vw] h-[80vh] shadow-[var(--lm-shadow)] dark:shadow-2xl border border-[var(--lm-border)] dark:border-neutral-800 overflow-hidden;
 }
 
 .modal-header-float {
   @apply absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4
-         bg-white/50 dark:bg-neutral-950/50 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800;
+         bg-[color-mix(in_srgb,var(--lm-bg-0)_85%,transparent)] dark:bg-neutral-950/50 backdrop-blur-md border-b border-[var(--lm-border)] dark:border-neutral-800;
 }
 
 .modal-header {
   @apply top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4
-         bg-white/50 dark:bg-neutral-950/50 backdrop-blur-md border-b border-neutral-300 dark:border-neutral-800;
+         bg-[color-mix(in_srgb,var(--lm-bg-0)_85%,transparent)] dark:bg-neutral-950/50 backdrop-blur-md border-b border-[var(--lm-border)] dark:border-neutral-800;
 }
 
 
@@ -109,15 +124,15 @@ input:disabled {
 
 @media (prefers-color-scheme: light) {
   :root {
-    color: #213547;
-    background-color: #ffffff;
+    color: var(--lm-text-0);
+    background-color: var(--lm-bg-0);
   }
   a:hover {
-    color: #747bff;
+    color: var(--lm-text-1);
   }
- 
+
   button:disabled {
-    background-color: #b9b9b9;
-    color: #505050;
+    background-color: var(--lm-bg-2);
+    color: var(--lm-text-1);
   }
 }

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full bg-neutral-100 text-neutral-800 dark:bg-neutral-950 dark:text-white flex flex-col">
+  <div class="h-full bg-[var(--lm-bg-0)] text-[var(--lm-text-0)] dark:bg-neutral-950 dark:text-white flex flex-col">
     <!-- Main Layout -->
     <div class="flex flex-1 overflow-hidden">
 
@@ -17,7 +17,7 @@
         <Toolbar/>
 
         <!-- Canvas Area -->
-        <div class="flex-1 relative overflow-hidden bg-neutral-200 dark:bg-neutral-900 flex items-center justify-center border-t border-neutral-300/60 dark:border-0">
+        <div class="flex-1 relative overflow-hidden bg-[var(--lm-bg-1)] dark:bg-neutral-900 flex items-center justify-center border-t border-[var(--lm-border)]/80 dark:border-0">
           <div class="pointer-events-none absolute inset-0 canvas-vignette" aria-hidden="true"></div>
           <MainCanvasStage
             v-bind="{
@@ -202,10 +202,10 @@ onUnmounted(() => {
 
 <style scoped>
 .canvas-vignette {
-  --vignette-inner: rgba(255, 255, 255, 0.08);
-  --vignette-middle: rgba(255, 255, 255, 0.04);
-  --vignette-outer: rgba(0, 0, 0, 0.16);
-  --vignette-shadow: inset 0 0 70px rgba(0, 0, 0, 0.18);
+  --vignette-inner: rgba(0, 0, 0, 0.06);
+  --vignette-middle: rgba(0, 0, 0, 0.04);
+  --vignette-outer: rgba(0, 0, 0, 0.08);
+  --vignette-shadow: inset 0 0 70px rgba(0, 0, 0, 0.12);
 
   background: radial-gradient(circle at center, var(--vignette-inner) 0%, var(--vignette-middle) 38%, var(--vignette-outer) 100%);
   box-shadow: var(--vignette-shadow);

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -219,4 +219,11 @@ onUnmounted(() => {
     --vignette-shadow: inset 0 0 140px rgba(0, 0, 0, 0.42);
   }
 }
+
+:global(.dark) .canvas-vignette {
+  --vignette-inner: rgba(224, 224, 224, 0.1);
+  --vignette-middle: rgba(255, 255, 255, 0.03);
+  --vignette-outer: rgba(0, 0, 0, 0.48);
+  --vignette-shadow: inset 0 0 140px rgba(0, 0, 0, 0.42);
+}
 </style>


### PR DESCRIPTION
## Summary
- introduce light-mode grayscale palette variables and apply them to panels, modals, and overlays
- restyle the SoundRoom layout, toolbars, and sidebars with neutral borders, shadows, and text colors
- soften canvas visuals, nodes, cones, and listener styling for low-saturation light mode while preserving dark mode

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69222baa8024832f8a5da7700ed54a56)