### PR TITLE
Add dynamic Supabase theme system

### DIFF
--- a/src/components/Settings/ThemeSelector.vue
+++ b/src/components/Settings/ThemeSelector.vue
@@ -1,0 +1,96 @@
+<template>
+  <section class="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 p-6 shadow-sm space-y-6">
+    <header class="space-y-2">
+      <h2 class="text-xl font-semibold">Appearance</h2>
+      <p class="text-sm text-neutral-600 dark:text-neutral-400">Pick a theme to update the interface instantly.</p>
+    </header>
+
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <button
+        v-for="theme in sortedThemes"
+        :key="theme.id"
+        type="button"
+        class="group relative flex items-center gap-4 border rounded-xl p-4 text-left transition hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
+        :class="[
+          isLocked(theme)
+            ? 'border-dashed border-red-300 dark:border-red-800 opacity-70 cursor-not-allowed'
+            : 'border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 shadow-sm hover:shadow-md'
+        ]"
+        :aria-pressed="currentThemeId === theme.id"
+        :disabled="isLocked(theme)"
+        @click="handleSelect(theme)"
+      >
+        <div
+          class="w-16 h-16 rounded-lg border overflow-hidden flex-shrink-0"
+          :class="isLocked(theme) ? 'border-red-300 dark:border-red-800' : 'border-neutral-200 dark:border-neutral-700'"
+          :style="previewStyle(theme)"
+        >
+          <span v-if="isLocked(theme)" class="sr-only">Locked theme</span>
+        </div>
+
+        <div class="flex-1 space-y-1">
+          <div class="flex items-center gap-2">
+            <p class="text-base font-medium">{{ theme.name }}</p>
+            <span
+              v-if="currentThemeId === theme.id"
+              class="px-2 py-0.5 text-xs rounded-full bg-blue-100 text-blue-800 dark:bg-blue-900/70 dark:text-blue-100"
+            >
+              Active
+            </span>
+          </div>
+          <p class="text-xs text-neutral-500 dark:text-neutral-400">{{ planLabel(theme.plan_required) }} plan or higher</p>
+          <p v-if="isLocked(theme)" class="text-xs text-red-500">Upgrade to use this theme.</p>
+          <p v-else class="text-xs text-neutral-500 dark:text-neutral-400">Click to apply instantly.</p>
+        </div>
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, onMounted } from 'vue'
+import { useTheme } from '@/composables/useTheme'
+
+const { themes, currentTheme, loadTheme, setTheme, isPremiumLocked } = useTheme()
+
+onMounted(() => {
+  void loadTheme()
+})
+
+const currentThemeId = computed(() => currentTheme.value?.id || '')
+
+const sortedThemes = computed(() => [...themes.value].sort((a, b) => a.name.localeCompare(b.name)))
+
+function planLabel(plan) {
+  if (!plan) return 'Free'
+  const normalized = plan.toLowerCase()
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1)
+}
+
+function previewStyle(theme) {
+  if (theme.preview_url) {
+    return {
+      backgroundImage: `url(${theme.preview_url})`,
+      backgroundSize: 'cover',
+      backgroundPosition: 'center'
+    }
+  }
+
+  const bg1 = theme.css_vars?.['--lm-bg-1'] || '#e5e5e5'
+  const bg2 = theme.css_vars?.['--lm-bg-2'] || '#dcdcdc'
+  const accent = theme.css_vars?.['--lm-node-blue'] || '#6c8edb'
+
+  return {
+    backgroundImage: `linear-gradient(135deg, ${bg1} 0%, ${bg2} 65%, ${accent} 100%)`
+  }
+}
+
+function isLocked(theme) {
+  return isPremiumLocked(theme)
+}
+
+async function handleSelect(theme) {
+  if (!theme || isLocked(theme)) return
+  await setTheme(theme.id)
+}
+</script>

--- a/src/components/SoundRoom/HeaderBar.vue
+++ b/src/components/SoundRoom/HeaderBar.vue
@@ -3,37 +3,49 @@
   <header class="px-6 py-4 border-b border-neutral-300 dark:border-neutral-800 dark:bg-black flex items-center justify-between relative">
     <h1 class="text-xl font-bold tracking-wide dark:text-gray-300"><RouterLink to="/" style="text-decoration: none; color: inherit;">SoundRoom</RouterLink></h1>
     
