### PR TITLE
Enhance contrast for sound library controls

### DIFF
--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -52,7 +52,7 @@
         to="/room-manager"
         aria-label="Open Room Manager"
       >
-        <BaseButton class="w-full">
+        <BaseButton class="w-full !bg-[var(--color-accent-strong)] !text-[var(--color-text-inverse)] hover:!bg-[var(--color-accent)]">
           RoomManager
         </BaseButton>
       </RouterLink>

--- a/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
@@ -20,7 +20,7 @@
   <button
     :disabled="soundLibrarySources.length == MAX_SOURCES"
     @click="() => { router.push('/sound-library') }"
-    class="w-full mt-4 bg-[var(--color-bg-surface)] text-xs rounded hover:bg-[var(--color-bg-elevated)] border border-[var(--color-border-subtle)] text-[var(--color-text-primary)]"
+    class="w-full mt-4 text-xs rounded bg-[var(--color-accent)] hover:bg-[var(--color-accent-strong)] text-[var(--color-text-inverse)] border border-[var(--color-border-strong)] shadow-[var(--color-shadow-soft)] focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]"
   >
     + Add Source
   </button>

--- a/src/components/ui/modals/SoundLibrary/CategoryList.vue
+++ b/src/components/ui/modals/SoundLibrary/CategoryList.vue
@@ -5,6 +5,7 @@
       v-if="isAuthenticated"
       :key="'your-sounds'"
       @click="handleSelectYourSounds"
+      variant="naked"
       :class="['sound-lib-button', { active: active === 'your-sounds', locked: !canUpload }]"
     >
       <span class="button-inner">
@@ -17,6 +18,7 @@
       v-for="cat in categories"
       :key="cat.id"
       @click="$emit('update:active', cat.id)"
+      variant="naked"
       :class="['sound-lib-button', { active: active === cat.id }]"
     >
       {{ cat.label }}
@@ -59,12 +61,22 @@ function handleSelectYourSounds() {
   padding: 0.5rem 0.75rem;
   font-size: 0.875rem;
   border-radius: 0.375rem;
-  transition: background-color 0.2s;
+  transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
+  background-color: color-mix(in srgb, var(--color-bg-surface) 82%, transparent);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-subtle);
+  box-shadow: var(--color-shadow-soft);
 }
-.sound-lib-button:hover { background-color: color-mix(in srgb, var(--color-bg-surface) 85%, transparent); }
+.sound-lib-button:hover {
+  background-color: color-mix(in srgb, var(--color-accent-soft) 70%, var(--color-bg-surface));
+  border-color: var(--color-border-strong);
+}
 .sound-lib-button.active {
   font-weight: 600;
-  background-color: color-mix(in srgb, var(--color-bg-elevated) 80%, transparent);
+  background-color: color-mix(in srgb, var(--color-accent) 55%, var(--color-bg-elevated));
+  color: var(--color-text-inverse);
+  border-color: var(--color-border-strong);
+  box-shadow: var(--color-shadow-strong);
 }
 
 .sound-lib-button.locked {

--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex-1 relative overflow-hidden">
-    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[color-mix(in_srgb,var(--color-bg-surface)_70%,transparent)] backdrop-blur-md border-b border-border-subtle text-text-primary">
+    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[var(--color-bg-elevated)] shadow-[var(--color-shadow-soft)] border-b border-border-strong text-text-primary">
       <h2 class="text-2xl font-bold">SoundLibrary</h2>
       <BaseButton class="text-sm" @click="$emit('close')">Close</BaseButton>
     </div>

--- a/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :class="[
-      'relative aspect-square flex flex-col items-center justify-between p-4 rounded-xl bg-surface-base text-text-primary shadow border-border-subtle border transition-shadow duration-200',
+      'relative aspect-square flex flex-col items-center justify-between p-4 rounded-xl bg-surface-raised text-text-primary shadow-[var(--color-shadow-soft)] border border-border-strong transition-shadow duration-200',
       highlightClass
     ]"
   >
@@ -24,7 +24,7 @@
     />
 
     <BaseButton
-      class="load-BaseButton text-xs px-3 py-1 rounded transition-colors mt-2 bg-[var(--color-bg-elevated)] hover:bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] border border-border-subtle"
+      class="load-BaseButton text-xs px-3 py-1 rounded transition-colors mt-2 bg-[var(--color-accent)] hover:bg-[var(--color-accent-strong)] text-[var(--color-text-inverse)] border border-border-strong shadow-[var(--color-shadow-soft)]"
       @click="handleToggle"
       :disabled="waiting || sound.send"
     >


### PR DESCRIPTION
## Summary
- restyle sound library category buttons, grid header, and items to use higher-contrast theme tokens
- update load/add controls and Room Manager entry to emphasize primary accent styling
- improve visual hierarchy with stronger borders, shadows, and inverse text where appropriate

## Testing
- not run (dev server missing @sentry/vite-plugin dependency)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925018cfa78832f9ccf94f3463813a2)