### PR TITLE
Improve dark mode palette variables

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -122,6 +122,26 @@ input:disabled {
 
 
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --lm-bg-0: #0b0b0f;
+    --lm-bg-1: #131317;
+    --lm-bg-2: #1c1c22;
+    --lm-border: #27272a;
+    --lm-text-0: #f5f5f5;
+    --lm-text-1: #a1a1aa;
+    --lm-grid-line: rgba(255, 255, 255, 0.06);
+    --lm-node-red: #f87171;
+    --lm-node-blue: #60a5fa;
+    --lm-cone-red: rgba(248, 113, 113, 0.12);
+    --lm-cone-blue: rgba(96, 165, 250, 0.14);
+    --lm-shadow: 0 8px 24px rgba(0, 0, 0, 0.55);
+
+    color: var(--lm-text-0);
+    background-color: var(--lm-bg-0);
+  }
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: var(--lm-text-0);


### PR DESCRIPTION
## Summary
- add dedicated dark-mode CSS variable set to keep backgrounds and text readable
- align canvas and UI accent variables with the dark theme palette

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692236a0dd8c832fa4fee50538c365c0)