-    <div v-if="shouldShowNavButtons" class="relative">
+    <div v-if="shouldShowNavButtons" class="flex items-center gap-3">
       <button
-        ref="menuButton"
         type="button"
-        @click="toggleMenu"
-        class="flex items-center justify-center w-12 h-12 !p-1 !bg-transparent"
-        :aria-expanded="isMenuOpen"
-        aria-haspopup="true"
+        class="hidden sm:inline-flex items-center gap-2 px-3 py-2 rounded-full border border-neutral-200 dark:border-neutral-700 bg-white/70 dark:bg-neutral-900/70 text-sm text-neutral-800 dark:text-neutral-100 hover:border-neutral-300 dark:hover:border-neutral-500 transition"
+        :disabled="!nextThemeId"
+        @click="cycleTheme"
       >
-        <span class="sr-only">Open navigation menu</span>
-        <HamburgerIcon class="w-full h-full text-neutral-900 dark:text-gray-300" />
-
+        <span class="w-2 h-2 rounded-full" :style="themeDotStyle" />
+        <span>{{ currentThemeName }}</span>
       </button>
-      <transition name="fade">
-        <div
-          v-if="isMenuOpen"
-          @mouseleave="closeMenu"
-          ref="menuPanel"
-          class="absolute right-0 mt-2 w-44 rounded-lg shadow-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 py-2 z-50 flex flex-col divide-y divide-neutral-200 dark:divide-neutral-800 overflow-hidden"
+
+      <div class="relative">
+        <button
+          ref="menuButton"
+          type="button"
+          @click="toggleMenu"
+          class="flex items-center justify-center w-12 h-12 !p-1 !bg-transparent"
+          :aria-expanded="isMenuOpen"
+          aria-haspopup="true"
         >
-          <template v-for="button in visibleButtons" :key="button.label">
-            <button
-              class="w-full px-4 py-2 text-left text-sm text-neutral-800 dark:text-neutral-100 hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-none !bg-transparent"
-              type="button"
-              @click="runAction(button.action)"
-            >
-              {{ button.label }}
-            </button>
-          </template>
-        </div>
-      </transition>
+          <span class="sr-only">Open navigation menu</span>
+          <HamburgerIcon class="w-full h-full text-neutral-900 dark:text-gray-300" />
+
+        </button>
+        <transition name="fade">
+          <div
+            v-if="isMenuOpen"
+            @mouseleave="closeMenu"
+            ref="menuPanel"
+            class="absolute right-0 mt-2 w-44 rounded-lg shadow-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 py-2 z-50 flex flex-col divide-y divide-neutral-200 dark:divide-neutral-800 overflow-hidden"
+          >
+            <template v-for="button in visibleButtons" :key="button.label">
+              <button
+                class="w-full px-4 py-2 text-left text-sm text-neutral-800 dark:text-neutral-100 hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-none !bg-transparent"
+                type="button"
+                @click="runAction(button.action)"
+              >
+                {{ button.label }}
+              </button>
+            </template>
+          </div>
+        </transition>
+      </div>
     </div>
 
   </header>
@@ -44,6 +56,7 @@ import { ref, watch, computed, onMounted, onBeforeUnmount } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useAuth } from '@/composables/useAuth';
 import { supabase } from '@/utils/supabase';
+import { useTheme } from '@/composables/useTheme'
 import PulsingOverlay from '@/components/ui/overlays/PulsingOverlay.vue';
 import HamburgerIcon from '@/assets/icons/hamburger.svg';
 const menuPanel = ref(null)
