### PR TITLE
Centralize Konva color fallbacks

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
@@ -126,64 +126,64 @@ onMounted(() => prefersDark.addEventListener('change', syncTheme))
 onBeforeUnmount(() => prefersDark.removeEventListener('change', syncTheme))
 
 const anchorGlowFill = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-500-rgb', 0.08, 'rgba(59, 130, 246, 0.08)')
-  : rgbaFromVar('--sr-black-rgb', 0.06, 'rgba(0, 0, 0, 0.06)'))
+  ? rgbaFromVar('--sr-blue-500-rgb', 0.08, 'var(--sr-blue-500-08)')
+  : rgbaFromVar('--sr-black-rgb', 0.06, 'var(--sr-listener-anchor-glow)'))
 const anchorShadowColor = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-500-rgb', 0.3, 'rgba(59, 130, 246, 0.3)')
-  : rgbaFromVar('--sr-black-rgb', 0.1, 'rgba(0, 0, 0, 0.1)'))
+  ? rgbaFromVar('--sr-blue-500-rgb', 0.3, 'var(--sr-blue-500-30)')
+  : rgbaFromVar('--sr-black-rgb', 0.1, 'var(--sr-listener-anchor-shadow)'))
 const anchorShadowBlur = computed(() => isDarkMode.value ? 18 : 10)
 const anchorShadowOpacity = computed(() => isDarkMode.value ? 0.35 : 0.18)
 
 const bodyFill = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-500-rgb', 0.15, 'rgba(59, 130, 246, 0.15)')
-  : rgbaFromVar('--sr-body-fill-rgb', 0.35, 'rgba(150, 165, 185, 0.35)'))
+  ? rgbaFromVar('--sr-blue-500-rgb', 0.15, 'var(--sr-blue-500-15)')
+  : rgbaFromVar('--sr-body-fill-rgb', 0.35, 'var(--sr-listener-body-fill)'))
 const bodyStroke = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-400-rgb', 0.9, 'rgba(96, 165, 250, 0.9)')
-  : getVar('--sr-detail-stroke', '#2f3a4a'))
+  ? rgbaFromVar('--sr-blue-400-rgb', 0.9, 'var(--sr-blue-400-90)')
+  : getVar('--sr-detail-stroke', 'var(--sr-detail-stroke)'))
 const bodyShadowColor = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-black-rgb', 0.2, 'rgba(0, 0, 0, 0.2)')
-  : rgbaFromVar('--sr-black-rgb', 0.08, 'rgba(0, 0, 0, 0.08)'))
+  ? rgbaFromVar('--sr-black-rgb', 0.2, 'var(--sr-black-20)')
+  : rgbaFromVar('--sr-black-rgb', 0.08, 'var(--sr-listener-body-shadow)'))
 const bodyShadowBlur = computed(() => isDarkMode.value ? 10 : 8)
 const bodyShadowOpacity = computed(() => isDarkMode.value ? 0.55 : 0.18)
 
 const detailFill = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-outline-contrast-rgb', 0.9, 'rgba(15, 23, 42, 0.9)')
-  : rgbaFromVar('--sr-detail-fill-rgb', 0.85, 'rgba(70, 80, 95, 0.85)'))
+  ? rgbaFromVar('--sr-outline-contrast-rgb', 0.9, 'var(--sr-outline-contrast-90)')
+  : rgbaFromVar('--sr-detail-fill-rgb', 0.85, 'var(--sr-listener-detail-fill)'))
 const detailStroke = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-100-rgb', 0.85, 'rgba(191, 219, 254, 0.85)')
-  : rgbaFromVar('--sr-body-stroke-rgb', 0.6, 'rgba(60, 70, 85, 0.6)'))
+  ? rgbaFromVar('--sr-blue-100-rgb', 0.85, 'var(--sr-blue-100-85)')
+  : rgbaFromVar('--sr-body-stroke-rgb', 0.6, 'var(--sr-listener-detail-stroke)'))
 
 const detailShadowColor = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-500-rgb', 0.35, 'rgba(59, 130, 246, 0.35)')
-  : rgbaFromVar('--sr-black-rgb', 0.08, 'rgba(0, 0, 0, 0.08)'))
+  ? rgbaFromVar('--sr-blue-500-rgb', 0.35, 'var(--sr-blue-500-35)')
+  : rgbaFromVar('--sr-black-rgb', 0.08, 'var(--sr-listener-detail-shadow)'))
 const detailShadowBlur = computed(() => isDarkMode.value ? 8 : 6)
 const detailShadowOpacity = computed(() => isDarkMode.value ? 0.45 : 0.2)
 
 const centerHighlightFill = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-white-rgb', 0.75, 'rgba(255, 255, 255, 0.75)')
-  : rgbaFromVar('--sr-white-rgb', 0.6, 'rgba(255, 255, 255, 0.6)'))
+  ? rgbaFromVar('--sr-white-rgb', 0.75, 'var(--sr-white-75)')
+  : rgbaFromVar('--sr-white-rgb', 0.6, 'var(--sr-listener-center-highlight)'))
 const centerHighlightStroke = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-white-rgb', 0.2, 'rgba(255, 255, 255, 0.2)')
-  : rgbaFromVar('--sr-black-rgb', 0.08, 'rgba(0, 0, 0, 0.08)'))
+  ? rgbaFromVar('--sr-white-rgb', 0.2, 'var(--sr-white-20)')
+  : rgbaFromVar('--sr-black-rgb', 0.08, 'var(--sr-listener-center-stroke)'))
 const highlightShadowColor = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-white-rgb', 0.35, 'rgba(255, 255, 255, 0.35)')
