### PR TITLE
Improve contrast for Sound Library controls

### DIFF
--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -52,7 +52,7 @@
         to="/room-manager"
         aria-label="Open Room Manager"
       >
-        <BaseButton class="w-full border border-border-strong shadow-strong">
+        <BaseButton class="w-full px-4 py-2 rounded text-sm font-semibold bg-[var(--color-accent)] hover:bg-[var(--color-accent-strong)] text-[var(--color-text-inverse)] border border-border-strong shadow-strong">
           RoomManager
         </BaseButton>
       </RouterLink>

--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -52,7 +52,7 @@
         to="/room-manager"
         aria-label="Open Room Manager"
       >
-        <BaseButton class="w-full px-4 py-2 rounded text-sm font-semibold bg-[var(--color-accent)] hover:bg-[var(--color-accent-strong)] text-[var(--color-text-inverse)] border border-border-strong shadow-strong">
+        <BaseButton class="w-full px-4 py-2 rounded text-sm font-semibold bg-[var(--color-accent)] hover:bg-[var(--color-accent-strong)] text-[var(--color-text-inverse)] border border-[var(--color-accent)] shadow-[var(--color-shadow-soft)] focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]">
           RoomManager
         </BaseButton>
       </RouterLink>

--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -52,7 +52,7 @@
         to="/room-manager"
         aria-label="Open Room Manager"
       >
-        <BaseButton class="w-full">
+        <BaseButton class="w-full border border-border-strong shadow-strong">
           RoomManager
         </BaseButton>
       </RouterLink>

--- a/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
@@ -20,7 +20,7 @@
   <button
     :disabled="soundLibrarySources.length == MAX_SOURCES"
     @click="() => { router.push('/sound-library') }"
-    class="w-full mt-4 text-xs font-semibold rounded bg-accent text-[var(--color-text-inverse)] hover:bg-accent-strong border border-[var(--color-accent)] shadow-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]"
+    class="w-full mt-4 text-xs font-semibold rounded bg-[var(--color-accent)] text-[var(--color-text-inverse)] hover:bg-[var(--color-accent-strong)] border border-[var(--color-accent)] shadow-[var(--color-shadow-soft)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]"
   >
     + Add Source
   </button>

--- a/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
@@ -20,7 +20,7 @@
   <button
     :disabled="soundLibrarySources.length == MAX_SOURCES"
     @click="() => { router.push('/sound-library') }"
-    class="w-full mt-4 bg-[var(--color-bg-surface)] text-xs rounded hover:bg-[var(--color-bg-elevated)] border border-[var(--color-border-subtle)] text-[var(--color-text-primary)]"
+    class="w-full mt-4 text-xs font-semibold rounded bg-accent text-[var(--color-text-inverse)] hover:bg-accent-strong border border-border-strong shadow-soft focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]"
   >
     + Add Source
   </button>

--- a/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
@@ -20,7 +20,7 @@
   <button
     :disabled="soundLibrarySources.length == MAX_SOURCES"
     @click="() => { router.push('/sound-library') }"
-    class="w-full mt-4 text-xs font-semibold rounded bg-accent text-[var(--color-text-inverse)] hover:bg-accent-strong border border-border-strong shadow-soft focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]"
+    class="w-full mt-4 text-xs font-semibold rounded bg-accent text-[var(--color-text-inverse)] hover:bg-accent-strong border border-[var(--color-accent)] shadow-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]"
   >
     + Add Source
   </button>

--- a/src/components/ui/modals/SoundLibrary/CategoryList.vue
+++ b/src/components/ui/modals/SoundLibrary/CategoryList.vue
@@ -1,10 +1,11 @@
 <template>
-  <aside class="w-60 bg-surface-base text-text-primary border-r border-border-subtle p-4 space-y-3 overflow-y-auto">
+  <aside class="w-60 bg-surface-raised text-text-primary border-r border-border-strong p-4 space-y-3 overflow-y-auto shadow-soft">
     <h2 class="font-bold text-sm mb-2">Categories</h2>
     <BaseButton
       v-if="isAuthenticated"
       :key="'your-sounds'"
       @click="handleSelectYourSounds"
+      variant="naked"
       :class="['sound-lib-button', { active: active === 'your-sounds', locked: !canUpload }]"
     >
       <span class="button-inner">
@@ -17,6 +18,7 @@
       v-for="cat in categories"
       :key="cat.id"
       @click="$emit('update:active', cat.id)"
+      variant="naked"
       :class="['sound-lib-button', { active: active === cat.id }]"
     >
       {{ cat.label }}
@@ -59,12 +61,20 @@ function handleSelectYourSounds() {
   padding: 0.5rem 0.75rem;
   font-size: 0.875rem;
   border-radius: 0.375rem;
-  transition: background-color 0.2s;
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border-subtle);
+  transition: background-color 0.2s, border-color 0.2s, color 0.2s;
 }
