### PR TITLE
Fix drag state when rotating sound sources

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -326,6 +326,12 @@ function onSourceDragMove(e) {
 
 // Source drop
 function onSourceMouseUp(e) {
+  const group = e.target.getParent()
+
+  if (group) {
+    group.draggable(false)
+  }
+
   const to = {
     x: props.source.instance.state.x,
     y: props.source.instance.state.y
@@ -345,6 +351,11 @@ function onHandleMouseDown(e) {
   e.evt.stopPropagation()
 
   initialSourceAngle = props.source.instance.state.angle
+
+  const group = e.target.getParent()
+  if (group) {
+    group.draggable(false)
+  }
 
   const stage = e.target.getStage()
   const mousePos = stage.getPointerPosition()


### PR DESCRIPTION
## Summary
- stop leaving sound source groups draggable after finishing a drag
- disable dragging when starting rotation to keep rotation smooth

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236bc3c0c0832fa49fa54957445403)