### PR TITLE
Refine SoundRoom light mode styling

### DIFF
--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -21,12 +21,12 @@
   />
 
   <!-- Footer Buttons -->
-  <div class="relative flex items-center justify-between h-15 p-2">
+  <div class="relative flex items-center justify-between h-15 p-2 bg-neutral-100 border-t border-neutral-300/40 dark:bg-transparent dark:border-transparent">
     <div class="flex space-x-3">
       <BaseButton
         @click="showSaveConfirm = true"
         :disabled="isSaving || !isRoomSaveable"
-        class="px-3 py-2 rounded bg-[var(--lm-bg-1)] hover:bg-[var(--lm-bg-0)] text-[var(--lm-text-0)] border border-[var(--lm-border)] dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        class="px-3 py-2 rounded bg-neutral-200 hover:bg-neutral-300 text-[var(--lm-text-0)] border border-neutral-300 dark:bg-neutral-800 dark:hover:bg-neutral-700 dark:border-transparent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         type="button"
         aria-label="Open save room confirmation"
       >
@@ -36,7 +36,7 @@
       <BaseButton
         @click="showNewRoomConfirm = true"
         :disabled="isSaving || isRoomEmpty"
-        class="px-3 py-2 rounded bg-[var(--lm-bg-1)] hover:bg-[var(--lm-bg-0)] text-[var(--lm-text-0)] border border-[var(--lm-border)] dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        class="px-3 py-2 rounded bg-neutral-200 hover:bg-neutral-300 text-[var(--lm-text-0)] border border-neutral-300 dark:bg-neutral-800 dark:hover:bg-neutral-700 dark:border-transparent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         type="button"
         aria-label="Open new room confirmation"
       >

--- a/src/components/SoundRoom/IRSelect.vue
+++ b/src/components/SoundRoom/IRSelect.vue
@@ -2,7 +2,7 @@
   <select
     v-model="selectedIR"
     @change="applyIR"
-    class="px-2 py-1 w-32 rounded border text-sm dark:bg-neutral-800 dark:border-neutral-700"
+    class="px-2 py-1 w-32 rounded border text-sm bg-neutral-100 border-neutral-300 text-neutral-800 dark:bg-neutral-800 dark:border-neutral-700 dark:text-white"
   >
     <option v-for="ir in irOptions" :key="ir.value" :value="ir.value">
       {{ ir.label }}

--- a/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
@@ -119,19 +119,19 @@ const syncTheme = (event) => {
 onMounted(() => prefersDark.addEventListener('change', syncTheme))
 onBeforeUnmount(() => prefersDark.removeEventListener('change', syncTheme))
 
-const anchorGlowFill = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.08)' : 'rgba(0, 0, 0, 0.06)')
-const anchorShadowColor = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.3)' : 'rgba(0, 0, 0, 0.1)')
-const anchorShadowBlur = computed(() => isDarkMode.value ? 18 : 10)
-const anchorShadowOpacity = computed(() => isDarkMode.value ? 0.35 : 0.18)
+const anchorGlowFill = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.08)' : 'rgba(0, 0, 0, 0.05)')
+const anchorShadowColor = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.3)' : 'rgba(0, 0, 0, 0.08)')
+const anchorShadowBlur = computed(() => isDarkMode.value ? 18 : 8)
+const anchorShadowOpacity = computed(() => isDarkMode.value ? 0.35 : 0.16)
 
-const bodyFill = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.15)' : 'rgba(150, 165, 185, 0.35)')
+const bodyFill = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.15)' : '#a4afc0')
 const bodyStroke = computed(() => isDarkMode.value ? 'rgba(96, 165, 250, 0.9)' : '#2f3a4a')
 const bodyShadowColor = computed(() => isDarkMode.value ? 'rgba(0, 0, 0, 0.2)' : 'rgba(0, 0, 0, 0.08)')
 const bodyShadowBlur = computed(() => isDarkMode.value ? 10 : 8)
-const bodyShadowOpacity = computed(() => isDarkMode.value ? 0.55 : 0.18)
+const bodyShadowOpacity = computed(() => isDarkMode.value ? 0.55 : 0.2)
 
