### PR TITLE
Add dynamic Supabase-driven theme system

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,11 +7,11 @@
     <div class="flex-1 min-h-0 flex flex-col">
       <div
         v-if="globalError"
-        class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-[var(--lm-bg-0)] text-[var(--lm-text-0)] dark:bg-black dark:text-white"
+        class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-[var(--sr-bg-0)] text-[var(--sr-text-0)] dark:bg-black dark:text-white"
       >
         <p class="text-sm uppercase tracking-[0.2em] text-rose-500 mb-3">Navigation error</p>
         <h2 class="text-2xl font-semibold mb-3">We couldn't load that page.</h2>
-        <p class="max-w-md text-[var(--lm-text-1)] dark:text-gray-400 mb-8">
+        <p class="max-w-md text-[var(--sr-text-1)] dark:text-gray-400 mb-8">
           {{ globalError.message }}
         </p>
         <div class="flex flex-wrap items-center justify-center gap-3">
@@ -37,10 +37,10 @@
             </ErrorBoundary>
           </template>
           <template #fallback>
-            <div class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-[var(--lm-bg-0)] text-[var(--lm-text-0)] dark:bg-black dark:text-white">
+            <div class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-[var(--sr-bg-0)] text-[var(--sr-text-0)] dark:bg-black dark:text-white">
               <p class="text-sm uppercase tracking-[0.2em] text-blue-500 mb-3">Loading</p>
               <h2 class="text-2xl font-semibold mb-3">Preparing SoundRoom…</h2>
-              <p class="max-w-md text-[var(--lm-text-1)] dark:text-gray-400">
+              <p class="max-w-md text-[var(--sr-text-1)] dark:text-gray-400">
                 Hang tight while we load the experience.
               </p>
             </div>

--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -26,7 +26,7 @@
       <BaseButton
         @click="showSaveConfirm = true"
         :disabled="isSaving || !isRoomSaveable"
-        class="px-3 py-2 rounded bg-[var(--lm-bg-1)] hover:bg-[var(--lm-bg-0)] text-[var(--lm-text-0)] border border-[var(--lm-border)] dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        class="px-3 py-2 rounded bg-[var(--sr-bg-1)] hover:bg-[var(--sr-bg-0)] text-[var(--sr-text-0)] border border-[var(--sr-border)] dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         type="button"
         aria-label="Open save room confirmation"
       >
@@ -36,7 +36,7 @@
       <BaseButton
         @click="showNewRoomConfirm = true"
         :disabled="isSaving || isRoomEmpty"
-        class="px-3 py-2 rounded bg-[var(--lm-bg-1)] hover:bg-[var(--lm-bg-0)] text-[var(--lm-text-0)] border border-[var(--lm-border)] dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        class="px-3 py-2 rounded bg-[var(--sr-bg-1)] hover:bg-[var(--sr-bg-0)] text-[var(--sr-text-0)] border border-[var(--sr-border)] dark:bg-neutral-800 dark:hover:bg-neutral-700 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         type="button"
         aria-label="Open new room confirmation"
       >

--- a/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
@@ -98,7 +98,7 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { computed, ref } from 'vue';
 import { useListenerStore } from '@/stores/useListenerStore';
 import { useActionManagerStore } from '@/stores/useActionManagerStore';
 import { useRoomStore } from '@/stores/useRoomStore';
@@ -109,8 +109,6 @@ const { listener } = storeToRefs(useListenerStore())
 const { actionManager } = storeToRefs(useActionManagerStore())
 const { room } = storeToRefs(useRoomStore())
 
-const prefersDark = window.matchMedia('(prefers-color-scheme: dark)')
-const isDarkMode = ref(prefersDark.matches)
 const rootStyles = computed(() => (typeof window !== 'undefined' ? getComputedStyle(document.documentElement) : null))
 const getVar = (name, fallback) => rootStyles.value?.getPropertyValue(name)?.trim() || fallback
 const rgbaFromVar = (name, alpha, fallback) => {
@@ -118,72 +116,39 @@ const rgbaFromVar = (name, alpha, fallback) => {
   return rgbValue ? `rgba(${rgbValue}, ${alpha})` : fallback
 }
 
-const syncTheme = (event) => {
-  isDarkMode.value = event.matches
-}
+const anchorGlowFill = computed(() => rgbaFromVar('--sr-primary-rgb', 0.12, 'rgba(46, 144, 250, 0.12)'))
+const anchorShadowColor = computed(() => rgbaFromVar('--sr-primary-rgb', 0.3, 'rgba(46, 144, 250, 0.3)'))
+const anchorShadowBlur = computed(() => parseFloat(getVar('--sr-node-shadow-blur', '12')) || 12)
+const anchorShadowOpacity = computed(() => parseFloat(getVar('--sr-node-shadow-opacity', '0.2')) || 0.2)
 
-onMounted(() => prefersDark.addEventListener('change', syncTheme))
-onBeforeUnmount(() => prefersDark.removeEventListener('change', syncTheme))
+const bodyFill = computed(() => rgbaFromVar('--sr-body-fill-rgb', 0.35, 'rgba(150, 165, 185, 0.35)'))
+const bodyStroke = computed(() => getVar('--sr-detail-stroke', '#2f3a4a'))
+const bodyShadowColor = computed(() => rgbaFromVar('--sr-black-rgb', 0.12, 'rgba(0, 0, 0, 0.12)'))
+const bodyShadowBlur = computed(() => parseFloat(getVar('--sr-node-shadow-blur', '8')) || 8)
+const bodyShadowOpacity = computed(() => parseFloat(getVar('--sr-node-shadow-opacity', '0.18')) || 0.18)
 
-const anchorGlowFill = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-500-rgb', 0.08, 'rgba(59, 130, 246, 0.08)')
-  : rgbaFromVar('--sr-black-rgb', 0.06, 'rgba(0, 0, 0, 0.06)'))
-const anchorShadowColor = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-500-rgb', 0.3, 'rgba(59, 130, 246, 0.3)')
-  : rgbaFromVar('--sr-black-rgb', 0.1, 'rgba(0, 0, 0, 0.1)'))
-const anchorShadowBlur = computed(() => isDarkMode.value ? 18 : 10)
-const anchorShadowOpacity = computed(() => isDarkMode.value ? 0.35 : 0.18)
+const detailFill = computed(() => rgbaFromVar('--sr-detail-fill-rgb', 0.85, 'rgba(70, 80, 95, 0.85)'))
+const detailStroke = computed(() => rgbaFromVar('--sr-outline-contrast-rgb', 0.85, 'rgba(17, 24, 39, 0.85)'))
 
-const bodyFill = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-500-rgb', 0.15, 'rgba(59, 130, 246, 0.15)')
-  : rgbaFromVar('--sr-body-fill-rgb', 0.35, 'rgba(150, 165, 185, 0.35)'))
-const bodyStroke = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-400-rgb', 0.9, 'rgba(96, 165, 250, 0.9)')
-  : getVar('--sr-detail-stroke', '#2f3a4a'))
-const bodyShadowColor = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-black-rgb', 0.2, 'rgba(0, 0, 0, 0.2)')
-  : rgbaFromVar('--sr-black-rgb', 0.08, 'rgba(0, 0, 0, 0.08)'))
-const bodyShadowBlur = computed(() => isDarkMode.value ? 10 : 8)
-const bodyShadowOpacity = computed(() => isDarkMode.value ? 0.55 : 0.18)
+const detailShadowColor = computed(() => rgbaFromVar('--sr-primary-rgb', 0.3, 'rgba(46, 144, 250, 0.3)'))
+const detailShadowBlur = computed(() => parseFloat(getVar('--sr-node-shadow-blur', '8')) || 8)
+const detailShadowOpacity = computed(() => parseFloat(getVar('--sr-selection-glow-opacity', '0.38')) || 0.38)
 
-const detailFill = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-outline-contrast-rgb', 0.9, 'rgba(15, 23, 42, 0.9)')
-  : rgbaFromVar('--sr-detail-fill-rgb', 0.85, 'rgba(70, 80, 95, 0.85)'))
-const detailStroke = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-100-rgb', 0.85, 'rgba(191, 219, 254, 0.85)')
-  : rgbaFromVar('--sr-body-stroke-rgb', 0.6, 'rgba(60, 70, 85, 0.6)'))
+const centerHighlightFill = computed(() => rgbaFromVar('--sr-white-rgb', 0.6, 'rgba(255, 255, 255, 0.6)'))
+const centerHighlightStroke = computed(() => rgbaFromVar('--sr-outline-contrast-rgb', 0.14, 'rgba(17, 24, 39, 0.14)'))
+const highlightShadowColor = computed(() => rgbaFromVar('--sr-primary-rgb', 0.22, 'rgba(46, 144, 250, 0.22)'))
+const highlightShadowOpacity = computed(() => parseFloat(getVar('--sr-selection-glow-opacity', '0.38')) || 0.38)
 