-  : rgbaFromVar('--sr-black-rgb', 0.06, 'rgba(0, 0, 0, 0.06)'))
+  ? rgbaFromVar('--sr-white-rgb', 0.35, 'var(--sr-white-35)')
+  : rgbaFromVar('--sr-black-rgb', 0.06, 'var(--sr-listener-highlight-shadow)'))
 const highlightShadowOpacity = computed(() => isDarkMode.value ? 0.5 : 0.28)
 
 const directionGradientStops = computed(() => isDarkMode.value
-  ? [0, rgbaFromVar('--sr-blue-100-rgb', 0.18, 'rgba(191, 219, 254, 0.18)'), 1, rgbaFromVar('--sr-blue-500-rgb', 0.85, 'rgba(59, 130, 246, 0.85)')]
-  : [0, rgbaFromVar('--sr-detail-gradient-rgb', 0.2, 'rgba(140, 150, 165, 0.2)'), 1, rgbaFromVar('--sr-body-stroke-rgb', 0.8, 'rgba(60, 70, 85, 0.8)')]
+  ? [0, rgbaFromVar('--sr-blue-100-rgb', 0.18, 'var(--sr-blue-100-18)'), 1, rgbaFromVar('--sr-blue-500-rgb', 0.85, 'var(--sr-blue-500-85)')]
+  : [0, rgbaFromVar('--sr-detail-gradient-rgb', 0.2, 'var(--sr-listener-direction-start)'), 1, rgbaFromVar('--sr-body-stroke-rgb', 0.8, 'var(--sr-listener-direction-end)')]
 )
 const directionStroke = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-outline-contrast-rgb', 0.85, 'rgba(15, 23, 42, 0.85)')
-  : getVar('--sr-text-strong', '#222222'))
+  ? rgbaFromVar('--sr-outline-contrast-rgb', 0.85, 'var(--sr-outline-contrast-85)')
+  : getVar('--sr-text-strong', 'var(--sr-text-strong)'))
 const directionShadowColor = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-500-rgb', 0.35, 'rgba(59, 130, 246, 0.35)')
-  : rgbaFromVar('--sr-black-rgb', 0.1, 'rgba(0, 0, 0, 0.1)'))
+  ? rgbaFromVar('--sr-blue-500-rgb', 0.35, 'var(--sr-blue-500-35)')
+  : rgbaFromVar('--sr-black-rgb', 0.1, 'var(--sr-listener-direction-shadow)'))
 
 const rotationHandleFill = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-blue-500-rgb', 0.1, 'rgba(59, 130, 246, 0.1)')
-  : rgbaFromVar('--sr-black-rgb', 0.06, 'rgba(0, 0, 0, 0.06)'))
+  ? rgbaFromVar('--sr-blue-500-rgb', 0.1, 'var(--sr-blue-500-10)')
+  : rgbaFromVar('--sr-black-rgb', 0.06, 'var(--sr-listener-rotation-fill)'))
 
 let moveListenerPayload = null
 let initialMouseAngle = null

--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -154,20 +154,20 @@ const isScheduledPlaying = computed(() => sched.value?.isPlaying)
 const sourceIsPlaying = computed(() => props.source.instance.playing);
 
 const lightPalette = computed(() => ({
-  bg2: getVar('--lm-bg-2', '#dcdcdc'),
-  nodeRed: getVar('--lm-node-red', '#d45a5a'),
-  nodeBlue: getVar('--lm-node-blue', '#6c8edb'),
-  coneRed: getVar('--lm-cone-red', 'rgba(212, 90, 90, 0.1)'),
-  coneBlue: getVar('--lm-cone-blue', 'rgba(108, 142, 219, 0.12)'),
+  bg2: getVar('--lm-bg-2', 'var(--sr-source-selected-bg)'),
+  nodeRed: getVar('--lm-node-red', 'var(--sr-source-node-red)'),
+  nodeBlue: getVar('--lm-node-blue', 'var(--sr-source-node-blue)'),
+  coneRed: getVar('--lm-cone-red', 'var(--sr-source-cone-red)'),
+  coneBlue: getVar('--lm-cone-blue', 'var(--sr-source-cone-blue)'),
 }))
 
 const themeTokens = computed(() => ({
-  primary: getVar('--sr-primary', '#2e90fa'),
-  danger: getVar('--sr-accent-danger', '#f44336'),
-  selected: getVar('--sr-accent-yellow', '#ffff00'),
-  selectionHighlight: getVar('--sr-highlight-blue', '#6fd7ff'),
-  mutedStroke: getVar('--sr-surface-muted', '#333333'),
-  white: getVar('--sr-white', '#ffffff'),
+  primary: getVar('--sr-primary', 'var(--sr-primary)'),
+  danger: getVar('--sr-accent-danger', 'var(--sr-accent-danger)'),
+  selected: getVar('--sr-accent-yellow', 'var(--sr-accent-yellow)'),
+  selectionHighlight: getVar('--sr-highlight-blue', 'var(--sr-highlight-blue)'),
+  mutedStroke: getVar('--sr-surface-muted', 'var(--sr-surface-muted)'),
+  white: getVar('--sr-white', 'var(--sr-white)'),
 }))
 
 const getFillColor = computed(() => {
@@ -181,39 +181,39 @@ const getFillColor = computed(() => {
 })
 
 const dotStrokeColor = computed(() => {
-  if (isDarkMode.value) return props.selected ? themeTokens.value.white : rgbaFromVar('--sr-white-rgb', 0.9, 'rgba(255, 255, 255, 0.9)')
+  if (isDarkMode.value) return props.selected ? themeTokens.value.white : rgbaFromVar('--sr-white-rgb', 0.9, 'var(--sr-white-90)')
   return themeTokens.value.mutedStroke
 })
 const selectionGlowColor = computed(() => (isDarkMode.value
   ? themeTokens.value.selectionHighlight
-  : rgbaFromVar('--sr-black-rgb', 0.05, 'rgba(0, 0, 0, 0.05)')))
+  : rgbaFromVar('--sr-black-rgb', 0.05, 'var(--sr-source-selection-glow)')))
 const selectedScale = computed(() => (props.selected ? 1.05 : 1))
 
 const outerConeFill = computed(() => {
-  if (isDarkMode.value) return rgbaFromVar('--sr-dark-warm-red-rgb', 0.16, 'rgba(255, 137, 137, 0.16)')
+  if (isDarkMode.value) return rgbaFromVar('--sr-dark-warm-red-rgb', 0.16, 'var(--sr-dark-warm-red-16)')
   const colors = lightPalette.value
   return isScheduled.value ? colors.coneBlue : colors.coneRed
 })
 const outerConeStroke = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-dark-warm-red-rgb', 0.28, 'rgba(255, 137, 137, 0.28)')