-const detailFill = computed(() => isDarkMode.value ? 'rgba(15, 23, 42, 0.9)' : 'rgba(70, 80, 95, 0.85)')
-const detailStroke = computed(() => isDarkMode.value ? 'rgba(191, 219, 254, 0.85)' : 'rgba(60, 70, 85, 0.6)')
+const detailFill = computed(() => isDarkMode.value ? 'rgba(15, 23, 42, 0.9)' : 'rgba(86, 96, 112, 0.9)')
+const detailStroke = computed(() => isDarkMode.value ? 'rgba(191, 219, 254, 0.85)' : 'rgba(54, 62, 78, 0.7)')
 
 const detailShadowColor = computed(() => isDarkMode.value ? 'rgba(59, 130, 246, 0.35)' : 'rgba(0, 0, 0, 0.08)')
 const detailShadowBlur = computed(() => isDarkMode.value ? 8 : 6)

--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -49,7 +49,7 @@
       :fill="getFillColor"
       :stroke="dotStrokeColor"
       :strokeWidth="2"
-      :shadowColor="getFillColor"
+      :shadowColor="nodeShadowColor"
       :shadowBlur="nodeShadowBlur"
       :shadowOpacity="nodeShadowOpacity"
       shadowForStrokeEnabled="false"
@@ -168,7 +168,7 @@ const getFillColor = computed(() => {
   return isScheduled.value ? colors.nodeBlue : colors.nodeRed
 })
 
-const dotStrokeColor = computed(() => (isDarkMode.value ? (props.selected ? '#ffffff' : 'rgba(255, 255, 255, 0.9)') : '#333333'))
+const dotStrokeColor = computed(() => (isDarkMode.value ? (props.selected ? '#ffffff' : 'rgba(255, 255, 255, 0.9)') : '#444444'))
 const selectionGlowColor = computed(() => (isDarkMode.value ? '#6fd7ff' : 'rgba(0, 0, 0, 0.05)'))
 const selectedScale = computed(() => (props.selected ? 1.05 : 1))
 
@@ -179,22 +179,23 @@ const outerConeFill = computed(() => {
 })
 const outerConeStroke = computed(() => isDarkMode.value
   ? 'rgba(255, 137, 137, 0.28)'
-  : (isScheduled.value ? 'rgba(108, 142, 219, 0.24)' : 'rgba(212, 90, 90, 0.2)'))
-const outerConeShadowColor = computed(() => isDarkMode.value ? 'rgba(255, 120, 120, 0.65)' : 'rgba(0, 0, 0, 0.12)')
+  : (isScheduled.value ? 'rgba(108, 142, 219, 0.22)' : 'rgba(210, 70, 70, 0.18)'))
+const outerConeShadowColor = computed(() => isDarkMode.value ? 'rgba(255, 120, 120, 0.65)' : 'rgba(0, 0, 0, 0.1)')
 const outerConeShadowBlur = computed(() => isDarkMode.value ? 18 : 10)
 
 const innerConeFill = computed(() => {
   if (isDarkMode.value) return 'rgba(255, 180, 180, 0.18)'
   const colors = lightPalette.value
-  return isScheduled.value ? 'rgba(108, 142, 219, 0.18)' : 'rgba(212, 90, 90, 0.16)'
+  return isScheduled.value ? 'rgba(108, 142, 219, 0.16)' : 'rgba(210, 70, 70, 0.14)'
 })
-const innerConeStroke = computed(() => isDarkMode.value ? 'rgba(255, 180, 180, 0.35)' : 'rgba(0, 0, 0, 0.18)')
+const innerConeStroke = computed(() => isDarkMode.value ? 'rgba(255, 180, 180, 0.35)' : 'rgba(0, 0, 0, 0.15)')
 
 const selectionGlowOpacity = computed(() => isDarkMode.value ? 0.75 : 0.22)
 const selectionGlowBlur = computed(() => isDarkMode.value ? 14 : 8)
 