-const detailShadowColor = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-500-rgb', 0.35, 'rgba(59, 130, 246, 0.35)')
-  : rgbaFromVar('--sr-black-rgb', 0.08, 'rgba(0, 0, 0, 0.08)'))
-const detailShadowBlur = computed(() => isDarkMode.value ? 8 : 6)
-const detailShadowOpacity = computed(() => isDarkMode.value ? 0.45 : 0.2)
+const directionGradientStops = computed(() => [
+  0,
+  rgbaFromVar('--sr-detail-gradient-rgb', 0.2, 'rgba(140, 150, 165, 0.2)'),
+  1,
+  rgbaFromVar('--sr-body-stroke-rgb', 0.8, 'rgba(60, 70, 85, 0.8)')
+])
+const directionStroke = computed(() => getVar('--sr-outline-contrast', '#111827'))
+const directionShadowColor = computed(() => rgbaFromVar('--sr-black-rgb', 0.1, 'rgba(0, 0, 0, 0.1)'))
 
-const centerHighlightFill = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-white-rgb', 0.75, 'rgba(255, 255, 255, 0.75)')
-  : rgbaFromVar('--sr-white-rgb', 0.6, 'rgba(255, 255, 255, 0.6)'))
-const centerHighlightStroke = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-white-rgb', 0.2, 'rgba(255, 255, 255, 0.2)')
-  : rgbaFromVar('--sr-black-rgb', 0.08, 'rgba(0, 0, 0, 0.08)'))
-const highlightShadowColor = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-white-rgb', 0.35, 'rgba(255, 255, 255, 0.35)')
-  : rgbaFromVar('--sr-black-rgb', 0.06, 'rgba(0, 0, 0, 0.06)'))
-const highlightShadowOpacity = computed(() => isDarkMode.value ? 0.5 : 0.28)
-
-const directionGradientStops = computed(() => isDarkMode.value
-  ? [0, rgbaFromVar('--sr-blue-100-rgb', 0.18, 'rgba(191, 219, 254, 0.18)'), 1, rgbaFromVar('--sr-blue-500-rgb', 0.85, 'rgba(59, 130, 246, 0.85)')]
-  : [0, rgbaFromVar('--sr-detail-gradient-rgb', 0.2, 'rgba(140, 150, 165, 0.2)'), 1, rgbaFromVar('--sr-body-stroke-rgb', 0.8, 'rgba(60, 70, 85, 0.8)')]
-)
-const directionStroke = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-outline-contrast-rgb', 0.85, 'rgba(15, 23, 42, 0.85)')
-  : getVar('--sr-text-strong', '#222222'))
-const directionShadowColor = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-500-rgb', 0.35, 'rgba(59, 130, 246, 0.35)')
-  : rgbaFromVar('--sr-black-rgb', 0.1, 'rgba(0, 0, 0, 0.1)'))
-
-const rotationHandleFill = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-500-rgb', 0.1, 'rgba(59, 130, 246, 0.1)')
-  : rgbaFromVar('--sr-black-rgb', 0.06, 'rgba(0, 0, 0, 0.06)'))
+const rotationHandleFill = computed(() => rgbaFromVar('--sr-primary-rgb', 0.1, 'rgba(46, 144, 250, 0.1)'))
 
 let moveListenerPayload = null
 let initialMouseAngle = null

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -4,7 +4,7 @@
     role="application"
     tabindex="0"
     aria-label="SoundRoom 2D audio environment. Use keyboard or mouse to interact with sound nodes."
-    class="canvas-grid relative border border-[var(--lm-border)] dark:border-neutral-700 dark:border-2 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 shadow-[var(--lm-shadow)] dark:shadow-none"
+    class="canvas-grid relative border border-[var(--sr-border)] dark:border-neutral-700 dark:border-2 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 shadow-[var(--sr-shadow)] dark:shadow-none"
     :class="`w-[${room.width}px] h-[${room.height}px]`"
     @dragover.prevent
     @drop="handleDrop"
@@ -120,18 +120,9 @@ const soundNodeTitleCoords = computed(() => {
 /* Grid spacing and line opacity can be tuned here to adjust density/visibility */
 .canvas-grid {
   background-size: 40px 40px; /* Adjust spacing between grid lines */
-  background-color: var(--lm-bg-1);
+  background-color: var(--sr-bg-1);
   background-image:
-    linear-gradient(to right, var(--lm-grid-line) 1px, transparent 1px),
-    linear-gradient(to bottom, var(--lm-grid-line) 1px, transparent 1px); /* Adjust line opacity */
-}
-
-@media (prefers-color-scheme: dark) {
-  .canvas-grid {
-    background-color: transparent;
-    background-image:
-      linear-gradient(to right, rgba(var(--sr-white-rgb), 0.08) 2px, transparent 2px),
-      linear-gradient(to bottom, rgba(var(--sr-white-rgb), 0.08) 2px, transparent 2px); /* Adjust dark mode opacity separately */
-  }
+    linear-gradient(to right, var(--sr-grid-line) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--sr-grid-line) 1px, transparent 1px); /* Adjust line opacity */
 }
 </style>

--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -115,7 +115,7 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useRoomStore } from '@/stores/useRoomStore'
 import { useActionManagerStore } from '@/stores/useActionManagerStore'
 import { storeToRefs } from 'pinia'
@@ -132,8 +132,6 @@ const { room } = storeToRefs(useRoomStore())
 const { actionManager } = storeToRefs(useActionManagerStore())
 const emit = defineEmits(['select'])
 
