### PR TITLE
Prevent sound source drag when starting rotation

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -326,6 +326,11 @@ function onSourceDragMove(e) {
 
 // Source drop
 function onSourceMouseUp(e) {
+  const group = e.target?.getParent?.()
+  if (group?.draggable()) {
+    group.draggable(false)
+  }
+
   const to = {
     x: props.source.instance.state.x,
     y: props.source.instance.state.y
@@ -343,6 +348,12 @@ function onSourceMouseUp(e) {
 function onHandleMouseDown(e) {
   emit('select', props.index)
   e.evt.stopPropagation()
+
+  const group = e.target.getParent()
+  if (group?.draggable()) {
+    group.stopDrag()
+    group.draggable(false)
+  }
 
   initialSourceAngle = props.source.instance.state.angle
 


### PR DESCRIPTION
## Summary
- stop any active dragging when initiating a rotation so the node does not move
- keep rotation handling unchanged while ensuring the group is not draggable during rotation attempts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236fc57e60832fb696a2daf8ec9f53)