-const nodeShadowBlur = computed(() => isDarkMode.value ? 10 : 6)
-const nodeShadowOpacity = computed(() => isDarkMode.value ? 0.65 : 0.08)
+const nodeShadowColor = computed(() => (isDarkMode.value ? getFillColor.value : 'rgba(0, 0, 0, 0.35)'))
+const nodeShadowBlur = computed(() => isDarkMode.value ? 10 : 4)
+const nodeShadowOpacity = computed(() => isDarkMode.value ? 0.65 : 0.14)
 
 const directionGradientStops = computed(() => isDarkMode.value
   ? [0, 'rgba(255,255,255,0.95)', 1, 'rgba(255,255,255,0.65)']

--- a/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
@@ -2,11 +2,11 @@
   <section class="flex flex-col h-full">
   <ContextMenu ref="menuRef" :functionList="[{ label: 'Delete', function: deleteSound }]" />
 
-  <h5 class="text-sm font-semibold uppercase text-[var(--lm-text-1)] dark:text-neutral-400">
+  <h5 class="text-sm font-semibold uppercase text-neutral-700 dark:text-neutral-400">
     Sound Sources
   </h5>
 
-  <ul class="overflow-y-auto space-y-2 text-sm text-[var(--lm-text-1)]"
+  <ul class="overflow-y-auto space-y-2 text-sm text-neutral-700 dark:text-neutral-300"
   :class="{ 'flex-1 mt-4': soundLibrarySources.length > 0 }">
     <LibrarySource 
       v-for="s in soundLibrarySources"
@@ -20,7 +20,7 @@
   <button
     :disabled="soundLibrarySources.length == MAX_SOURCES"
     @click="() => { router.push('/sound-library') }"
-    class="w-full mt-4 bg-[var(--lm-bg-1)] dark:bg-neutral-800 text-xs rounded hover:bg-[var(--lm-bg-0)] dark:hover:bg-neutral-700 border border-[var(--lm-border)] dark:border-neutral-700 text-[var(--lm-text-0)]"
+    class="w-full mt-4 bg-neutral-200 dark:bg-neutral-800 text-xs rounded hover:bg-neutral-300 dark:hover:bg-neutral-700 border border-neutral-300 dark:border-neutral-700 text-neutral-800 dark:text-white transition-colors"
   >
     + Add Source
   </button>

--- a/src/components/SoundRoom/SidebarLeft/ListenerReadout.vue
+++ b/src/components/SoundRoom/SidebarLeft/ListenerReadout.vue
@@ -1,6 +1,6 @@
 <template>
-  <section class="text-[var(--lm-text-1)]">
-    <h5 class="text-sm font-semibold uppercase text-[var(--lm-text-1)] dark:text-neutral-400 mb-2">Listener</h5>
+  <section class="text-neutral-700 dark:text-neutral-300">
+    <h5 class="text-sm font-semibold uppercase text-neutral-800 dark:text-neutral-400 mb-2">Listener</h5>
     <div class="text-xs space-y-1">
       <p>X: {{ store.listener.x }}</p>
       <p>Y: {{ store.listener.y }}</p>

--- a/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
+++ b/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-[var(--lm-bg-2)] dark:bg-neutral-900 border-r border-[var(--lm-border)] dark:border-neutral-800 p-4 space-y-6"
+    class="flex flex-col h-full bg-[#dcdcdc] dark:bg-neutral-900 border-r border-neutral-300/40 dark:border-neutral-800 p-4 space-y-6"
     role="region"
     aria-labelledby="library-panel-label"
   >

--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -1,12 +1,12 @@
 <template>
-  <section class="text-[var(--lm-text-0)]">
-    <h5 class="text-sm font-semibold uppercase text-[var(--lm-text-1)] dark:text-neutral-400 mb-2">
+  <section class="text-neutral-800 dark:text-white">
+    <h5 class="text-sm font-semibold uppercase text-neutral-700 dark:text-neutral-400 mb-2">
       Selected Source
     </h5>
 
     <div v-if="selectedSource" class="space-y-6 flex flex-col items-center">
       <!-- Readouts -->
-      <div class="space-y-1 text-xs text-[var(--lm-text-1)]">
+      <div class="space-y-1 text-xs text-neutral-700 dark:text-neutral-300">
         <h4>{{ selectedSource.name }}</h4>
         <p>X: {{ cleanSourceXY.x }}</p>
         <p>Y: {{ cleanSourceXY.y }}</p>
@@ -33,13 +33,13 @@
       <div class="w-full space-y-2">
         <button
           @click="playPauseSource"
-          class="w-full bg-[var(--lm-bg-1)] dark:bg-red-600 text-xs rounded hover:bg-[var(--lm-bg-0)] dark:hover:bg-red-500 border border-[var(--lm-border)] dark:border-red-700 text-[var(--lm-text-0)] dark:text-white"
+          class="w-full bg-neutral-200 dark:bg-red-600 text-xs rounded hover:bg-neutral-300 dark:hover:bg-red-500 border border-neutral-300 dark:border-red-700 text-neutral-800 dark:text-white transition-colors"
         >
           {{ playPauseLabel }}
         </button>
         <button
           @click="deleteSource"
-          class="w-full bg-[var(--lm-bg-1)] dark:bg-red-600 text-xs rounded hover:bg-[var(--lm-bg-0)] dark:hover:bg-red-500 border border-[var(--lm-border)] dark:border-red-700 text-[var(--lm-text-0)] dark:text-white"
+          class="w-full bg-neutral-200 dark:bg-red-600 text-xs rounded hover:bg-neutral-300 dark:hover:bg-red-500 border border-neutral-300 dark:border-red-700 text-neutral-800 dark:text-white transition-colors"
         >
           Delete
         </button>
@@ -48,7 +48,7 @@
       <hr class="w-full border-[var(--lm-border)] dark:border-neutral-700" />
 
       <!-- Scheduling Toggle -->
-      <div class="w-full flex items-center space-x-2 text-left px-1 text-[var(--lm-text-1)]">
+      <div class="w-full flex items-center space-x-2 text-left px-1 text-neutral-700 dark:text-neutral-300">
         <input
           type="checkbox"
           :checked="schedulingEnabled"
@@ -68,7 +68,7 @@
       <!-- Scheduling Settings -->
       <div
         v-if="schedulingEnabled && canUseTimedLoops"
-        class="space-y-4 w-full text-xs text-[var(--lm-text-1)] dark:text-neutral-300 px-1"
+        class="space-y-4 w-full text-xs text-neutral-700 dark:text-neutral-300 px-1"
       >
         <!-- Mode -->
         <div class="flex flex-col space-y-1">

--- a/src/components/SoundRoom/SidebarRight/SidebarRight.vue
+++ b/src/components/SoundRoom/SidebarRight/SidebarRight.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-[var(--lm-bg-2)] dark:bg-neutral-900 border-l border-[var(--lm-border)] dark:border-neutral-800 p-4 space-y-4"
+    class="flex flex-col h-full bg-[#e6e6e6] dark:bg-neutral-900 border-l border-neutral-300/40 dark:border-neutral-800 p-4 space-y-4 shadow-[0_1px_4px_rgba(0,0,0,0.06)] dark:shadow-none"
     role="region"
     aria-labelledby="selected-sound-panel-label"
   >

--- a/src/components/SoundRoom/Toolbar.vue
+++ b/src/components/SoundRoom/Toolbar.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="flex items-center justify-between p-3 border-[var(--lm-border)] dark:border-neutral-800 bg-[var(--lm-bg-2)] dark:bg-neutral-900 space-x-10 w-full shadow-[var(--lm-shadow)] dark:shadow-none">
+  <div class="flex items-center justify-between p-3 border-b border-neutral-300/60 dark:border-neutral-800 bg-[#e6e6e6] dark:bg-neutral-900 space-x-10 w-full shadow-[var(--lm-shadow)] dark:shadow-none text-neutral-800">
           
     <div class="flex space-x-2 w-1/3">
       <BaseButton
       :disabled="audioEngine.soundSources.value.length === 0"
       @click="isPlaying ? audioEngine.pauseAll() : audioEngine.playAll()"
-      class="px-3 py-1 rounded text-sm bg-[var(--lm-bg-1)] hover:bg-[var(--lm-bg-2)] text-[var(--lm-text-0)] dark:bg-neutral-800 dark:hover:bg-neutral-700"
+      class="px-3 py-1 rounded text-sm bg-neutral-200 border border-neutral-300 hover:bg-neutral-300 transition-colors text-[var(--lm-text-0)] dark:bg-neutral-800 dark:hover:bg-neutral-700 dark:border-transparent"
       > 
         
         <component :is="isPlaying ? Pause : Play" class="h-4 w-4 fill-black dark:fill-white" />
@@ -13,14 +13,14 @@
       <BaseButton
         :disabled="actionStackEmpty || waiting"
         @click="actionManager.undoLastAction"
-        class="px-3 py-1 rounded text-sm bg-[var(--lm-bg-1)] hover:bg-[var(--lm-bg-2)] text-[var(--lm-text-0)] dark:bg-neutral-800 dark:hover:bg-neutral-700"
+        class="px-3 py-1 rounded text-sm bg-neutral-200 border border-neutral-300 hover:bg-neutral-300 transition-colors text-[var(--lm-text-0)] dark:bg-neutral-800 dark:hover:bg-neutral-700 dark:border-transparent"
       >
         <UndoRedo class="h-4 w-4 fill-black dark:fill-white"/>
       </BaseButton>
       <BaseButton
         :disabled="redoStackEmpty || waiting"
         @click="actionManager.redoLastAction"
-        class="px-3 py-1 rounded text-sm bg-[var(--lm-bg-1)] hover:bg-[var(--lm-bg-2)] text-[var(--lm-text-0)] dark:bg-neutral-800 dark:hover:bg-neutral-700"
+        class="px-3 py-1 rounded text-sm bg-neutral-200 border border-neutral-300 hover:bg-neutral-300 transition-colors text-[var(--lm-text-0)] dark:bg-neutral-800 dark:hover:bg-neutral-700 dark:border-transparent"
       >
         <UndoRedo class="h-4 w-4 scale-x-[-1] fill-black dark:fill-white"/>
       </BaseButton>
@@ -34,7 +34,7 @@
     />
     <div class="flex items-center justify-center space-x-2 w-1/3">
      
-      <span class="text-xs text-[var(--lm-text-1)]">Master</span>
+      <span class="text-xs text-neutral-700 dark:text-neutral-300">Master</span>
       <VueSlider 
         v-model="audioEngine.masterVolume.value"
         :min="0" 

--- a/src/components/ui/text/SoundSourceLabel.vue
+++ b/src/components/ui/text/SoundSourceLabel.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="absolute pointer-events-none w-20 overflow-hidden text-xs text-[var(--lm-text-1)] dark:text-neutral-300"
+    class="absolute pointer-events-none w-20 overflow-hidden text-xs text-neutral-700 dark:text-neutral-300"
     :style="{
       top: `${y}px`,
       left: `${x}px`,

--- a/src/style.css
+++ b/src/style.css
@@ -8,18 +8,18 @@
   color: var(--lm-text-0);
   background-color: var(--lm-bg-0);
 
-  --lm-bg-0: #f5f5f5;
-  --lm-bg-1: #ebebeb;
+  --lm-bg-0: #f3f3f3;
+  --lm-bg-1: #e1e1e1;
   --lm-bg-2: #dcdcdc;
-  --lm-border: #c8c8c8;
+  --lm-border: #c9c9c9;
   --lm-text-0: #222222;
-  --lm-text-1: #555555;
-  --lm-grid-line: rgba(0, 0, 0, 0.08);
+  --lm-text-1: #4a4a4a;
+  --lm-grid-line: rgba(0, 0, 0, 0.06);
   --lm-node-red: #d45a5a;
   --lm-node-blue: #6c8edb;
-  --lm-cone-red: rgba(212, 90, 90, 0.1);
+  --lm-cone-red: rgba(210, 70, 70, 0.1);
   --lm-cone-blue: rgba(108, 142, 219, 0.12);
-  --lm-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+  --lm-shadow: 0 3px 10px rgba(0, 0, 0, 0.12);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -17,7 +17,7 @@
         <Toolbar/>
 
         <!-- Canvas Area -->
-        <div class="flex-1 relative overflow-hidden bg-[var(--lm-bg-1)] dark:bg-neutral-900 flex items-center justify-center border-t border-[var(--lm-border)]/80 dark:border-0">
+        <div class="flex-1 relative overflow-hidden bg-[#e1e1e1] dark:bg-neutral-900 flex items-center justify-center border border-neutral-300/40 dark:border-0 shadow-[0_2px_8px_rgba(0,0,0,0.10)]">
           <div class="pointer-events-none absolute inset-0 canvas-vignette" aria-hidden="true"></div>
           <MainCanvasStage
             v-bind="{
@@ -202,10 +202,10 @@ onUnmounted(() => {
 
 <style scoped>
 .canvas-vignette {
-  --vignette-inner: rgba(0, 0, 0, 0.06);
-  --vignette-middle: rgba(0, 0, 0, 0.04);
-  --vignette-outer: rgba(0, 0, 0, 0.08);
-  --vignette-shadow: inset 0 0 70px rgba(0, 0, 0, 0.12);
+  --vignette-inner: rgba(0, 0, 0, 0.05);
+  --vignette-middle: rgba(0, 0, 0, 0.03);
+  --vignette-outer: rgba(0, 0, 0, 0.05);
+  --vignette-shadow: inset 0 0 60px rgba(0, 0, 0, 0.05);
 
   background: radial-gradient(circle at center, var(--vignette-inner) 0%, var(--vignette-middle) 38%, var(--vignette-outer) 100%);
   box-shadow: var(--vignette-shadow);


### PR DESCRIPTION
## Summary
- add clearer separation and shading for canvas and side panels in light mode
- adjust controls, footer, and dropdowns with neutral backgrounds and borders for better structure
- refine node, listener, and label styling with muted pastels and higher contrast text without affecting dark mode

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69235228ff84832fa700dd4d762602d4)