-const prefersDark = window.matchMedia('(prefers-color-scheme: dark)')
-const isDarkMode = ref(prefersDark.matches)
 const rootStyles = computed(() => (typeof window !== 'undefined' ? getComputedStyle(document.documentElement) : null))
 const getVar = (name, fallback) => rootStyles.value?.getPropertyValue(name)?.trim() || fallback
 const rgbaFromVar = (name, alpha, fallback) => {
@@ -141,96 +139,63 @@ const rgbaFromVar = (name, alpha, fallback) => {
   return rgbValue ? `rgba(${rgbValue}, ${alpha})` : fallback
 }
 
-const syncTheme = (event) => {
-  isDarkMode.value = event.matches
-}
-
-onMounted(() => prefersDark.addEventListener('change', syncTheme))
-onBeforeUnmount(() => prefersDark.removeEventListener('change', syncTheme))
-
 const sched = computed(() => props.source.instance.state.schedule)
 const isScheduled = computed(() => sched.value?.enabled)
 const isScheduledPlaying = computed(() => sched.value?.isPlaying)
 const sourceIsPlaying = computed(() => props.source.instance.playing);
 
-const lightPalette = computed(() => ({
-  bg2: getVar('--lm-bg-2', '#dcdcdc'),
-  nodeRed: getVar('--lm-node-red', '#d45a5a'),
-  nodeBlue: getVar('--lm-node-blue', '#6c8edb'),
-  coneRed: getVar('--lm-cone-red', 'rgba(212, 90, 90, 0.1)'),
-  coneBlue: getVar('--lm-cone-blue', 'rgba(108, 142, 219, 0.12)'),
-}))
-
-const themeTokens = computed(() => ({
+const palette = computed(() => ({
+  surface: getVar('--sr-bg-2', '#dcdcdc'),
+  nodeRed: getVar('--sr-node-red', '#d45a5a'),
+  nodeBlue: getVar('--sr-node-blue', '#6c8edb'),
+  coneRed: getVar('--sr-cone-red', 'rgba(212, 90, 90, 0.1)'),
+  coneBlue: getVar('--sr-cone-blue', 'rgba(108, 142, 219, 0.12)'),
   primary: getVar('--sr-primary', '#2e90fa'),
-  danger: getVar('--sr-accent-danger', '#f44336'),
-  selected: getVar('--sr-accent-yellow', '#ffff00'),
-  selectionHighlight: getVar('--sr-highlight-blue', '#6fd7ff'),
-  mutedStroke: getVar('--sr-surface-muted', '#333333'),
+  danger: getVar('--sr-danger', '#f44336'),
+  selectionHighlight: getVar('--sr-selection-glow', '#6fd7ff'),
+  outline: getVar('--sr-outline-contrast', '#111827'),
   white: getVar('--sr-white', '#ffffff'),
 }))
 
 const getFillColor = computed(() => {
-  if (isDarkMode.value) {
-    if (props.selected) return themeTokens.value.selected
-    return isScheduled.value ? themeTokens.value.primary : themeTokens.value.danger
-  }
-  const colors = lightPalette.value
-  if (props.selected) return colors.bg2
-  return isScheduled.value ? colors.nodeBlue : colors.nodeRed
+  if (props.selected) return palette.value.surface
+  return isScheduled.value ? palette.value.nodeBlue : palette.value.nodeRed
 })
 
-const dotStrokeColor = computed(() => {
-  if (isDarkMode.value) return props.selected ? themeTokens.value.white : rgbaFromVar('--sr-white-rgb', 0.9, 'rgba(255, 255, 255, 0.9)')
-  return themeTokens.value.mutedStroke
-})
-const selectionGlowColor = computed(() => (isDarkMode.value
-  ? themeTokens.value.selectionHighlight
-  : rgbaFromVar('--sr-black-rgb', 0.05, 'rgba(0, 0, 0, 0.05)')))
+const dotStrokeColor = computed(() => (props.selected
+  ? palette.value.white
+  : palette.value.outline))
+const selectionGlowColor = computed(() => palette.value.selectionHighlight)
 const selectedScale = computed(() => (props.selected ? 1.05 : 1))
 
-const outerConeFill = computed(() => {
-  if (isDarkMode.value) return rgbaFromVar('--sr-dark-warm-red-rgb', 0.16, 'rgba(255, 137, 137, 0.16)')
-  const colors = lightPalette.value
-  return isScheduled.value ? colors.coneBlue : colors.coneRed
-})
-const outerConeStroke = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-dark-warm-red-rgb', 0.28, 'rgba(255, 137, 137, 0.28)')
-  : (isScheduled.value
-    ? rgbaFromVar('--sr-node-blue-rgb', 0.24, 'rgba(108, 142, 219, 0.24)')
-    : rgbaFromVar('--sr-node-red-rgb', 0.2, 'rgba(212, 90, 90, 0.2)')))
-const outerConeShadowColor = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-dark-bright-red-rgb', 0.65, 'rgba(255, 120, 120, 0.65)')
-  : rgbaFromVar('--sr-black-rgb', 0.12, 'rgba(0, 0, 0, 0.12)'))
-const outerConeShadowBlur = computed(() => isDarkMode.value ? 18 : 10)
+const outerConeFill = computed(() => (isScheduled.value ? palette.value.coneBlue : palette.value.coneRed))
+const outerConeStroke = computed(() => (isScheduled.value
+  ? rgbaFromVar('--sr-node-blue-rgb', 0.24, 'rgba(108, 142, 219, 0.24)')
+  : rgbaFromVar('--sr-node-red-rgb', 0.2, 'rgba(212, 90, 90, 0.2)')))
+const outerConeShadowColor = computed(() => (isScheduled.value
+  ? rgbaFromVar('--sr-node-blue-rgb', 0.45, 'rgba(108, 142, 219, 0.45)')
+  : rgbaFromVar('--sr-node-red-rgb', 0.45, 'rgba(212, 90, 90, 0.45)')))
+const outerConeShadowBlur = computed(() => parseFloat(getVar('--sr-node-shadow-blur', '10')) || 10)
 
-const innerConeFill = computed(() => {
-  if (isDarkMode.value) return rgbaFromVar('--sr-dark-soft-red-rgb', 0.18, 'rgba(255, 180, 180, 0.18)')
-  const colors = lightPalette.value
-  return isScheduled.value
-    ? rgbaFromVar('--sr-node-blue-rgb', 0.18, 'rgba(108, 142, 219, 0.18)')
-    : rgbaFromVar('--sr-node-red-rgb', 0.16, 'rgba(212, 90, 90, 0.16)')
-})
-const innerConeStroke = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-dark-soft-red-rgb', 0.35, 'rgba(255, 180, 180, 0.35)')
-  : rgbaFromVar('--sr-black-rgb', 0.18, 'rgba(0, 0, 0, 0.18)'))
+const innerConeFill = computed(() => (isScheduled.value
+  ? rgbaFromVar('--sr-node-blue-rgb', 0.18, 'rgba(108, 142, 219, 0.18)')
+  : rgbaFromVar('--sr-node-red-rgb', 0.16, 'rgba(212, 90, 90, 0.16)')))
+const innerConeStroke = computed(() => rgbaFromVar('--sr-outline-contrast-rgb', 0.18, 'rgba(17, 24, 39, 0.18)'))
 
-const selectionGlowOpacity = computed(() => isDarkMode.value ? 0.75 : 0.22)
-const selectionGlowBlur = computed(() => isDarkMode.value ? 14 : 8)
+const selectionGlowOpacity = computed(() => parseFloat(getVar('--sr-selection-glow-opacity', '0.38')) || 0.38)
+const selectionGlowBlur = computed(() => parseFloat(getVar('--sr-selection-glow-blur', '10')) || 10)
 
-const nodeShadowBlur = computed(() => isDarkMode.value ? 10 : 6)
-const nodeShadowOpacity = computed(() => isDarkMode.value ? 0.65 : 0.08)
+const nodeShadowBlur = computed(() => parseFloat(getVar('--sr-node-shadow-blur', '8')) || 8)
+const nodeShadowOpacity = computed(() => parseFloat(getVar('--sr-node-shadow-opacity', '0.18')) || 0.18)
 
-const directionGradientStops = computed(() => isDarkMode.value
-  ? [0, rgbaFromVar('--sr-white-rgb', 0.95, 'rgba(255,255,255,0.95)'), 1, rgbaFromVar('--sr-white-rgb', 0.65, 'rgba(255,255,255,0.65)')]
-  : [0, rgbaFromVar('--sr-white-rgb', 0.7, 'rgba(255,255,255,0.7)'), 1, rgbaFromVar('--sr-black-rgb', 0.12, 'rgba(0,0,0,0.12)')]
-)
-const directionStroke = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-black-rgb', 0.6, 'rgba(0, 0, 0, 0.6)')
-  : themeTokens.value.mutedStroke)
-const directionShadowColor = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-black-rgb', 0.35, 'rgba(0,0,0,0.35)')
-  : rgbaFromVar('--sr-black-rgb', 0.12, 'rgba(0,0,0,0.12)'))
+const directionGradientStops = computed(() => [
+  0,
+  rgbaFromVar('--sr-white-rgb', 0.7, 'rgba(255,255,255,0.7)'),
+  1,
+  rgbaFromVar('--sr-black-rgb', 0.12, 'rgba(0,0,0,0.12)')
+])
+const directionStroke = computed(() => palette.value.outline)
+const directionShadowColor = computed(() => rgbaFromVar('--sr-black-rgb', 0.12, 'rgba(0,0,0,0.12)'))
 
 
 

--- a/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
@@ -2,11 +2,11 @@
   <section class="flex flex-col h-full">
   <ContextMenu ref="menuRef" :functionList="[{ label: 'Delete', function: deleteSound }]" />
 
-  <h5 class="text-sm font-semibold uppercase text-[var(--lm-text-1)] dark:text-neutral-400">
+  <h5 class="text-sm font-semibold uppercase text-[var(--sr-text-1)] dark:text-neutral-400">
     Sound Sources
   </h5>
 
-  <ul class="overflow-y-auto space-y-2 text-sm text-[var(--lm-text-1)]"
+  <ul class="overflow-y-auto space-y-2 text-sm text-[var(--sr-text-1)]"
   :class="{ 'flex-1 mt-4': soundLibrarySources.length > 0 }">
     <LibrarySource 
       v-for="s in soundLibrarySources"
@@ -20,7 +20,7 @@
   <button
     :disabled="soundLibrarySources.length == MAX_SOURCES"
     @click="() => { router.push('/sound-library') }"
-    class="w-full mt-4 bg-[var(--lm-bg-1)] dark:bg-neutral-800 text-xs rounded hover:bg-[var(--lm-bg-0)] dark:hover:bg-neutral-700 border border-[var(--lm-border)] dark:border-neutral-700 text-[var(--lm-text-0)]"
+    class="w-full mt-4 bg-[var(--sr-bg-1)] dark:bg-neutral-800 text-xs rounded hover:bg-[var(--sr-bg-0)] dark:hover:bg-neutral-700 border border-[var(--sr-border)] dark:border-neutral-700 text-[var(--sr-text-0)]"
   >
     + Add Source
   </button>

--- a/src/components/SoundRoom/SidebarLeft/ListenerReadout.vue
+++ b/src/components/SoundRoom/SidebarLeft/ListenerReadout.vue
@@ -1,6 +1,6 @@
 <template>
-  <section class="text-[var(--lm-text-1)]">
-    <h5 class="text-sm font-semibold uppercase text-[var(--lm-text-1)] dark:text-neutral-400 mb-2">Listener</h5>
+  <section class="text-[var(--sr-text-1)]">
+    <h5 class="text-sm font-semibold uppercase text-[var(--sr-text-1)] dark:text-neutral-400 mb-2">Listener</h5>
     <div class="text-xs space-y-1">
       <p>X: {{ store.listener.x }}</p>
       <p>Y: {{ store.listener.y }}</p>

--- a/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
+++ b/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-[var(--lm-bg-2)] dark:bg-neutral-900 border-r border-[var(--lm-border)] dark:border-neutral-800 p-4 space-y-6"
+  class="flex flex-col h-full bg-[var(--sr-bg-2)] dark:bg-neutral-900 border-r border-[var(--sr-border)] dark:border-neutral-800 p-4 space-y-6"
     role="region"
     aria-labelledby="library-panel-label"
   >