-.sound-lib-button:hover { background-color: color-mix(in srgb, var(--color-bg-surface) 85%, transparent); }
+.sound-lib-button:hover {
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border-strong);
+}
 .sound-lib-button.active {
   font-weight: 600;
-  background-color: color-mix(in srgb, var(--color-bg-elevated) 80%, transparent);
+  background-color: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-strong);
+  color: var(--color-text-primary);
 }
 
 .sound-lib-button.locked {

--- a/src/components/ui/modals/SoundLibrary/CategoryList.vue
+++ b/src/components/ui/modals/SoundLibrary/CategoryList.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside class="w-60 bg-[var(--color-panel)] text-text-primary border-r border-border-strong p-4 space-y-3 overflow-y-auto shadow-strong">
+  <aside class="w-60 bg-[var(--color-bg-elevated)] text-text-primary border-r border-border-strong p-4 space-y-3 overflow-y-auto shadow-strong">
     <h2 class="font-bold text-sm mb-2">Categories</h2>
     <BaseButton
       v-if="isAuthenticated"
@@ -60,21 +60,28 @@ function handleSelectYourSounds() {
   text-align: left;
   padding: 0.5rem 0.75rem;
   font-size: 0.875rem;
-  border-radius: 0.375rem;
+  border-radius: 0.5rem;
   color: var(--color-text-primary);
-  background-color: var(--color-surface-muted);
-  border: 1px solid var(--color-border-strong);
-  transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+  background-color: var(--color-bg-surface);
+  border: 1px solid var(--color-border-subtle);
+  box-shadow: var(--color-shadow-soft);
+  transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s;
 }
 .sound-lib-button:hover {
   background-color: var(--color-bg-elevated);
   border: 1px solid var(--color-border-strong);
+  box-shadow: var(--color-shadow-soft);
+}
+.sound-lib-button:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
 }
 .sound-lib-button.active {
-  font-weight: 600;
-  background-color: var(--color-bg-elevated);
+  font-weight: 700;
+  background-color: var(--color-accent-soft);
   border: 1px solid var(--color-accent);
-  color: var(--color-text-primary);
+  color: var(--color-text-inverse);
+  box-shadow: 0 0 0 3px rgba(var(--color-accent-rgb), 0.22);
 }
 
 .sound-lib-button.locked {

--- a/src/components/ui/modals/SoundLibrary/CategoryList.vue
+++ b/src/components/ui/modals/SoundLibrary/CategoryList.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside class="w-60 bg-surface-raised text-text-primary border-r border-border-strong p-4 space-y-3 overflow-y-auto shadow-soft">
+  <aside class="w-60 bg-[var(--color-panel)] text-text-primary border-r border-border-strong p-4 space-y-3 overflow-y-auto shadow-strong">
     <h2 class="font-bold text-sm mb-2">Categories</h2>
     <BaseButton
       v-if="isAuthenticated"
@@ -62,18 +62,18 @@ function handleSelectYourSounds() {
   font-size: 0.875rem;
   border-radius: 0.375rem;
   color: var(--color-text-primary);
-  background-color: var(--color-bg-surface);
-  border: 1px solid var(--color-border-subtle);
+  background-color: var(--color-surface-muted);
+  border: 1px solid var(--color-border-strong);
   transition: background-color 0.2s, border-color 0.2s, color 0.2s;
 }
 .sound-lib-button:hover {
-  background-color: var(--color-bg-surface);
+  background-color: var(--color-bg-elevated);
   border: 1px solid var(--color-border-strong);
 }
 .sound-lib-button.active {
   font-weight: 600;
   background-color: var(--color-bg-elevated);
-  border: 1px solid var(--color-border-strong);
+  border: 1px solid var(--color-accent);
   color: var(--color-text-primary);
 }
 

--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex-1 relative overflow-hidden">
-    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[color-mix(in_srgb,var(--color-bg-surface)_70%,transparent)] backdrop-blur-md border-b border-border-subtle text-text-primary">
+    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-surface-raised border-b border-border-strong text-text-primary shadow-soft">
       <h2 class="text-2xl font-bold">SoundLibrary</h2>
       <BaseButton class="text-sm" @click="$emit('close')">Close</BaseButton>
     </div>
@@ -25,7 +25,7 @@
     </div>
      <div
         v-if="isAuthenticated && activeCategory === 'your-sounds'"
-        class="absolute bottom-0 left-0 right-0 p-4 bg-surface-base border-t border-border-subtle text-text-primary"
+        class="absolute bottom-0 left-0 right-0 p-4 bg-surface-raised border-t border-border-strong text-text-primary shadow-soft"
       >
         <div class="flex items-center justify-between gap-3">
           <button

--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex-1 relative overflow-hidden">
-    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-surface-raised border-b border-border-strong text-text-primary shadow-soft">
+    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[var(--color-panel)] border-b border-border-strong text-text-primary shadow-strong">
       <h2 class="text-2xl font-bold">SoundLibrary</h2>
       <BaseButton class="text-sm" @click="$emit('close')">Close</BaseButton>
     </div>
@@ -25,7 +25,7 @@
     </div>
      <div
         v-if="isAuthenticated && activeCategory === 'your-sounds'"
-        class="absolute bottom-0 left-0 right-0 p-4 bg-surface-raised border-t border-border-strong text-text-primary shadow-soft"
+        class="absolute bottom-0 left-0 right-0 p-4 bg-[var(--color-panel)] border-t border-border-strong text-text-primary shadow-strong"
       >
         <div class="flex items-center justify-between gap-3">
           <button

--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="flex-1 relative overflow-hidden">
-    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[var(--color-panel)] border-b border-border-strong text-text-primary shadow-strong">
+    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[var(--color-bg-elevated)] border-b border-border-strong text-text-primary shadow-strong">
       <h2 class="text-2xl font-bold">SoundLibrary</h2>
-      <BaseButton class="text-sm" @click="$emit('close')">Close</BaseButton>
+      <BaseButton class="text-sm bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] border border-[var(--color-border-strong)] hover:bg-[var(--color-bg-elevated)] shadow-[var(--color-shadow-soft)]" @click="$emit('close')">Close</BaseButton>
     </div>
     <div ref="gridScroll" class="mt-5 place-content-start p-6 pt-20 overflow-y-auto h-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
       <SoundGridItem
@@ -25,7 +25,7 @@
     </div>
      <div
         v-if="isAuthenticated && activeCategory === 'your-sounds'"
-        class="absolute bottom-0 left-0 right-0 p-4 bg-[var(--color-panel)] border-t border-border-strong text-text-primary shadow-strong"
+        class="absolute bottom-0 left-0 right-0 p-4 bg-[var(--color-bg-elevated)] border-t border-border-strong text-text-primary shadow-strong"
       >
         <div class="flex items-center justify-between gap-3">
           <button

--- a/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :class="[
-      'relative aspect-square flex flex-col items-center justify-between p-4 rounded-xl bg-[var(--color-surface-muted)] text-text-primary shadow-strong border-border-strong border transition-shadow duration-200',
+      'relative aspect-square flex flex-col items-center justify-between p-4 rounded-xl bg-[var(--color-bg-surface)] text-text-primary shadow-[var(--color-shadow-soft)] border border-[var(--color-border-subtle)] hover:border-[var(--color-border-strong)] focus-within:border-[var(--color-border-strong)] focus-within:ring-2 focus-within:ring-[var(--color-focus-ring)] focus-within:ring-offset-2 focus-within:ring-offset-[var(--color-bg-elevated)] transition-shadow duration-200',
       highlightClass
     ]"
   >