@@ -62,6 +75,19 @@ const shouldShowNavButtons = computed(() => !hiddenHeaderRoutes.includes(route.p
 const isLoggingOut = ref(false); // Track if logging out
 
 const authMode = ref('signup'); // 'login' | 'signup' | 'reset
+
+const { themes, currentTheme, setTheme, loadTheme, isPremiumLocked } = useTheme()
+const accessibleThemes = computed(() => themes.value.filter((theme) => !isPremiumLocked(theme)))
+const currentThemeName = computed(() => currentTheme.value?.name ?? 'Theme')
+const nextThemeId = computed(() => {
+  if (!accessibleThemes.value.length) return null
+  const currentIndex = accessibleThemes.value.findIndex((theme) => theme.id === currentTheme.value?.id)
+  if (currentIndex === -1) return accessibleThemes.value[0]?.id ?? null
+  return accessibleThemes.value[(currentIndex + 1) % accessibleThemes.value.length]?.id ?? null
+})
+const themeDotStyle = computed(() => ({
+  background: currentTheme.value?.css_vars?.['--lm-bg-2'] || 'var(--lm-bg-2)'
+}))
 
 const toggleMenu = () => {
   isMenuOpen.value = !isMenuOpen.value
@@ -90,7 +116,13 @@ const handleEscape = (event) => {
   }
 }
 
+async function cycleTheme() {
+  if (!nextThemeId.value) return
+  await setTheme(nextThemeId.value)
+}
+
 onMounted(() => {
+  void loadTheme()
   document.addEventListener('click', handleDocumentClick)
   document.addEventListener('keydown', handleEscape)
 })

--- a/src/composables/useTheme.js
+++ b/src/composables/useTheme.js
@@ -1,0 +1,216 @@
+import { computed, ref, watch } from 'vue'
+import { supabase } from '@/utils/supabase'
+import { useAuth } from '@/composables/useAuth'
+import { PLANS } from '@/constants/entitlements'
+
+const THEME_ID_KEY = 'soundroom.themeId'
+const THEME_CACHE_KEY = 'soundroom.themeCache'
+
+const themes = ref([])
+const currentThemeId = ref(null)
+const isLoadingThemes = ref(false)
+let authWatcherInitialized = false
+let primedFromCache = false
+
+const { user, tier } = useAuth()
+
+function cacheThemes(themeList) {
+  try {
+    localStorage.setItem(THEME_CACHE_KEY, JSON.stringify(themeList))
+  } catch (error) {
+    console.warn('Unable to cache themes', error)
+  }
+}
+
+function loadCachedThemes() {
+  try {
+    const cached = localStorage.getItem(THEME_CACHE_KEY)
+    if (!cached) return []
+    const parsed = JSON.parse(cached)
+    if (Array.isArray(parsed)) return parsed
+    return []
+  } catch (error) {
+    console.warn('Unable to parse cached themes', error)
+    return []
+  }
+}
+
+function applyCssVariables(theme) {
+  if (!theme?.css_vars) return
+
+  Object.entries(theme.css_vars).forEach(([key, value]) => {
+    if (typeof value === 'string') {
+      document.documentElement.style.setProperty(key, value)
+    }
+  })
+
+  const name = theme.name?.toLowerCase()
+  if (name === 'dark') {
+    document.documentElement.style.colorScheme = 'dark'
+    document.documentElement.classList.add('dark')
+  } else if (name === 'light') {
+    document.documentElement.style.colorScheme = 'light'
+    document.documentElement.classList.remove('dark')
+  }
+}
+
+function primeThemeFromCache() {
+  if (primedFromCache) return
+  primedFromCache = true
+
+  const cached = loadCachedThemes()
+  if (cached.length) {
+    themes.value = cached
+  }
+
+  const storedId = localStorage.getItem(THEME_ID_KEY)
+  if (storedId && cached.length) {
+    const cachedTheme = cached.find((theme) => theme.id === storedId)
+    if (cachedTheme) {
+      currentThemeId.value = storedId
+      applyCssVariables(cachedTheme)
+    }
+  }
+}
+
+async function fetchThemes() {
+  if (isLoadingThemes.value) return themes.value
+  isLoadingThemes.value = true
+  try {
+    const { data, error } = await supabase
+      .from('themes')
+      .select('id, name, plan_required, css_vars, preview_url')
+      .order('name', { ascending: true })
+
+    if (error) throw error
+
+    themes.value = data || []
+    cacheThemes(themes.value)
+    return themes.value
+  } catch (error) {
+    console.error('Failed to fetch themes', error)
+    return themes.value
+  } finally {
+    isLoadingThemes.value = false
+  }
+}
+
+async function fetchUserThemeId(userId) {
+  if (!userId) return null
+  const { data, error } = await supabase
+    .from('users')
+    .select('theme_id')
+    .eq('id', userId)
+    .single()
+
+  if (error) {
+    console.warn('Unable to load user theme', error)
+    return null
+  }
+
+  return data?.theme_id || null
+}
+
+function bestAvailableTheme(targetId) {
+  if (!themes.value.length) return null
+
+  const accessibleThemes = themes.value.filter((theme) => !isPremiumLocked(theme))
+
+  if (targetId) {
+    const matched = themes.value.find((theme) => theme.id === targetId)
+    if (matched && !isPremiumLocked(matched)) return matched
+  }
+
+  return accessibleThemes[0] || themes.value[0]
+}
+
+async function loadTheme() {
+  primeThemeFromCache()
+
+  if (!themes.value.length) {
+    await fetchThemes()
+  }
+
+  const { data } = await supabase.auth.getSession()
+  const sessionUserId = data.session?.user?.id
+  let desiredId = localStorage.getItem(THEME_ID_KEY)
+
+  if (sessionUserId) {
+    desiredId = await fetchUserThemeId(sessionUserId) || desiredId
+  }
+
+  const targetTheme = bestAvailableTheme(desiredId)
+  if (targetTheme) {
+    currentThemeId.value = targetTheme.id
+    applyCssVariables(targetTheme)
+    localStorage.setItem(THEME_ID_KEY, targetTheme.id)
+  }
+
+  return targetTheme
+}
+
+function planRank(value) {
+  const normalized = (value || 'free').toLowerCase()
+  const index = PLANS.indexOf(normalized)
+  return index === -1 ? 0 : index
+}
+
+function isPremiumLocked(theme) {
+  if (!theme) return false
+  return planRank(tier.value) < planRank(theme.plan_required)
+}
+
+async function setTheme(themeId) {
+  if (!themeId) return null
+  if (!themes.value.length) await fetchThemes()
+
+  const theme = themes.value.find((item) => item.id === themeId)
+  if (!theme) return null
+  if (isPremiumLocked(theme)) return null
+
+  currentThemeId.value = themeId
+  applyCssVariables(theme)
+  localStorage.setItem(THEME_ID_KEY, themeId)
+  cacheThemes(themes.value)
+
+  if (user.value?.id) {
+    const { error } = await supabase
+      .from('users')
+      .update({ theme_id: themeId })
+      .eq('id', user.value.id)
+
+    if (error) {
+      console.warn('Failed to persist theme preference', error)
+    }
+  }
+
+  return theme
+}
+
+function ensureAuthWatcher() {
+  if (authWatcherInitialized) return
+  authWatcherInitialized = true
+
+  watch(
+    () => user.value?.id,
+    (newId, oldId) => {
+      if (newId && newId !== oldId) {
+        void loadTheme()
+      }
+    }
+  )
+}
+
+export function useTheme() {
+  ensureAuthWatcher()
+
+  return {
+    themes: computed(() => themes.value),
+    currentTheme: computed(() => themes.value.find((theme) => theme.id === currentThemeId.value) || null),
+    loadTheme,
+    setTheme,
+    isPremiumLocked,
+  }
+}
+
+export { primeThemeFromCache }

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,13 @@ import PortalVue from 'portal-vue'
 import { createPinia } from 'pinia';
 import router from '@/utils/router.js'
 import '@/composables/useAuth.js' // Ensure auth is initialized before app mounts
+import { primeThemeFromCache, useTheme } from '@/composables/useTheme.js'
 import * as Sentry from "@sentry/vue";
+
+// Immediately hydrate theme variables to avoid flashes
+primeThemeFromCache()
+const { loadTheme } = useTheme()
+await loadTheme()
 
 const app = createApp(App);
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -134,6 +134,8 @@
         </form>
       </section>
 
+      <ThemeSelector />
+
       <section class="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Playback Preferences</h2>
@@ -226,6 +228,7 @@ import BaseButton from '@/components/ui/input/BaseButton.vue'
 import BaseInput from '@/components/ui/input/BaseInput.vue'
 import { useAuth } from '@/composables/useAuth'
 import { supabase } from '@/utils/supabase'
+import ThemeSelector from '@/components/Settings/ThemeSelector.vue'
 
 const router = useRouter()
 const route = useRoute()

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ const withAlpha = (variable) => `rgb(var(${variable}) / <alpha-value>)`
 
 module.exports = {
   important: true,
+  darkMode: 'class',
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- add a useTheme composable that loads Supabase theme variables, caches them locally, and persists user selections
- initialize themes before mounting to apply CSS variables and Tailwind dark class without flashes and add a navbar quick-toggle
- add a settings ThemeSelector UI for choosing available themes with plan-based locking

## Testing
- npm run build *(fails: missing @sentry/vite-plugin in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692383340f74832f85600b9f7496beea)