--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -1,12 +1,12 @@
 <template>
-  <section class="text-[var(--lm-text-0)]">
-    <h5 class="text-sm font-semibold uppercase text-[var(--lm-text-1)] dark:text-neutral-400 mb-2">
+  <section class="text-[var(--sr-text-0)]">
+    <h5 class="text-sm font-semibold uppercase text-[var(--sr-text-1)] dark:text-neutral-400 mb-2">
       Selected Source
     </h5>
 
     <div v-if="selectedSource" class="space-y-6 flex flex-col items-center">
       <!-- Readouts -->
-      <div class="space-y-1 text-xs text-[var(--lm-text-1)]">
+      <div class="space-y-1 text-xs text-[var(--sr-text-1)]">
         <h4>{{ selectedSource.name }}</h4>
         <p>X: {{ cleanSourceXY.x }}</p>
         <p>Y: {{ cleanSourceXY.y }}</p>
@@ -33,22 +33,22 @@
       <div class="w-full space-y-2">
         <button
           @click="playPauseSource"
-          class="w-full bg-[var(--lm-bg-1)] dark:bg-red-600 text-xs rounded hover:bg-[var(--lm-bg-0)] dark:hover:bg-red-500 border border-[var(--lm-border)] dark:border-red-700 text-[var(--lm-text-0)] dark:text-white"
+          class="w-full bg-[var(--sr-bg-1)] dark:bg-red-600 text-xs rounded hover:bg-[var(--sr-bg-0)] dark:hover:bg-red-500 border border-[var(--sr-border)] dark:border-red-700 text-[var(--sr-text-0)] dark:text-white"
         >
           {{ playPauseLabel }}
         </button>
         <button
           @click="deleteSource"
-          class="w-full bg-[var(--lm-bg-1)] dark:bg-red-600 text-xs rounded hover:bg-[var(--lm-bg-0)] dark:hover:bg-red-500 border border-[var(--lm-border)] dark:border-red-700 text-[var(--lm-text-0)] dark:text-white"
+          class="w-full bg-[var(--sr-bg-1)] dark:bg-red-600 text-xs rounded hover:bg-[var(--sr-bg-0)] dark:hover:bg-red-500 border border-[var(--sr-border)] dark:border-red-700 text-[var(--sr-text-0)] dark:text-white"
         >
           Delete
         </button>
       </div>
 
-      <hr class="w-full border-[var(--lm-border)] dark:border-neutral-700" />
+      <hr class="w-full border-[var(--sr-border)] dark:border-neutral-700" />
 
       <!-- Scheduling Toggle -->
-      <div class="w-full flex items-center space-x-2 text-left px-1 text-[var(--lm-text-1)]">
+      <div class="w-full flex items-center space-x-2 text-left px-1 text-[var(--sr-text-1)]">
         <input
           type="checkbox"
           :checked="schedulingEnabled"
@@ -68,7 +68,7 @@
       <!-- Scheduling Settings -->
       <div
         v-if="schedulingEnabled && canUseTimedLoops"
-        class="space-y-4 w-full text-xs text-[var(--lm-text-1)] dark:text-neutral-300 px-1"
+        class="space-y-4 w-full text-xs text-[var(--sr-text-1)] dark:text-neutral-300 px-1"
       >
         <!-- Mode -->
         <div class="flex flex-col space-y-1">
@@ -77,7 +77,7 @@
             :value="schedule.mode"
             @change="handleScheduleModeChange"
             @blur="commitScheduleEdit"
-            class="px-2 py-1 rounded border border-[var(--lm-border)] dark:bg-neutral-800 dark:border-neutral-700">
+            class="px-2 py-1 rounded border border-[var(--sr-border)] dark:bg-neutral-800 dark:border-neutral-700">
             <option value="interval">Interval</option>
             <option v-if="canUseAdvancedScheduling" value="count">Count</option>
             <option v-if="canUseAdvancedScheduling" value="interval+count">Interval + Count</option>
@@ -99,7 +99,7 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border border-[var(--lm-border)] dark:bg-neutral-800 dark:border-neutral-700"
+              class="px-2 py-1 rounded border border-[var(--sr-border)] dark:bg-neutral-800 dark:border-neutral-700"
             />
           </div>
           <div class="flex flex-col space-y-1">
@@ -116,7 +116,7 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border border-[var(--lm-border)] dark:bg-neutral-800 dark:border-neutral-700"
+              class="px-2 py-1 rounded border border-[var(--sr-border)] dark:bg-neutral-800 dark:border-neutral-700"
             />
             <p v-if="schedule.gapMax < schedule.gapMin" class="text-red-500 text-xs">
               Gap Max cannot be smaller than Gap Min
@@ -140,7 +140,7 @@
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
               placeholder="Unlimited"
-              class="px-2 py-1 rounded border border-[var(--lm-border)] dark:bg-neutral-800 dark:border-neutral-700"
+              class="px-2 py-1 rounded border border-[var(--sr-border)] dark:bg-neutral-800 dark:border-neutral-700"
             />
           </div>
           <div class="flex flex-col space-y-1">
@@ -156,7 +156,7 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border border-[var(--lm-border)] dark:bg-neutral-800 dark:border-neutral-700"
+              class="px-2 py-1 rounded border border-[var(--sr-border)] dark:bg-neutral-800 dark:border-neutral-700"
             />
           </div>
           <div class="flex flex-col space-y-1">
@@ -171,7 +171,7 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border border-[var(--lm-border)] dark:bg-neutral-800 dark:border-neutral-700"
+              class="px-2 py-1 rounded border border-[var(--sr-border)] dark:bg-neutral-800 dark:border-neutral-700"
             />
           </div>
         </div>

--- a/src/components/SoundRoom/SidebarRight/SidebarRight.vue
+++ b/src/components/SoundRoom/SidebarRight/SidebarRight.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-[var(--lm-bg-2)] dark:bg-neutral-900 border-l border-[var(--lm-border)] dark:border-neutral-800 p-4 space-y-4"
+  class="flex flex-col h-full bg-[var(--sr-bg-2)] dark:bg-neutral-900 border-l border-[var(--sr-border)] dark:border-neutral-800 p-4 space-y-4"
     role="region"
     aria-labelledby="selected-sound-panel-label"
   >

--- a/src/components/SoundRoom/Toolbar.vue
+++ b/src/components/SoundRoom/Toolbar.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="flex items-center justify-between p-3 border-[var(--lm-border)] dark:border-neutral-800 bg-[var(--lm-bg-2)] dark:bg-neutral-900 space-x-10 w-full shadow-[var(--lm-shadow)] dark:shadow-none">
+  <div class="flex items-center justify-between p-3 border-[var(--sr-border)] dark:border-neutral-800 bg-[var(--sr-bg-2)] dark:bg-neutral-900 space-x-10 w-full shadow-[var(--sr-shadow)] dark:shadow-none">
           
     <div class="flex space-x-2 w-1/3">
       <BaseButton
       :disabled="audioEngine.soundSources.value.length === 0"
       @click="isPlaying ? audioEngine.pauseAll() : audioEngine.playAll()"
-      class="px-3 py-1 rounded text-sm bg-[var(--lm-bg-1)] hover:bg-[var(--lm-bg-2)] text-[var(--lm-text-0)] dark:bg-neutral-800 dark:hover:bg-neutral-700"
+      class="px-3 py-1 rounded text-sm bg-[var(--sr-bg-1)] hover:bg-[var(--sr-bg-2)] text-[var(--sr-text-0)] dark:bg-neutral-800 dark:hover:bg-neutral-700"
       > 
         
         <component :is="isPlaying ? Pause : Play" class="h-4 w-4 fill-black dark:fill-white" />
@@ -13,14 +13,14 @@
       <BaseButton
         :disabled="actionStackEmpty || waiting"
         @click="actionManager.undoLastAction"
-        class="px-3 py-1 rounded text-sm bg-[var(--lm-bg-1)] hover:bg-[var(--lm-bg-2)] text-[var(--lm-text-0)] dark:bg-neutral-800 dark:hover:bg-neutral-700"
+        class="px-3 py-1 rounded text-sm bg-[var(--sr-bg-1)] hover:bg-[var(--sr-bg-2)] text-[var(--sr-text-0)] dark:bg-neutral-800 dark:hover:bg-neutral-700"
       >
         <UndoRedo class="h-4 w-4 fill-black dark:fill-white"/>
       </BaseButton>
       <BaseButton
         :disabled="redoStackEmpty || waiting"
         @click="actionManager.redoLastAction"
-        class="px-3 py-1 rounded text-sm bg-[var(--lm-bg-1)] hover:bg-[var(--lm-bg-2)] text-[var(--lm-text-0)] dark:bg-neutral-800 dark:hover:bg-neutral-700"
+        class="px-3 py-1 rounded text-sm bg-[var(--sr-bg-1)] hover:bg-[var(--sr-bg-2)] text-[var(--sr-text-0)] dark:bg-neutral-800 dark:hover:bg-neutral-700"
       >
         <UndoRedo class="h-4 w-4 scale-x-[-1] fill-black dark:fill-white"/>
       </BaseButton>