@@ -24,7 +24,7 @@
     />
 
     <BaseButton
-      class="load-BaseButton text-xs px-3 py-1 rounded transition-colors mt-2 bg-accent text-[var(--color-text-inverse)] hover:bg-accent-strong border border-border-strong shadow-soft"
+      class="load-BaseButton text-xs px-3 py-1 rounded transition-colors mt-2 bg-[var(--color-accent)] text-[var(--color-text-inverse)] hover:bg-[var(--color-accent-strong)] border border-[var(--color-accent)] shadow-soft focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-elevated)]"
       @click="handleToggle"
       :disabled="waiting || sound.send"
     >

--- a/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :class="[
-      'relative aspect-square flex flex-col items-center justify-between p-4 rounded-xl bg-surface-raised text-text-primary shadow-soft border-border-strong border transition-shadow duration-200',
+      'relative aspect-square flex flex-col items-center justify-between p-4 rounded-xl bg-[var(--color-surface-muted)] text-text-primary shadow-strong border-border-strong border transition-shadow duration-200',
       highlightClass
     ]"
   >

--- a/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :class="[
-      'relative aspect-square flex flex-col items-center justify-between p-4 rounded-xl bg-surface-base text-text-primary shadow border-border-subtle border transition-shadow duration-200',
+      'relative aspect-square flex flex-col items-center justify-between p-4 rounded-xl bg-surface-raised text-text-primary shadow-soft border-border-strong border transition-shadow duration-200',
       highlightClass
     ]"
   >
@@ -24,7 +24,7 @@
     />
 
     <BaseButton
-      class="load-BaseButton text-xs px-3 py-1 rounded transition-colors mt-2 bg-[var(--color-bg-elevated)] hover:bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] border border-border-subtle"
+      class="load-BaseButton text-xs px-3 py-1 rounded transition-colors mt-2 bg-accent text-[var(--color-text-inverse)] hover:bg-accent-strong border border-border-strong shadow-soft"
       @click="handleToggle"
       :disabled="waiting || sound.send"
     >


### PR DESCRIPTION
## Summary
- Raise contrast in Sound Library surfaces, buttons, and grid headers using stronger surface and border tokens
- Emphasize call-to-action buttons such as Add Source and Load with accent backgrounds and clearer focus styling
- Add stronger emphasis to the Room Manager entry point via bolder border and shadow tokens

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692503d28200832fa3fd3519206f42af)