+  ? rgbaFromVar('--sr-dark-warm-red-rgb', 0.28, 'var(--sr-dark-warm-red-28)')
   : (isScheduled.value
-    ? rgbaFromVar('--sr-node-blue-rgb', 0.24, 'rgba(108, 142, 219, 0.24)')
-    : rgbaFromVar('--sr-node-red-rgb', 0.2, 'rgba(212, 90, 90, 0.2)')))
+    ? rgbaFromVar('--sr-node-blue-rgb', 0.24, 'var(--sr-node-blue-24)')
+    : rgbaFromVar('--sr-node-red-rgb', 0.2, 'var(--sr-node-red-20)')))
 const outerConeShadowColor = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-dark-bright-red-rgb', 0.65, 'rgba(255, 120, 120, 0.65)')
-  : rgbaFromVar('--sr-black-rgb', 0.12, 'rgba(0, 0, 0, 0.12)'))
+  ? rgbaFromVar('--sr-dark-bright-red-rgb', 0.65, 'var(--sr-dark-bright-red-65)')
+  : rgbaFromVar('--sr-black-rgb', 0.12, 'var(--sr-black-12)'))
 const outerConeShadowBlur = computed(() => isDarkMode.value ? 18 : 10)
 
 const innerConeFill = computed(() => {
-  if (isDarkMode.value) return rgbaFromVar('--sr-dark-soft-red-rgb', 0.18, 'rgba(255, 180, 180, 0.18)')
+  if (isDarkMode.value) return rgbaFromVar('--sr-dark-soft-red-rgb', 0.18, 'var(--sr-dark-soft-red-18)')
   const colors = lightPalette.value
   return isScheduled.value
-    ? rgbaFromVar('--sr-node-blue-rgb', 0.18, 'rgba(108, 142, 219, 0.18)')
-    : rgbaFromVar('--sr-node-red-rgb', 0.16, 'rgba(212, 90, 90, 0.16)')
+    ? rgbaFromVar('--sr-node-blue-rgb', 0.18, 'var(--sr-node-blue-18)')
+    : rgbaFromVar('--sr-node-red-rgb', 0.16, 'var(--sr-node-red-16)')
 })
 const innerConeStroke = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-dark-soft-red-rgb', 0.35, 'rgba(255, 180, 180, 0.35)')
-  : rgbaFromVar('--sr-black-rgb', 0.18, 'rgba(0, 0, 0, 0.18)'))
+  ? rgbaFromVar('--sr-dark-soft-red-rgb', 0.35, 'var(--sr-dark-soft-red-35)')
+  : rgbaFromVar('--sr-black-rgb', 0.18, 'var(--sr-black-18)'))
 
 const selectionGlowOpacity = computed(() => isDarkMode.value ? 0.75 : 0.22)
 const selectionGlowBlur = computed(() => isDarkMode.value ? 14 : 8)
@@ -222,15 +222,15 @@ const nodeShadowBlur = computed(() => isDarkMode.value ? 10 : 6)
 const nodeShadowOpacity = computed(() => isDarkMode.value ? 0.65 : 0.08)
 
 const directionGradientStops = computed(() => isDarkMode.value
-  ? [0, rgbaFromVar('--sr-white-rgb', 0.95, 'rgba(255,255,255,0.95)'), 1, rgbaFromVar('--sr-white-rgb', 0.65, 'rgba(255,255,255,0.65)')]
-  : [0, rgbaFromVar('--sr-white-rgb', 0.7, 'rgba(255,255,255,0.7)'), 1, rgbaFromVar('--sr-black-rgb', 0.12, 'rgba(0,0,0,0.12)')]
+  ? [0, rgbaFromVar('--sr-white-rgb', 0.95, 'var(--sr-white-95)'), 1, rgbaFromVar('--sr-white-rgb', 0.65, 'var(--sr-white-65)')]
+  : [0, rgbaFromVar('--sr-white-rgb', 0.7, 'var(--sr-white-70)'), 1, rgbaFromVar('--sr-black-rgb', 0.12, 'var(--sr-black-12)')]
 )
 const directionStroke = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-black-rgb', 0.6, 'rgba(0, 0, 0, 0.6)')
+  ? rgbaFromVar('--sr-black-rgb', 0.6, 'var(--sr-black-60)')
   : themeTokens.value.mutedStroke)
 const directionShadowColor = computed(() => isDarkMode.value
-  ? rgbaFromVar('--sr-black-rgb', 0.35, 'rgba(0,0,0,0.35)')
-  : rgbaFromVar('--sr-black-rgb', 0.12, 'rgba(0,0,0,0.12)'))
+  ? rgbaFromVar('--sr-black-rgb', 0.35, 'var(--sr-black-35)')
+  : rgbaFromVar('--sr-black-rgb', 0.12, 'var(--sr-black-12)'))
 
 
 

--- a/src/constants/preferences.js
+++ b/src/constants/preferences.js
@@ -1,0 +1,2 @@
+export const LOCAL_PREF_KEY = 'soundroom.userPreferences'
+export const DEFAULT_THEME = 'system'

--- a/src/main.js
+++ b/src/main.js
@@ -7,8 +7,20 @@ import { createPinia } from 'pinia';
 import router from '@/utils/router.js'
 import '@/composables/useAuth.js' // Ensure auth is initialized before app mounts
 import * as Sentry from "@sentry/vue";