@@ -34,7 +34,7 @@
     />
     <div class="flex items-center justify-center space-x-2 w-1/3">
      
-      <span class="text-xs text-[var(--lm-text-1)]">Master</span>
+      <span class="text-xs text-[var(--sr-text-1)]">Master</span>
       <VueSlider 
         v-model="audioEngine.masterVolume.value"
         :min="0" 

--- a/src/components/ui/ThemeSelector.vue
+++ b/src/components/ui/ThemeSelector.vue
@@ -1,0 +1,87 @@
+<template>
+  <section class="rounded-2xl border border-[var(--sr-border)] bg-[var(--sr-bg-1)] shadow-[var(--sr-shadow)] text-left p-4 space-y-4">
+    <div class="flex items-center justify-between gap-3">
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-wide text-[var(--sr-text-1)]">Themes</p>
+        <h3 class="text-lg font-semibold text-[var(--sr-text-0)]">Choose your vibe</h3>
+        <p class="text-sm text-[var(--sr-text-1)]">Themes update instantly and persist to your account.</p>
+      </div>
+      <div v-if="loading" class="text-xs text-[var(--sr-text-1)]">Loading…</div>
+    </div>
+
+    <p v-if="error" class="text-sm text-red-600">{{ error }}</p>
+
+    <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      <button
+        v-for="theme in sortedThemes"
+        :key="theme.id"
+        type="button"
+        class="flex flex-col items-start gap-2 rounded-xl border w-full text-left p-3 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--sr-focus)]"
+        :class="[
+          theme.id === activeId ? 'border-[var(--sr-primary)] shadow-[var(--sr-shadow)]' : 'border-[var(--sr-border)]',
+          isPremiumLocked(theme) ? 'opacity-60 cursor-not-allowed' : 'hover:border-[var(--sr-primary)]'
+        ]"
+        @click="handleSelect(theme)"
+      >
+        <div class="flex items-center justify-between w-full">
+          <div class="flex items-center gap-2">
+            <span class="inline-flex h-3 w-3 rounded-full" :style="previewStyle(theme)"></span>
+            <span class="text-sm font-semibold text-[var(--sr-text-0)]">{{ theme.name || 'Untitled theme' }}</span>
+          </div>
+          <span v-if="theme.id === activeId" class="text-xs text-[var(--sr-primary)] font-medium">Active</span>
+        </div>
+        <p class="text-xs text-[var(--sr-text-1)] leading-snug">{{ theme.description || 'Custom theme' }}</p>
+        <div v-if="isPremiumLocked(theme)" class="text-xs text-amber-600 flex items-center gap-1">
+          <span aria-hidden="true">🔒</span>
+          <span>Premium required</span>
+        </div>
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useTheme } from '@/composables/useTheme'
+
+const { themes, currentTheme, fetchThemes, setTheme, isPremiumLocked } = useTheme()
+const loading = ref(false)
+const error = ref('')
+
+const sortedThemes = computed(() => themes.value || [])
+const activeId = computed(() => currentTheme.value?.id)
+
+const previewStyle = (theme) => ({
+  background: theme?.css_vars?.sr_bg_1 || theme?.css_vars?.sr_bg_0 || 'var(--sr-primary)'
+})
+
+async function handleSelect(theme) {
+  if (!theme) return
+  if (isPremiumLocked(theme)) {
+    error.value = 'This theme is locked. Upgrade to unlock premium themes.'
+    return
+  }
+  error.value = ''
+  loading.value = true
+  try {
+    await setTheme(theme.id)
+  } catch (err) {
+    console.error('Unable to apply theme', err)
+    error.value = 'Unable to apply theme right now.'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(async () => {
+  loading.value = true
+  try {
+    await fetchThemes()
+  } catch (err) {
+    console.error('Theme fetch failed', err)
+    error.value = 'Unable to load themes from Supabase.'
+  } finally {
+    loading.value = false
+  }
+})
+</script>

--- a/src/components/ui/modals/EntitlementUpsellModal.vue
+++ b/src/components/ui/modals/EntitlementUpsellModal.vue
@@ -57,11 +57,9 @@ function handleUpgrade() {
   box-shadow: 0 20px 45px rgba(var(--sr-outline-contrast-rgb), 0.15);
 }
 
-@media (prefers-color-scheme: dark) {
-  .modal-panel {
-    background-color: var(--sr-dark-plain);
-    color: var(--sr-slate-200);
-    box-shadow: 0 20px 45px rgba(var(--sr-black-rgb), 0.6);
-  }
+:global(.dark) .modal-panel {
+  background-color: var(--sr-dark-plain);
+  color: var(--sr-slate-200);
+  box-shadow: 0 20px 45px rgba(var(--sr-black-rgb), 0.6);
 }
 </style>

--- a/src/components/ui/modals/RoomManager/RoomManager.vue
+++ b/src/components/ui/modals/RoomManager/RoomManager.vue
@@ -228,10 +228,8 @@ const createNewRoom = () => {
   margin-left: 20px;
 }
 
-@media (prefers-color-scheme: light) {
-  .load-button {
-    background-color: var(--sr-white);
-  }
+.load-button {
+  background-color: var(--sr-bg-1);
 }
 
 /* Base button styling */
@@ -250,10 +248,8 @@ const createNewRoom = () => {
   background-color: var(--sr-neutral-200);
 }
 
-@media (prefers-color-scheme: dark) {
-  .sound-manager-button:hover {
-    background-color: var(--sr-outline-strong);
-  }
+:global(.dark) .sound-manager-button:hover {
+  background-color: var(--sr-outline-strong);
 }
 
 /* Active/selected state */
@@ -262,9 +258,7 @@ const createNewRoom = () => {
   background-color: var(--sr-neutral-300);
 }
 
-@media (prefers-color-scheme: dark) {
-  .sound-manager-button.active {
-    background-color: var(--sr-outline-strong);
-  }
+:global(.dark) .sound-manager-button.active {
+  background-color: var(--sr-outline-strong);
 }
 </style>

--- a/src/components/ui/modals/SoundLibrary/CategoryList.vue
+++ b/src/components/ui/modals/SoundLibrary/CategoryList.vue
@@ -62,16 +62,12 @@ function handleSelectYourSounds() {
   transition: background-color 0.2s;
 }
 .sound-lib-button:hover { background-color: var(--sr-neutral-200); }
-@media (prefers-color-scheme: dark) {
-  .sound-lib-button:hover { background-color: var(--sr-outline-strong); }
-}
+:global(.dark) .sound-lib-button:hover { background-color: var(--sr-outline-strong); }
 .sound-lib-button.active {
   font-weight: 600;
   background-color: var(--sr-neutral-300);
 }
-@media (prefers-color-scheme: dark) {
-  .sound-lib-button.active { background-color: var(--sr-outline-strong); }
-}
+:global(.dark) .sound-lib-button.active { background-color: var(--sr-outline-strong); }
 
 .sound-lib-button.locked {
   opacity: 0.75;
@@ -90,10 +86,7 @@ function handleSelectYourSounds() {
   text-transform: uppercase;
   color: var(--sr-purple-600);
 }
-
-@media (prefers-color-scheme: dark) {
-  .badge {
-    color: var(--sr-purple-500);
-  }
+:global(.dark) .badge {
+  color: var(--sr-purple-500);
 }
 </style>

--- a/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
@@ -237,10 +237,8 @@ async function listUserSounds() {
   margin-left: 20px;
 }
 
-@media (prefers-color-scheme: light) {
-  .load-button {
-    background-color: var(--sr-white);
-  }
+.load-button {
+  background-color: var(--sr-bg-1);
 }
 
 </style>

--- a/src/components/ui/overlays/PulsingOverlay.vue
+++ b/src/components/ui/overlays/PulsingOverlay.vue
@@ -2,10 +2,10 @@
   <transition name="fade" @after-leave="emit('done')">
     <div
       v-if="visible"
-      class="absolute inset-0 flex items-center justify-center backdrop-blur-sm bg-[color-mix(in_srgb,var(--lm-bg-1)_70%,transparent)] dark:bg-black/40 z-50"
+      class="absolute inset-0 flex items-center justify-center backdrop-blur-sm bg-[color-mix(in_srgb,var(--sr-bg-1)_70%,transparent)] dark:bg-black/40 z-50"
     >
       <div
-        class="text-xl font-medium tracking-wide text-[var(--lm-text-0)] dark:text-white animate-pulse"
+        class="text-xl font-medium tracking-wide text-[var(--sr-text-0)] dark:text-white animate-pulse"
       >
         {{ text }}
       </div>

--- a/src/components/ui/overlays/WelcomeOverlay.vue
+++ b/src/components/ui/overlays/WelcomeOverlay.vue
@@ -2,7 +2,7 @@
   <transition name="fade">
     <div
       v-if="visible"
-      class="absolute inset-0 z-50 flex items-center justify-center backdrop-blur-md bg-[color-mix(in_srgb,var(--lm-bg-1)_70%,transparent)] dark:bg-black/50"
+      class="absolute inset-0 z-50 flex items-center justify-center backdrop-blur-md bg-[color-mix(in_srgb,var(--sr-bg-1)_70%,transparent)] dark:bg-black/50"
     >
       <div class="text-center space-y-4">
         <h1
@@ -12,7 +12,7 @@
         </h1>
         <p
           v-if="subtext"
-          class="text-lg text-[var(--lm-text-1)] dark:text-neutral-300 opacity-80"
+          class="text-lg text-[var(--sr-text-1)] dark:text-neutral-300 opacity-80"
         >
           {{ subtext }}
         </p>

--- a/src/components/ui/text/SoundSourceLabel.vue
+++ b/src/components/ui/text/SoundSourceLabel.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="absolute pointer-events-none w-20 overflow-hidden text-xs text-[var(--lm-text-1)] dark:text-neutral-300"
+    class="absolute pointer-events-none w-20 overflow-hidden text-xs text-[var(--sr-text-1)] dark:text-neutral-300"
     :style="{
       top: `${y}px`,
       left: `${x}px`,

--- a/src/composables/useTheme.js
+++ b/src/composables/useTheme.js
@@ -1,0 +1,219 @@
+import { readonly, ref } from 'vue'
+import { supabase } from '@/utils/supabase'
+import { useAuth } from './useAuth'
+
+const THEME_CACHE_KEY = 'soundroom_theme_id'
+
+const BASE_CSS_VARS = {
+  sr_bg_0: '#f5f5f5',
+  sr_bg_1: '#ebebeb',
+  sr_bg_2: '#dcdcdc',
+  sr_white: '#ffffff',
+  sr_white_rgb: '255, 255, 255',
+  sr_black: '#000000',
+  sr_black_rgb: '0, 0, 0',
+  sr_text_0: '#222222',
+  sr_text_1: '#555555',
+  sr_surface_muted: '#333333',
+  sr_border: '#c8c8c8',
+  sr_grid_line: 'rgba(0, 0, 0, 0.08)',
+  sr_shadow: '0 4px 10px rgba(0, 0, 0, 0.12)',
+  sr_primary: '#2e90fa',
+  sr_primary_rgb: '46, 144, 250',
+  sr_danger: '#f44336',
+  sr_danger_rgb: '244, 67, 54',
+  sr_highlight: '#ffff00',
+  sr_selection_glow: '#6fd7ff',
+  sr_node_red: '#d45a5a',
+  sr_node_red_rgb: '212, 90, 90',
+  sr_node_blue: '#6c8edb',
+  sr_node_blue_rgb: '108, 142, 219',
+  sr_cone_red: 'rgba(212, 90, 90, 0.1)',
+  sr_cone_blue: 'rgba(108, 142, 219, 0.12)',
+  sr_detail_stroke: '#2f3a4a',
+  sr_detail_fill_rgb: '70, 80, 95',
+  sr_detail_gradient_rgb: '140, 150, 165',
+  sr_body_fill_rgb: '150, 165, 185',
+  sr_body_stroke_rgb: '60, 70, 85',
+  sr_detail_fill: 'rgba(70, 80, 95, 0.85)',
+  sr_outline_contrast: '#111827',
+  sr_outline_contrast_rgb: '17, 24, 39',
+  sr_focus: '#4a90e2',
+  sr_focus_rgb: '74, 144, 226',
+  sr_panel: '#f8f8f8',
+  sr_input_bg: '#dcdcdc',
+  sr_disabled_bg: '#dcdcdc',
+  sr_disabled_text: '#555555',
+  sr_vignette_inner: 'rgba(0, 0, 0, 0.06)',
+  sr_vignette_middle: 'rgba(0, 0, 0, 0.04)',
+  sr_vignette_outer: 'rgba(0, 0, 0, 0.08)',
+  sr_vignette_shadow: 'inset 0 0 70px rgba(0, 0, 0, 0.12)',
+  sr_panel_border: 'rgba(200, 200, 200, 0.75)',
+  sr_icon_muted: '#6b7280',
+  sr_palette_blue_500: '#3b82f6',
+  sr_palette_green_500: '#22c55e',
+  sr_palette_red_500: '#ef4444',
+  sr_palette_amber_500: '#f59e0b',
+  sr_palette_violet_500: '#8b5cf6'
+}
+
+const BASE_THEME = {
+  id: 'base-default',
+  name: 'Default',
+  is_dark_mode: false,
+  css_vars: BASE_CSS_VARS
+}
+
+const themes = ref([BASE_THEME])
+const currentTheme = ref(BASE_THEME)
+const isLoadingThemes = ref(false)
+
+function toCssName(key) {
+  return `--${key.replace(/_/g, '-')}`
+}
+
+function hexToRgb(value) {
+  if (typeof value !== 'string') return null
+  const hex = value.trim().replace('#', '')
+  if (![3, 6].includes(hex.length)) return null
+  const normalized = hex.length === 3
+    ? hex.split('').map(c => c + c).join('')
+    : hex
+  const intVal = parseInt(normalized, 16)
+  const r = (intVal >> 16) & 255
+  const g = (intVal >> 8) & 255
+  const b = intVal & 255
+  return `${r}, ${g}, ${b}`
+}
+
+function valueToRgb(value) {
+  if (!value) return null
+  if (value.startsWith('rgb')) {
+    const digits = value.replace(/rgba?\(|\)/g, '').split(',').slice(0, 3).map(v => v.trim())
+    if (digits.length === 3 && digits.every(v => v !== '')) return digits.join(', ')
+    return null
+  }
+  if (value.startsWith('#')) return hexToRgb(value)
+  return null
+}
+
+function clearSrVars(root) {
+  Array.from(root.style).forEach((prop) => {
+    if (prop.startsWith('--sr-')) {
+      root.style.removeProperty(prop)
+    }
+  })
+}
+
+function mergeCssVars(cssVars = {}) {
+  return { ...BASE_CSS_VARS, ...cssVars }
+}
+
+async function persistUserTheme(themeId) {
+  const { user } = useAuth()
+  if (!user.value?.id) return
+  await supabase.from('users').update({ theme_id: themeId }).eq('id', user.value.id)
+}
+
+async function applyTheme(theme) {
+  const root = document.documentElement
+  const merged = mergeCssVars(theme?.css_vars)
+  clearSrVars(root)
+
+  Object.entries(merged).forEach(([key, value]) => {
+    const cssName = toCssName(key)
+    const normalizedValue = typeof value === 'number' ? String(value) : value
+    if (typeof normalizedValue === 'string') {
+      root.style.setProperty(cssName, normalizedValue)
+      const rgbValue = valueToRgb(normalizedValue)
+      if (rgbValue && !cssName.endsWith('-rgb')) {
+        root.style.setProperty(`${cssName}-rgb`, rgbValue)
+      }
+    }
+  })
+
+  if (theme?.is_dark_mode) root.classList.add('dark')
+  else root.classList.remove('dark')
+
+  root.style.setProperty('color-scheme', theme?.is_dark_mode ? 'dark' : 'light')
+  currentTheme.value = { ...(theme ?? BASE_THEME), css_vars: merged }
+  localStorage.setItem(THEME_CACHE_KEY, theme?.id ?? BASE_THEME.id)
+}
+
+async function fetchThemes() {
+  isLoadingThemes.value = true
+  try {
+    const { data, error } = await supabase
+      .from('themes')
+      .select('id, name, css_vars, is_dark_mode, is_premium, required_plan')
+    if (error) throw error
+    themes.value = [BASE_THEME, ...(data ?? [])]
+    return themes.value
+  } catch (error) {
+    console.error('Failed to fetch themes', error)
+    themes.value = [BASE_THEME]
+    return themes.value
+  } finally {
+    isLoadingThemes.value = false
+  }
+}
+
+function isPremiumLocked(theme) {
+  const { tier } = useAuth()
+  const requiredPlan = (theme?.required_plan || (theme?.is_premium ? 'pro' : 'free')).toLowerCase()
+  const currentTier = (tier.value || 'free').toLowerCase()
+  if (requiredPlan === 'free') return false
+  return currentTier === 'free'
+}
+
+async function setTheme(themeId, { persist = true } = {}) {
+  const theme = themes.value.find((t) => t.id === themeId) ?? BASE_THEME
+  await applyTheme(theme)
+  if (persist) {
+    localStorage.setItem(THEME_CACHE_KEY, theme.id)
+    await persistUserTheme(theme.id)
+  }
+  return theme
+}
+
+async function preloadTheme() {
+  await applyTheme(currentTheme.value)
+  let savedId = localStorage.getItem(THEME_CACHE_KEY)
+  try {
+    if (!savedId) {
+      const { data: authData } = await supabase.auth.getUser()
+      const authUserId = authData?.user?.id
+      if (authUserId) {
+        const { data: userTheme } = await supabase
+          .from('users')
+          .select('theme_id')
+          .eq('id', authUserId)
+          .single()
+        savedId = userTheme?.theme_id || savedId
+        if (savedId) {
+          localStorage.setItem(THEME_CACHE_KEY, savedId)
+        }
+      }
+    }
+    await fetchThemes()
+    const matched = themes.value.find((theme) => theme.id === savedId)
+    if (matched) {
+      await applyTheme(matched)
+    }
+  } catch (error) {
+    console.warn('Theme preload fallback to base', error)
+  }
+}
+
+export function useTheme() {
+  return {
+    themes: readonly(themes),
+    currentTheme: readonly(currentTheme),
+    isLoadingThemes: readonly(isLoadingThemes),
+    fetchThemes,
+    setTheme,
+    applyTheme,
+    preloadTheme,
+    isPremiumLocked,
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,10 @@ import { createPinia } from 'pinia';
 import router from '@/utils/router.js'
 import '@/composables/useAuth.js' // Ensure auth is initialized before app mounts
 import * as Sentry from "@sentry/vue";
+import { useTheme } from '@/composables/useTheme'
+
+const { preloadTheme } = useTheme()
+await preloadTheme()
 
 const app = createApp(App);
 

--- a/src/style.css
+++ b/src/style.css
@@ -1,13 +1,14 @@
 @import "tailwindcss";
+
 :root {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
   line-height: 1.5;
   font-weight: 400;
+  color-scheme: light;
+  color: var(--sr-text-0);
+  background-color: var(--sr-bg-0);
 
-  color-scheme: light dark;
-  color: var(--lm-text-0);
-  background-color: var(--lm-bg-0);
-
+  /* Base palette tokens */
   --sr-white: #ffffff;
   --sr-white-rgb: 255, 255, 255;
   --sr-black: #000000;
@@ -139,91 +140,72 @@
   --sr-rose-500: #f43f5e;
   --sr-rose-500-rgb: 244, 63, 94;
 
-  --sr-primary: #2e90fa;
-  --sr-primary-rgb: 46, 144, 250;
-  --sr-accent-yellow: #ffff00;
-  --sr-accent-yellow-rgb: 255, 255, 0;
-  --sr-accent-danger: #f44336;
-  --sr-accent-danger-rgb: 244, 67, 54;
-  --sr-surface-0: var(--sr-neutral-100);
-  --sr-surface-1: #ebebeb;
-  --sr-surface-2: #dcdcdc;
-  --sr-surface-contrast: #1a1a1a;
-  --sr-surface-muted: #333333;
-  --sr-surface-faint: #444444;
-  --sr-border: #c8c8c8;
-  --sr-text-strong: #222222;
-  --sr-text-muted: #555555;
-  --sr-text-contrast: #a1a1aa;
-  --sr-node-red: #d45a5a;
-  --sr-node-red-rgb: 212, 90, 90;
-  --sr-node-blue: #6c8edb;
-  --sr-node-blue-rgb: 108, 142, 219;
-  --sr-highlight-blue: #6fd7ff;
-  --sr-detail-stroke: #2f3a4a;
-  --sr-body-fill-rgb: 150, 165, 185;
-  --sr-body-stroke-rgb: 60, 70, 85;
-  --sr-detail-fill-rgb: 70, 80, 95;
-  --sr-detail-gradient-rgb: 140, 150, 165;
-  --sr-outline-strong: #1f2937;
-  --sr-outline-contrast: #111827;
-  --sr-outline-contrast-rgb: 17, 24, 39;
   --sr-purple-600: #7c3aed;
   --sr-purple-600-rgb: 124, 58, 237;
   --sr-purple-500: #a855f7;
   --sr-purple-500-rgb: 168, 85, 247;
-  --sr-focus-blue: #4a90e2;
-  --sr-focus-blue-rgb: 74, 144, 226;
-  --sr-dark-bg-0: #0b0b0f;
-  --sr-dark-bg-1: #131317;
-  --sr-dark-bg-2: #1c1c22;
-  --sr-dark-border: #27272a;
-  --sr-dark-text-0: #f5f5f5;
-  --sr-dark-text-1: #a1a1aa;
-  --sr-dark-grid-line: rgba(255, 255, 255, 0.06);
-  --sr-dark-node-red: #f87171;
-  --sr-dark-node-blue: #60a5fa;
-  --sr-dark-cone-red: rgba(248, 113, 113, 0.12);
-  --sr-dark-cone-blue: rgba(96, 165, 250, 0.14);
-  --sr-dark-shadow: 0 8px 24px rgba(var(--sr-black-rgb), 0.55);
-  --sr-dark-panel: #1a1a1a;
-  --sr-dark-input: #333333;
-  --sr-dark-disabled-bg: #444444;
-  --sr-dark-disabled-text: #cccccc;
-  --sr-dark-warm-red-rgb: 255, 137, 137;
-  --sr-dark-soft-red-rgb: 255, 180, 180;
-  --sr-dark-bright-red-rgb: 255, 120, 120;
+
+  /* Theme semantic tokens */
+  --sr-bg-0: #f5f5f5;
+  --sr-bg-1: #ebebeb;
+  --sr-bg-2: #dcdcdc;
+  --sr-text-0: #222222;
+  --sr-text-1: #555555;
+  --sr-border: #c8c8c8;
+  --sr-surface-muted: #333333;
+  --sr-grid-line: rgba(0, 0, 0, 0.08);
+  --sr-shadow: 0 4px 10px rgba(var(--sr-black-rgb), 0.12);
+  --sr-primary: #2e90fa;
+  --sr-primary-rgb: 46, 144, 250;
+  --sr-danger: #f44336;
+  --sr-danger-rgb: 244, 67, 54;
+  --sr-highlight: #ffff00;
+  --sr-selection-glow: #6fd7ff;
+  --sr-node-red: #d45a5a;
+  --sr-node-red-rgb: 212, 90, 90;
+  --sr-node-blue: #6c8edb;
+  --sr-node-blue-rgb: 108, 142, 219;
+  --sr-cone-red: rgba(212, 90, 90, 0.1);
+  --sr-cone-blue: rgba(108, 142, 219, 0.12);
+  --sr-detail-stroke: #2f3a4a;
+  --sr-detail-fill-rgb: 70, 80, 95;
+  --sr-detail-gradient-rgb: 140, 150, 165;
+  --sr-body-fill-rgb: 150, 165, 185;
+  --sr-body-stroke-rgb: 60, 70, 85;
+  --sr-detail-fill: rgba(70, 80, 95, 0.85);
+  --sr-outline-contrast: #111827;
+  --sr-outline-contrast-rgb: 17, 24, 39;
+  --sr-focus: #4a90e2;
+  --sr-focus-rgb: 74, 144, 226;
+  --sr-panel: #f8f8f8;
   --sr-panel-soft: #f8f8f8;
+  --sr-input-bg: #dcdcdc;
+  --sr-disabled-bg: #dcdcdc;
+  --sr-disabled-text: #555555;
+  --sr-node-shadow-opacity: 0.18;
+  --sr-node-shadow-blur: 8px;
+  --sr-selection-glow-opacity: 0.38;
+  --sr-selection-glow-blur: 10px;
+  --sr-vignette-inner: rgba(0, 0, 0, 0.06);
+  --sr-vignette-middle: rgba(0, 0, 0, 0.04);
+  --sr-vignette-outer: rgba(0, 0, 0, 0.08);
+  --sr-vignette-shadow: inset 0 0 70px rgba(0, 0, 0, 0.12);
+  --sr-panel-border: rgba(200, 200, 200, 0.75);
   --sr-dark-plain: #111111;
-  --sr-slate-200: #e5e7eb;
-  --sr-slate-200-rgb: 229, 231, 235;
+}
 
-  --lm-bg-0: var(--sr-surface-0);
-  --lm-bg-1: var(--sr-surface-1);
-  --lm-bg-2: var(--sr-surface-2);
-  --lm-border: var(--sr-border);
-  --lm-text-0: var(--sr-text-strong);
-  --lm-text-1: var(--sr-text-muted);
-  --lm-grid-line: rgba(var(--sr-black-rgb), 0.08);
-  --lm-node-red: var(--sr-node-red);
-  --lm-node-blue: var(--sr-node-blue);
-  --lm-cone-red: rgba(212, 90, 90, 0.1);
-  --lm-cone-blue: rgba(108, 142, 219, 0.12);
-  --lm-shadow: 0 4px 10px rgba(var(--sr-black-rgb), 0.12);
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+.dark {
+  color-scheme: dark;
 }
 
 a {
   font-weight: 500;
-  color: var(--lm-text-0);
+  color: var(--sr-text-0);
   text-decoration: inherit;
 }
+
 a:hover {
-  color: var(--lm-text-1);
+  color: var(--sr-text-1);
 }
 
 body {
@@ -232,8 +214,8 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
-  color: var(--lm-text-0);
-  background: var(--lm-bg-0);
+  color: var(--sr-text-0);
+  background: var(--sr-bg-0);
 }
 
 h1 {
@@ -248,15 +230,15 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-
   cursor: pointer;
   transition: border-color 0.25s;
+  @apply bg-[var(--sr-bg-1)] text-[var(--sr-text-0)];
+}
 
-  @apply bg-[var(--lm-bg-1)] dark:bg-[var(--sr-dark-panel)] text-[var(--lm-text-0)];
-}
 button:hover {
-  border-color: var(--lm-border);
+  border-color: var(--sr-border);
 }
+
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
@@ -268,7 +250,6 @@ button:focus-visible {
 
 #app {
   margin: 0 auto;
-  
   text-align: center;
 }
 
@@ -276,88 +257,32 @@ button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
   pointer-events: none;
-  background-color: var(--sr-dark-disabled-bg);
-  color: var(--sr-dark-disabled-text);
+  background-color: var(--sr-disabled-bg);
+  color: var(--sr-disabled-text);
 }
 
 input[type="text"],
 input[type="email"],
 input[type="password"] {
-  @apply w-full p-3 border border-[var(--lm-border)] rounded-lg dark:bg-[var(--sr-dark-input)] bg-[var(--lm-bg-2)] dark:text-[var(--sr-white)] text-[var(--lm-text-0)];
+  @apply w-full p-3 border border-[var(--sr-border)] rounded-lg bg-[var(--sr-input-bg)] text-[var(--sr-text-0)];
 }
 
 input:disabled {
-  @apply dark:bg-neutral-700 dark:text-neutral-400 opacity-50 cursor-not-allowed bg-[var(--lm-bg-2)] text-[var(--lm-text-1)];
+  @apply opacity-50 cursor-not-allowed bg-[var(--sr-disabled-bg)] text-[var(--sr-disabled-text)];
 }
-
 
 .modal-backdrop {
   @apply fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center;
 }
 
 .modal-panel {
-  @apply bg-[var(--lm-bg-0)] dark:bg-neutral-950 rounded-2xl w-[80vw] h-[80vh] shadow-[var(--lm-shadow)] dark:shadow-2xl border border-[var(--lm-border)] dark:border-neutral-800 overflow-hidden;
+  @apply bg-[var(--sr-bg-0)] rounded-2xl w-[80vw] h-[80vh] shadow-[var(--sr-shadow)] border border-[var(--sr-border)] overflow-hidden;
 }
 
 .modal-header-float {
-  @apply absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4
-         bg-[color-mix(in_srgb,var(--lm-bg-0)_85%,transparent)] dark:bg-neutral-950/50 backdrop-blur-md border-b border-[var(--lm-border)] dark:border-neutral-800;
+  @apply absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[color-mix(in_srgb,var(--sr-bg-0)_85%,transparent)] backdrop-blur-md border-b border-[var(--sr-border)];
 }
 
 .modal-header {
-  @apply top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4
-         bg-[color-mix(in_srgb,var(--lm-bg-0)_85%,transparent)] dark:bg-neutral-950/50 backdrop-blur-md border-b border-[var(--lm-border)] dark:border-neutral-800;
-}
-
-
-
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --lm-bg-0: var(--sr-dark-bg-0);
-    --lm-bg-1: var(--sr-dark-bg-1);
-    --lm-bg-2: var(--sr-dark-bg-2);
-    --lm-border: var(--sr-dark-border);
-    --lm-text-0: var(--sr-dark-text-0);
-    --lm-text-1: var(--sr-dark-text-1);
-    --lm-grid-line: var(--sr-dark-grid-line);
-    --lm-node-red: var(--sr-dark-node-red);
-    --lm-node-blue: var(--sr-dark-node-blue);
-    --lm-cone-red: var(--sr-dark-cone-red);
-    --lm-cone-blue: var(--sr-dark-cone-blue);
-    --lm-shadow: var(--sr-dark-shadow);
-
-    color: var(--lm-text-0);
-    background-color: var(--lm-bg-0);
-  }
-}
-
-.dark {
-  --lm-bg-0: var(--sr-dark-bg-0);
-  --lm-bg-1: var(--sr-dark-bg-1);
-  --lm-bg-2: var(--sr-dark-bg-2);
-  --lm-border: var(--sr-dark-border);
-  --lm-text-0: var(--sr-dark-text-0);
-  --lm-text-1: var(--sr-dark-text-1);
-  --lm-grid-line: var(--sr-dark-grid-line);
-  --lm-node-red: var(--sr-dark-node-red);
-  --lm-node-blue: var(--sr-dark-node-blue);
-  --lm-cone-red: var(--sr-dark-cone-red);
-  --lm-cone-blue: var(--sr-dark-cone-blue);
-  --lm-shadow: var(--sr-dark-shadow);
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: var(--lm-text-0);
-    background-color: var(--lm-bg-0);
-  }
-  a:hover {
-    color: var(--lm-text-1);
-  }
-
-  button:disabled {
-    background-color: var(--lm-bg-2);
-    color: var(--lm-text-1);
-  }
+  @apply top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[color-mix(in_srgb,var(--sr-bg-0)_85%,transparent)] backdrop-blur-md border-b border-[var(--sr-border)];
 }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -67,6 +67,8 @@
         </div>
       </section>
 
+      <ThemeSelector />
+
       <section class="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Profile</h2>
@@ -224,6 +226,7 @@ import { computed, reactive, ref, watch, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import BaseButton from '@/components/ui/input/BaseButton.vue'
 import BaseInput from '@/components/ui/input/BaseInput.vue'
+import ThemeSelector from '@/components/ui/ThemeSelector.vue'
 import { useAuth } from '@/composables/useAuth'
 import { supabase } from '@/utils/supabase'
 

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full bg-[var(--lm-bg-0)] text-[var(--lm-text-0)] dark:bg-neutral-950 dark:text-white flex flex-col">
+<div class="h-full bg-[var(--sr-bg-0)] text-[var(--sr-text-0)] dark:bg-neutral-950 dark:text-white flex flex-col">
     <!-- Main Layout -->
     <div class="flex flex-1 overflow-hidden">
 
@@ -17,7 +17,7 @@
         <Toolbar/>
 
         <!-- Canvas Area -->
-        <div class="flex-1 relative overflow-hidden bg-[var(--lm-bg-1)] dark:bg-neutral-900 flex items-center justify-center border-t border-[var(--lm-border)]/80 dark:border-0">
+      <div class="flex-1 relative overflow-hidden bg-[var(--sr-bg-1)] dark:bg-neutral-900 flex items-center justify-center border-t border-[var(--sr-border)]/80 dark:border-0">
           <div class="pointer-events-none absolute inset-0 canvas-vignette" aria-hidden="true"></div>
           <MainCanvasStage
             v-bind="{
@@ -202,21 +202,11 @@ onUnmounted(() => {
 
 <style scoped>
 .canvas-vignette {
-  --vignette-inner: rgba(0, 0, 0, 0.06);
-  --vignette-middle: rgba(0, 0, 0, 0.04);
-  --vignette-outer: rgba(0, 0, 0, 0.08);
-  --vignette-shadow: inset 0 0 70px rgba(0, 0, 0, 0.12);
+  --vignette-inner: var(--sr-vignette-inner);
+  --vignette-middle: var(--sr-vignette-middle);
+  --vignette-outer: var(--sr-vignette-outer);
 
   background: radial-gradient(circle at center, var(--vignette-inner) 0%, var(--vignette-middle) 38%, var(--vignette-outer) 100%);
-  box-shadow: var(--vignette-shadow);
-}
-
-@media (prefers-color-scheme: dark) {
-  .canvas-vignette {
-    --vignette-inner: rgba(224, 224, 224, 0.1);
-    --vignette-middle: rgba(255, 255, 255, 0.03);
-    --vignette-outer: rgba(0, 0, 0, 0.48);
-    --vignette-shadow: inset 0 0 140px rgba(0, 0, 0, 0.42);
-  }
+  box-shadow: var(--sr-vignette-shadow);
 }
 </style>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@
 const withAlpha = (variable) => `rgb(var(${variable}) / <alpha-value>)`
 
 module.exports = {
+  darkMode: 'class',
   important: true,
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- add a Supabase-driven `useTheme` composable with fallback defaults, dark-class handling, and persistence
- switch global styling and canvas components to shared sr- CSS variables and class-based dark mode
- introduce a ThemeSelector UI and route-level preload to apply user-selected themes before mount

## Testing
- npm run build *(fails: missing @sentry/vite-plugin dependency in current environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692389989a28832fb6db9e8dc13e18d9)