+import { LOCAL_PREF_KEY, DEFAULT_THEME } from '@/constants/preferences'
+import { applyThemePreference } from '@/utils/theme'
 
 const app = createApp(App);
+
+try {
+  const storedPreferences = localStorage.getItem(LOCAL_PREF_KEY)
+  const parsedPreferences = storedPreferences ? JSON.parse(storedPreferences) : {}
+  const themePreference = parsedPreferences?.theme || DEFAULT_THEME
+  applyThemePreference(themePreference)
+} catch (error) {
+  console.warn('Unable to load stored preferences, using default theme.', error)
+  applyThemePreference(DEFAULT_THEME)
+}
 
 Sentry.init({
   app,

--- a/src/style.css
+++ b/src/style.css
@@ -173,6 +173,7 @@
   --sr-accent-yellow-rgb: 255, 255, 0;
   --sr-accent-danger: #f44336;
   --sr-accent-danger-rgb: 244, 67, 54;
+  --sr-shadow: 0 4px 10px rgba(var(--sr-black-rgb), 0.12);
   --sr-surface-0: var(--sr-neutral-100);
   --sr-surface-1: #ebebeb;
   --sr-surface-2: #dcdcdc;

--- a/src/style.css
+++ b/src/style.css
@@ -381,6 +381,49 @@ input:disabled {
 
 
 
+:root[data-theme='dark'],
+.dark {
+  --lm-bg-0: var(--sr-dark-bg-0);
+  --lm-bg-1: var(--sr-dark-bg-1);
+  --lm-bg-2: var(--sr-dark-bg-2);
+  --lm-border: var(--sr-dark-border);
+  --lm-text-0: var(--sr-dark-text-0);
+  --lm-text-1: var(--sr-dark-text-1);
+  --lm-grid-line: var(--sr-dark-grid-line);
+  --lm-node-red: var(--sr-dark-node-red);
+  --lm-node-blue: var(--sr-dark-node-blue);
+  --lm-cone-red: var(--sr-dark-cone-red);
+  --lm-cone-blue: var(--sr-dark-cone-blue);
+  --lm-shadow: var(--sr-dark-shadow);
+
+  --sr-source-selected-bg: var(--sr-dark-bg-2);
+  --sr-source-node-red: var(--sr-dark-node-red);
+  --sr-source-node-blue: var(--sr-dark-node-blue);
+  --sr-source-cone-red: var(--sr-dark-cone-red);
+  --sr-source-cone-blue: var(--sr-dark-cone-blue);
+  --sr-source-selection-glow: var(--sr-dark-warm-red-16);
+
+  --sr-listener-anchor-glow: var(--sr-blue-500-08);
+  --sr-listener-anchor-shadow: var(--sr-blue-500-30);
+  --sr-listener-body-fill: var(--sr-blue-500-15);
+  --sr-listener-body-shadow: var(--sr-black-20);
+  --sr-listener-detail-fill: var(--sr-outline-contrast-90);
+  --sr-listener-detail-stroke: var(--sr-blue-100-85);
+  --sr-listener-detail-shadow: var(--sr-blue-500-35);
+  --sr-listener-center-highlight: var(--sr-white-75);
+  --sr-listener-center-stroke: var(--sr-white-20);
+  --sr-listener-highlight-shadow: var(--sr-white-35);
+  --sr-listener-direction-start: var(--sr-blue-100-18);
+  --sr-listener-direction-end: var(--sr-blue-500-85);
+  --sr-listener-direction-stroke: var(--sr-outline-contrast-85);
+  --sr-listener-direction-shadow: var(--sr-blue-500-35);
+  --sr-listener-rotation-fill: var(--sr-blue-500-10);
+
+  color: var(--lm-text-0);
+  background-color: var(--lm-bg-0);
+  color-scheme: dark;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     --lm-bg-0: var(--sr-dark-bg-0);
@@ -421,45 +464,8 @@ input:disabled {
 
     color: var(--lm-text-0);
     background-color: var(--lm-bg-0);
+    color-scheme: dark;
   }
-}
-
-.dark {
-  --lm-bg-0: var(--sr-dark-bg-0);
-  --lm-bg-1: var(--sr-dark-bg-1);
-  --lm-bg-2: var(--sr-dark-bg-2);
-  --lm-border: var(--sr-dark-border);
-  --lm-text-0: var(--sr-dark-text-0);
-  --lm-text-1: var(--sr-dark-text-1);
-  --lm-grid-line: var(--sr-dark-grid-line);
-  --lm-node-red: var(--sr-dark-node-red);
-  --lm-node-blue: var(--sr-dark-node-blue);
-  --lm-cone-red: var(--sr-dark-cone-red);
-  --lm-cone-blue: var(--sr-dark-cone-blue);
-  --lm-shadow: var(--sr-dark-shadow);
-
-  --sr-source-selected-bg: var(--sr-dark-bg-2);
-  --sr-source-node-red: var(--sr-dark-node-red);
-  --sr-source-node-blue: var(--sr-dark-node-blue);
-  --sr-source-cone-red: var(--sr-dark-cone-red);
-  --sr-source-cone-blue: var(--sr-dark-cone-blue);
-  --sr-source-selection-glow: var(--sr-dark-warm-red-16);
-
-  --sr-listener-anchor-glow: var(--sr-blue-500-08);
-  --sr-listener-anchor-shadow: var(--sr-blue-500-30);
-  --sr-listener-body-fill: var(--sr-blue-500-15);
-  --sr-listener-body-shadow: var(--sr-black-20);
-  --sr-listener-detail-fill: var(--sr-outline-contrast-90);
-  --sr-listener-detail-stroke: var(--sr-blue-100-85);
-  --sr-listener-detail-shadow: var(--sr-blue-500-35);
-  --sr-listener-center-highlight: var(--sr-white-75);
-  --sr-listener-center-stroke: var(--sr-white-20);
-  --sr-listener-highlight-shadow: var(--sr-white-35);
-  --sr-listener-direction-start: var(--sr-blue-100-18);
-  --sr-listener-direction-end: var(--sr-blue-500-85);
-  --sr-listener-direction-stroke: var(--sr-outline-contrast-85);
-  --sr-listener-direction-shadow: var(--sr-blue-500-35);
-  --sr-listener-rotation-fill: var(--sr-blue-500-10);
 }
 
 @media (prefers-color-scheme: light) {
@@ -475,4 +481,46 @@ input:disabled {
     background-color: var(--lm-bg-2);
     color: var(--lm-text-1);
   }
+}
+
+:root[data-theme='light'] {
+  --lm-bg-0: var(--sr-surface-0);
+  --lm-bg-1: var(--sr-surface-1);
+  --lm-bg-2: var(--sr-surface-2);
+  --lm-border: var(--sr-border);
+  --lm-text-0: var(--sr-text-strong);
+  --lm-text-1: var(--sr-text-muted);
+  --lm-grid-line: rgba(var(--sr-black-rgb), 0.08);
+  --lm-node-red: var(--sr-node-red);
+  --lm-node-blue: var(--sr-node-blue);
+  --lm-cone-red: var(--sr-node-red-10);
+  --lm-cone-blue: var(--sr-node-blue-12);
+  --lm-shadow: var(--sr-shadow);
+
+  --sr-source-selected-bg: var(--sr-surface-2);
+  --sr-source-node-red: var(--sr-node-red);
+  --sr-source-node-blue: var(--sr-node-blue);
+  --sr-source-cone-red: var(--sr-node-red-10);
+  --sr-source-cone-blue: var(--sr-node-blue-12);
+  --sr-source-selection-glow: var(--sr-black-05);
+
+  --sr-listener-anchor-glow: var(--sr-black-06);
+  --sr-listener-anchor-shadow: var(--sr-black-10);
+  --sr-listener-body-fill: var(--sr-body-fill-35);
+  --sr-listener-body-shadow: var(--sr-black-08);
+  --sr-listener-detail-fill: var(--sr-detail-fill-85);
+  --sr-listener-detail-stroke: var(--sr-body-stroke-60);
+  --sr-listener-detail-shadow: var(--sr-black-08);
+  --sr-listener-center-highlight: var(--sr-white-60);
+  --sr-listener-center-stroke: var(--sr-black-08);
+  --sr-listener-highlight-shadow: var(--sr-black-06);
+  --sr-listener-direction-start: var(--sr-detail-gradient-20);
+  --sr-listener-direction-end: var(--sr-body-stroke-80);
+  --sr-listener-direction-stroke: var(--sr-text-strong);
+  --sr-listener-direction-shadow: var(--sr-black-10);
+  --sr-listener-rotation-fill: var(--sr-black-06);
+
+  color: var(--lm-text-0);
+  background-color: var(--lm-bg-0);
+  color-scheme: light;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -13,6 +13,25 @@
   --sr-black: #000000;
   --sr-black-rgb: 0, 0, 0;
 
+  --sr-black-05: rgba(var(--sr-black-rgb), 0.05);
+  --sr-black-06: rgba(var(--sr-black-rgb), 0.06);
+  --sr-black-08: rgba(var(--sr-black-rgb), 0.08);
+  --sr-black-10: rgba(var(--sr-black-rgb), 0.1);
+  --sr-black-12: rgba(var(--sr-black-rgb), 0.12);
+  --sr-black-20: rgba(var(--sr-black-rgb), 0.2);
+  --sr-black-18: rgba(var(--sr-black-rgb), 0.18);
+  --sr-black-35: rgba(var(--sr-black-rgb), 0.35);
+  --sr-black-60: rgba(var(--sr-black-rgb), 0.6);
+
+  --sr-white-20: rgba(var(--sr-white-rgb), 0.2);
+  --sr-white-35: rgba(var(--sr-white-rgb), 0.35);
+  --sr-white-60: rgba(var(--sr-white-rgb), 0.6);
+  --sr-white-65: rgba(var(--sr-white-rgb), 0.65);
+  --sr-white-70: rgba(var(--sr-white-rgb), 0.7);
+  --sr-white-75: rgba(var(--sr-white-rgb), 0.75);
+  --sr-white-90: rgba(var(--sr-white-rgb), 0.9);
+  --sr-white-95: rgba(var(--sr-white-rgb), 0.95);
+
   --sr-neutral-50: #fafafa;
   --sr-neutral-50-rgb: 250, 250, 250;
   --sr-neutral-100: #f5f5f5;
@@ -40,14 +59,23 @@
   --sr-blue-50-rgb: 239, 246, 255;
   --sr-blue-100: #dbeafe;
   --sr-blue-100-rgb: 219, 234, 254;
+  --sr-blue-100-18: rgba(var(--sr-blue-100-rgb), 0.18);
+  --sr-blue-100-85: rgba(var(--sr-blue-100-rgb), 0.85);
   --sr-blue-200: #bfdbfe;
   --sr-blue-200-rgb: 191, 219, 254;
   --sr-blue-300: #93c5fd;
   --sr-blue-300-rgb: 147, 197, 253;
   --sr-blue-400: #60a5fa;
   --sr-blue-400-rgb: 96, 165, 250;
+  --sr-blue-400-90: rgba(var(--sr-blue-400-rgb), 0.9);
   --sr-blue-500: #3b82f6;
   --sr-blue-500-rgb: 59, 130, 246;
+  --sr-blue-500-08: rgba(var(--sr-blue-500-rgb), 0.08);
+  --sr-blue-500-10: rgba(var(--sr-blue-500-rgb), 0.1);
+  --sr-blue-500-15: rgba(var(--sr-blue-500-rgb), 0.15);
+  --sr-blue-500-30: rgba(var(--sr-blue-500-rgb), 0.3);
+  --sr-blue-500-35: rgba(var(--sr-blue-500-rgb), 0.35);
+  --sr-blue-500-85: rgba(var(--sr-blue-500-rgb), 0.85);
   --sr-blue-600: #2563eb;
   --sr-blue-600-rgb: 37, 99, 235;
   --sr-blue-700: #1d4ed8;
@@ -157,17 +185,30 @@
   --sr-text-contrast: #a1a1aa;
   --sr-node-red: #d45a5a;
   --sr-node-red-rgb: 212, 90, 90;
+  --sr-node-red-10: rgba(var(--sr-node-red-rgb), 0.1);
+  --sr-node-red-16: rgba(var(--sr-node-red-rgb), 0.16);
+  --sr-node-red-20: rgba(var(--sr-node-red-rgb), 0.2);
   --sr-node-blue: #6c8edb;
   --sr-node-blue-rgb: 108, 142, 219;
+  --sr-node-blue-12: rgba(var(--sr-node-blue-rgb), 0.12);
+  --sr-node-blue-18: rgba(var(--sr-node-blue-rgb), 0.18);
+  --sr-node-blue-24: rgba(var(--sr-node-blue-rgb), 0.24);
   --sr-highlight-blue: #6fd7ff;
   --sr-detail-stroke: #2f3a4a;
   --sr-body-fill-rgb: 150, 165, 185;
+  --sr-body-fill-35: rgba(var(--sr-body-fill-rgb), 0.35);
   --sr-body-stroke-rgb: 60, 70, 85;
+  --sr-body-stroke-60: rgba(var(--sr-body-stroke-rgb), 0.6);
+  --sr-body-stroke-80: rgba(var(--sr-body-stroke-rgb), 0.8);
   --sr-detail-fill-rgb: 70, 80, 95;
+  --sr-detail-fill-85: rgba(var(--sr-detail-fill-rgb), 0.85);
   --sr-detail-gradient-rgb: 140, 150, 165;
+  --sr-detail-gradient-20: rgba(var(--sr-detail-gradient-rgb), 0.2);
   --sr-outline-strong: #1f2937;
   --sr-outline-contrast: #111827;
   --sr-outline-contrast-rgb: 17, 24, 39;
+  --sr-outline-contrast-85: rgba(var(--sr-outline-contrast-rgb), 0.85);
+  --sr-outline-contrast-90: rgba(var(--sr-outline-contrast-rgb), 0.9);
   --sr-purple-600: #7c3aed;
   --sr-purple-600-rgb: 124, 58, 237;
   --sr-purple-500: #a855f7;
@@ -191,12 +232,40 @@
   --sr-dark-disabled-bg: #444444;
   --sr-dark-disabled-text: #cccccc;
   --sr-dark-warm-red-rgb: 255, 137, 137;
+  --sr-dark-warm-red-16: rgba(var(--sr-dark-warm-red-rgb), 0.16);
+  --sr-dark-warm-red-28: rgba(var(--sr-dark-warm-red-rgb), 0.28);
   --sr-dark-soft-red-rgb: 255, 180, 180;
+  --sr-dark-soft-red-18: rgba(var(--sr-dark-soft-red-rgb), 0.18);
+  --sr-dark-soft-red-35: rgba(var(--sr-dark-soft-red-rgb), 0.35);
   --sr-dark-bright-red-rgb: 255, 120, 120;
+  --sr-dark-bright-red-65: rgba(var(--sr-dark-bright-red-rgb), 0.65);
   --sr-panel-soft: #f8f8f8;
   --sr-dark-plain: #111111;
   --sr-slate-200: #e5e7eb;
   --sr-slate-200-rgb: 229, 231, 235;
+
+  --sr-source-selected-bg: var(--sr-surface-2);
+  --sr-source-node-red: var(--sr-node-red);
+  --sr-source-node-blue: var(--sr-node-blue);
+  --sr-source-cone-red: var(--sr-node-red-10);
+  --sr-source-cone-blue: var(--sr-node-blue-12);
+  --sr-source-selection-glow: var(--sr-black-05);
+
+  --sr-listener-anchor-glow: var(--sr-black-06);
+  --sr-listener-anchor-shadow: var(--sr-black-10);
+  --sr-listener-body-fill: var(--sr-body-fill-35);
+  --sr-listener-body-shadow: var(--sr-black-08);
+  --sr-listener-detail-fill: var(--sr-detail-fill-85);
+  --sr-listener-detail-stroke: var(--sr-body-stroke-60);
+  --sr-listener-detail-shadow: var(--sr-black-08);
+  --sr-listener-center-highlight: var(--sr-white-60);
+  --sr-listener-center-stroke: var(--sr-black-08);
+  --sr-listener-highlight-shadow: var(--sr-black-06);
+  --sr-listener-direction-start: var(--sr-detail-gradient-20);
+  --sr-listener-direction-end: var(--sr-body-stroke-80);
+  --sr-listener-direction-stroke: var(--sr-text-strong);
+  --sr-listener-direction-shadow: var(--sr-black-10);
+  --sr-listener-rotation-fill: var(--sr-black-06);
 
   --lm-bg-0: var(--sr-surface-0);
   --lm-bg-1: var(--sr-surface-1);
@@ -207,8 +276,8 @@
   --lm-grid-line: rgba(var(--sr-black-rgb), 0.08);
   --lm-node-red: var(--sr-node-red);
   --lm-node-blue: var(--sr-node-blue);
-  --lm-cone-red: rgba(212, 90, 90, 0.1);
-  --lm-cone-blue: rgba(108, 142, 219, 0.12);
+  --lm-cone-red: var(--sr-node-red-10);
+  --lm-cone-blue: var(--sr-node-blue-12);
   --lm-shadow: 0 4px 10px rgba(var(--sr-black-rgb), 0.12);
 
   font-synthesis: none;
@@ -327,6 +396,29 @@ input:disabled {
     --lm-cone-blue: var(--sr-dark-cone-blue);
     --lm-shadow: var(--sr-dark-shadow);
 
+    --sr-source-selected-bg: var(--sr-dark-bg-2);
+    --sr-source-node-red: var(--sr-dark-node-red);
+    --sr-source-node-blue: var(--sr-dark-node-blue);
+    --sr-source-cone-red: var(--sr-dark-cone-red);
+    --sr-source-cone-blue: var(--sr-dark-cone-blue);
+    --sr-source-selection-glow: var(--sr-dark-warm-red-16);
+
+    --sr-listener-anchor-glow: var(--sr-blue-500-08);
+    --sr-listener-anchor-shadow: var(--sr-blue-500-30);
+    --sr-listener-body-fill: var(--sr-blue-500-15);
+    --sr-listener-body-shadow: var(--sr-black-20);
+    --sr-listener-detail-fill: var(--sr-outline-contrast-90);
+    --sr-listener-detail-stroke: var(--sr-blue-100-85);
+    --sr-listener-detail-shadow: var(--sr-blue-500-35);
+    --sr-listener-center-highlight: var(--sr-white-75);
+    --sr-listener-center-stroke: var(--sr-white-20);
+    --sr-listener-highlight-shadow: var(--sr-white-35);
+    --sr-listener-direction-start: var(--sr-blue-100-18);
+    --sr-listener-direction-end: var(--sr-blue-500-85);
+    --sr-listener-direction-stroke: var(--sr-outline-contrast-85);
+    --sr-listener-direction-shadow: var(--sr-blue-500-35);
+    --sr-listener-rotation-fill: var(--sr-blue-500-10);
+
     color: var(--lm-text-0);
     background-color: var(--lm-bg-0);
   }
@@ -345,6 +437,29 @@ input:disabled {
   --lm-cone-red: var(--sr-dark-cone-red);
   --lm-cone-blue: var(--sr-dark-cone-blue);
   --lm-shadow: var(--sr-dark-shadow);
+
+  --sr-source-selected-bg: var(--sr-dark-bg-2);
+  --sr-source-node-red: var(--sr-dark-node-red);
+  --sr-source-node-blue: var(--sr-dark-node-blue);
+  --sr-source-cone-red: var(--sr-dark-cone-red);
+  --sr-source-cone-blue: var(--sr-dark-cone-blue);
+  --sr-source-selection-glow: var(--sr-dark-warm-red-16);
+
+  --sr-listener-anchor-glow: var(--sr-blue-500-08);
+  --sr-listener-anchor-shadow: var(--sr-blue-500-30);
+  --sr-listener-body-fill: var(--sr-blue-500-15);
+  --sr-listener-body-shadow: var(--sr-black-20);
+  --sr-listener-detail-fill: var(--sr-outline-contrast-90);
+  --sr-listener-detail-stroke: var(--sr-blue-100-85);
+  --sr-listener-detail-shadow: var(--sr-blue-500-35);
+  --sr-listener-center-highlight: var(--sr-white-75);
+  --sr-listener-center-stroke: var(--sr-white-20);
+  --sr-listener-highlight-shadow: var(--sr-white-35);
+  --sr-listener-direction-start: var(--sr-blue-100-18);
+  --sr-listener-direction-end: var(--sr-blue-500-85);
+  --sr-listener-direction-stroke: var(--sr-outline-contrast-85);
+  --sr-listener-direction-shadow: var(--sr-blue-500-35);
+  --sr-listener-rotation-fill: var(--sr-blue-500-10);
 }
 
 @media (prefers-color-scheme: light) {

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,0 +1,46 @@
+import { DEFAULT_THEME } from '@/constants/preferences'
+
+const systemThemeQuery = typeof window !== 'undefined'
+  ? window.matchMedia('(prefers-color-scheme: dark)')
+  : null
+
+function prefersDarkScheme() {
+  return systemThemeQuery?.matches ?? false
+}
+
+function setColorScheme(isDark) {
+  const root = document.documentElement
+  root.classList.toggle('dark', isDark)
+  root.style.colorScheme = isDark ? 'dark' : 'light'
+}
+
+export function applyThemePreference(theme = DEFAULT_THEME) {
+  const isDark = theme === 'dark' || (theme === 'system' && prefersDarkScheme())
+  document.documentElement.dataset.theme = theme
+  setColorScheme(isDark)
+  return isDark
+}
+
+export function onSystemThemeChange(callback) {
+  if (!systemThemeQuery || typeof callback !== 'function') return () => {}
+
+  const handler = (event) => callback(event.matches)
+
+  if (typeof systemThemeQuery.addEventListener === 'function') {
+    systemThemeQuery.addEventListener('change', handler)
+  } else if (typeof systemThemeQuery.addListener === 'function') {
+    systemThemeQuery.addListener(handler)
+  }
+
+  return () => {
+    if (typeof systemThemeQuery.removeEventListener === 'function') {
+      systemThemeQuery.removeEventListener('change', handler)
+    } else if (typeof systemThemeQuery.removeListener === 'function') {
+      systemThemeQuery.removeListener(handler)
+    }
+  }
+}
+
+export function getSystemPrefersDark() {
+  return prefersDarkScheme()
+}

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -8,17 +8,23 @@ function prefersDarkScheme() {
   return systemThemeQuery?.matches ?? false
 }
 
-function setColorScheme(isDark) {
+function setColorScheme(isDark, appliedTheme) {
   const root = document.documentElement
   root.classList.toggle('dark', isDark)
+  root.dataset.theme = appliedTheme
   root.style.colorScheme = isDark ? 'dark' : 'light'
+
+  const metaTheme = document.querySelector('meta[name="theme-color"]')
+  if (metaTheme) {
+    metaTheme.setAttribute('content', isDark ? '#0b0b0f' : '#f5f5f5')
+  }
 }
 
 export function applyThemePreference(theme = DEFAULT_THEME) {
   const isDark = theme === 'dark' || (theme === 'system' && prefersDarkScheme())
-  document.documentElement.dataset.theme = theme
-  setColorScheme(isDark)
-  return isDark
+  const appliedTheme = isDark ? 'dark' : 'light'
+  setColorScheme(isDark, appliedTheme)
+  return appliedTheme
 }
 
 export function onSystemThemeChange(callback) {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -141,6 +141,42 @@
         </header>
 
         <div class="space-y-6">
+          <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+            <div class="space-y-1">
+              <h3 class="text-base font-medium">Theme</h3>
+              <p class="text-sm text-neutral-600 dark:text-neutral-400">
+                Switch between light and dark modes or follow your system to preview palette updates.
+              </p>
+              <p class="text-xs text-neutral-500 dark:text-neutral-500">
+                System preference: {{ isSystemDark ? 'Dark' : 'Light' }}
+              </p>
+            </div>
+            <div class="flex flex-wrap items-center gap-2">
+              <label
+                v-for="option in themeOptions"
+                :key="option.value"
+                class="flex items-center gap-2 px-3 py-2 rounded-lg border cursor-pointer transition text-sm bg-white/70 dark:bg-neutral-800/70"
+                :class="[
+                  preferences.theme === option.value
+                    ? 'border-blue-500 text-blue-600 dark:border-blue-400 dark:text-blue-300'
+                    : 'border-neutral-200 text-neutral-700 hover:border-neutral-300 dark:border-neutral-700 dark:text-neutral-200 dark:hover:border-neutral-600'
+                ]"
+              >
+                <input
+                  class="sr-only"
+                  type="radio"
+                  name="theme-preference"
+                  :value="option.value"
+                  v-model="preferences.theme"
+                >
+                <div class="flex flex-col items-start leading-tight">
+                  <span class="font-medium">{{ option.label }}</span>
+                  <span class="text-xs text-neutral-500 dark:text-neutral-400">{{ option.description }}</span>
+                </div>
+              </label>
+            </div>
+          </div>
+
           <div class="flex items-start justify-between gap-6">
             <div>
               <h3 class="text-base font-medium">Auto-resume sessions</h3>
@@ -220,16 +256,24 @@
 </template>
 
 <script setup>
-import { computed, reactive, ref, watch, onMounted } from 'vue'
+import { computed, reactive, ref, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import BaseButton from '@/components/ui/input/BaseButton.vue'
 import BaseInput from '@/components/ui/input/BaseInput.vue'
 import { useAuth } from '@/composables/useAuth'
 import { supabase } from '@/utils/supabase'
+import { LOCAL_PREF_KEY, DEFAULT_THEME } from '@/constants/preferences'
+import { applyThemePreference, getSystemPrefersDark, onSystemThemeChange } from '@/utils/theme'
 
 const router = useRouter()
 const route = useRoute()
 const { user, sessionLoaded, tier, refreshTier, primeTier } = useAuth()
+
+const themeOptions = Object.freeze([
+  { value: 'system', label: 'System', description: 'Follow your device preference' },
+  { value: 'light', label: 'Light', description: 'Force a bright interface' },
+  { value: 'dark', label: 'Dark', description: 'Force a dim interface' },
+])
 
 const profileForm = reactive({
   displayName: '',
@@ -253,12 +297,14 @@ const avatarFailed = ref(false)
 
 const preferenceDefaults = Object.freeze({
   autoResumePlayback: false,
-  showInterfaceTips: true
+  showInterfaceTips: true,
+  theme: DEFAULT_THEME,
 })
 
 const preferences = reactive({
   autoResumePlayback: preferenceDefaults.autoResumePlayback,
-  showInterfaceTips: preferenceDefaults.showInterfaceTips
+  showInterfaceTips: preferenceDefaults.showInterfaceTips,
+  theme: preferenceDefaults.theme,
 })
 
 const preferenceInitial = ref({ ...preferenceDefaults })
@@ -271,7 +317,8 @@ const planStatusMessage = ref('')
 const planErrorMessage = ref('')
 const isProcessingCheckout = ref(false)
 
-const LOCAL_PREF_KEY = 'soundroom.userPreferences'
+const isSystemDark = ref(getSystemPrefersDark())
+let stopSystemThemeListener = () => {}
 
 const userEmail = computed(() => user.value?.email ?? 'Unknown user')
 const formattedUserId = computed(() => user.value?.id ?? '—')
@@ -387,6 +434,7 @@ function applyPreferences(source) {
   Object.entries(preferenceDefaults).forEach(([key, value]) => {
     preferences[key] = source[key] ?? value
   })
+  applyThemePreference(preferences.theme)
 }
 
 function loadPreferences() {
@@ -581,8 +629,26 @@ watch(hasPreferenceChanges, (dirty) => {
   }
 })
 
+watch(
+  () => preferences.theme,
+  () => {
+    applyThemePreference(preferences.theme)
+  }
+)
+
 onMounted(() => {
   loadPreferences()
   syncCheckoutIfNeeded()
+
+  stopSystemThemeListener = onSystemThemeChange((matches) => {
+    isSystemDark.value = matches
+    if (preferences.theme === 'system') {
+      applyThemePreference('system')
+    }
+  })
+})
+
+onBeforeUnmount(() => {
+  stopSystemThemeListener?.()
 })
 </script>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ const withAlpha = (variable) => `rgb(var(${variable}) / <alpha-value>)`
 
 module.exports = {
   important: true,
+  darkMode: 'class',
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- add centralized Sound Room canvas color tokens for both light and dark themes
- update SoundSourceNode and ListenerNode to use palette variables instead of hard-coded Konva fallbacks
- align Konva light/dark palette entries with new shared CSS variables

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923977b4b80832faffcb3bd3c6b8aa4)