### PR TITLE
Refactor theme tokens into Tailwind classes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,27 +5,27 @@
   <div class="h-screen max-h-screen min-w-screen flex flex-col">
     <HeaderBar />
     <div class="flex-1 min-h-0 flex flex-col">
-      <div
-        v-if="globalError"
-        class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-[var(--color-bg-app)] text-[var(--color-text-primary)]"
-      >
-        <p class="text-sm uppercase tracking-[0.2em] text-[var(--color-danger)] mb-3">Navigation error</p>
-        <h2 class="text-2xl font-semibold mb-3">We couldn't load that page.</h2>
-        <p class="max-w-md text-[var(--color-text-muted)] mb-8">
-          {{ globalError.message }}
-        </p>
-        <div class="flex flex-wrap items-center justify-center gap-3">
-          <BaseButton @click="retryGlobalError">
-            Try again
-          </BaseButton>
-          <BaseButton
-            variant="naked"
-            class="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] text-sm font-medium"
-            @click="returnHome"
-          >
-            Go back home
-          </BaseButton>
-        </div>
+        <div
+          v-if="globalError"
+          class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-surface-app text-text-primary"
+        >
+          <p class="text-sm uppercase tracking-[0.2em] text-status-danger mb-3">Navigation error</p>
+          <h2 class="text-2xl font-semibold mb-3">We couldn't load that page.</h2>
+          <p class="max-w-md text-text-muted mb-8">
+            {{ globalError.message }}
+          </p>
+          <div class="flex flex-wrap items-center justify-center gap-3">
+            <BaseButton @click="retryGlobalError">
+              Try again
+            </BaseButton>
+            <BaseButton
+              variant="naked"
+              class="text-text-secondary hover:text-text-primary text-sm font-medium"
+              @click="returnHome"
+            >
+              Go back home
+            </BaseButton>
+          </div>
       </div>
       <RouterView v-else v-slot="{ Component, route }">
         <Suspense>
@@ -37,10 +37,10 @@
             </ErrorBoundary>
           </template>
           <template #fallback>
-            <div class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-[var(--color-bg-app)] text-[var(--color-text-primary)]">
-              <p class="text-sm uppercase tracking-[0.2em] text-[var(--color-accent)] mb-3">Loading</p>
+            <div class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-surface-app text-text-primary">
+              <p class="text-sm uppercase tracking-[0.2em] text-accent mb-3">Loading</p>
               <h2 class="text-2xl font-semibold mb-3">Preparing SoundRoom…</h2>
-              <p class="max-w-md text-[var(--color-text-muted)]">
+              <p class="max-w-md text-text-muted">
                 Hang tight while we load the experience.
               </p>
             </div>

--- a/src/components/Settings/ThemeSelector.vue
+++ b/src/components/Settings/ThemeSelector.vue
@@ -1,8 +1,8 @@
 <template>
-  <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] p-6 shadow-sm space-y-6">
+  <section class="rounded-2xl border border-border-subtle bg-surface-base/90 p-6 shadow-sm space-y-6">
     <header class="space-y-2">
       <h2 class="text-xl font-semibold">Appearance</h2>
-      <p class="text-sm text-[var(--color-text-muted)]">Pick a theme and preview its palette.</p>
+      <p class="text-sm text-text-muted">Pick a theme and preview its palette.</p>
     </header>
 
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -13,9 +13,9 @@
         class="relative flex flex-col gap-3 rounded-xl border p-4 text-left transition duration-200"
         :class="[
           activeTheme === theme.name
-            ? 'border-[var(--color-accent-soft)] ring-2 ring-[color-mix(in_srgb,var(--color-accent)_65%,transparent)] shadow-md'
-            : 'border-border-subtle hover:border-[var(--color-border-strong)] hover:shadow-sm',
-          'bg-[color-mix(in_srgb,var(--color-bg-elevated)_86%,transparent)] hover:-translate-y-0.5 hover:scale-[1.01]'
+            ? 'border-accent-soft ring-2 ring-[color-mix(in_srgb,var(--color-accent)_65%,transparent)] shadow-md'
+            : 'border-border-subtle hover:border-border-strong hover:shadow-sm',
+          'bg-surface-raised/86 hover:-translate-y-0.5 hover:scale-[1.01]'
         ]"
         :style="previewStyle(theme.name)"
         @click="selectTheme(theme.name)"
@@ -23,11 +23,11 @@
         <div class="flex items-center justify-between">
           <div class="space-y-1">
             <p class="text-sm font-semibold">{{ theme.label }}</p>
-            <p class="text-xs text-[var(--color-text-muted)]">Preview.</p>
+            <p class="text-xs text-text-muted">Preview.</p>
           </div>
           <span
             v-if="activeTheme === theme.name"
-            class="text-[11px] font-medium rounded-full px-2 py-1 bg-[color-mix(in_srgb,var(--color-accent)_16%,transparent)] text-[var(--color-text-primary)]"
+            class="text-[11px] font-medium rounded-full px-2 py-1 bg-accent/16 text-text-primary"
           >
             Active
           </span>

--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -26,7 +26,7 @@
       <BaseButton
         @click="showSaveConfirm = true"
         :disabled="isSaving || !isRoomSaveable"
-        class="px-3 py-2 rounded bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] border border-[var(--color-border-subtle)] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+        class="px-3 py-2 rounded bg-surface-base hover:bg-surface-raised text-text-primary border border-border-subtle transition focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
         type="button"
         aria-label="Open save room confirmation"
       >
@@ -36,7 +36,7 @@
       <BaseButton
         @click="showNewRoomConfirm = true"
         :disabled="isSaving || isRoomEmpty"
-        class="px-3 py-2 rounded bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] border border-[var(--color-border-subtle)] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+        class="px-3 py-2 rounded bg-surface-base hover:bg-surface-raised text-text-primary border border-border-subtle transition focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
         type="button"
         aria-label="Open new room confirmation"
       >

--- a/src/components/SoundRoom/HeaderBar.vue
+++ b/src/components/SoundRoom/HeaderBar.vue
@@ -1,14 +1,14 @@
 <template>
   <PulsingOverlay v-if="isLoggingOut" :duration="2000" :text="'Logging out...'" @done="isLoggingOut = false" />
-  <header class="px-6 py-4 border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] flex items-center justify-between relative">
-    <h1 class="text-xl font-bold tracking-wide text-[var(--color-text-primary)]"><RouterLink to="/" style="text-decoration: none; color: inherit;">SoundRoom</RouterLink></h1>
+  <header class="px-6 py-4 border-b border-border-subtle bg-surface-base text-text-primary flex items-center justify-between relative">
+    <h1 class="text-xl font-bold tracking-wide text-text-primary"><RouterLink to="/" style="text-decoration: none; color: inherit;">SoundRoom</RouterLink></h1>
     
     <div v-if="shouldShowNavButtons" class="relative">
       <button
         ref="menuButton"
         type="button"
         @click="toggleMenu"
-        class="flex items-center justify-center w-12 h-12 !p-1 !bg-transparent text-[var(--color-text-primary)]"
+        class="flex items-center justify-center w-12 h-12 !p-1 !bg-transparent text-text-primary"
         :aria-expanded="isMenuOpen"
         aria-haspopup="true"
       >
@@ -21,11 +21,11 @@
           v-if="isMenuOpen"
           @mouseleave="closeMenu"
           ref="menuPanel"
-          class="absolute right-0 mt-2 w-44 rounded-lg shadow-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] py-2 z-50 flex flex-col divide-y divide-[var(--color-border-subtle)] overflow-hidden"
+          class="absolute right-0 mt-2 w-44 rounded-lg shadow-lg border border-border-subtle bg-surface-raised text-text-primary py-2 z-50 flex flex-col divide-y divide-border-subtle overflow-hidden"
         >
           <template v-for="button in visibleButtons" :key="button.label">
             <button
-              class="w-full px-4 py-2 text-left text-sm text-[var(--color-text-primary)] hover:bg-[color-mix(in_srgb,var(--color-bg-surface)_85%,transparent)] focus:outline-none !bg-transparent"
+              class="w-full px-4 py-2 text-left text-sm text-text-primary hover:bg-surface-base/85 focus:outline-none !bg-transparent"
               type="button"
               @click="runAction(button.action)"
             >

--- a/src/components/SoundRoom/IRSelect.vue
+++ b/src/components/SoundRoom/IRSelect.vue
@@ -2,7 +2,7 @@
   <select
     v-model="selectedIR"
     @change="applyIR"
-    class="px-2 py-1 w-32 rounded border text-sm bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] border-[var(--color-border-subtle)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]"
+    class="px-2 py-1 w-32 rounded border text-sm bg-surface-base text-text-primary border-border-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base"
   >
     <option v-for="ir in irOptions" :key="ir.value" :value="ir.value">
       {{ ir.label }}

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -4,7 +4,7 @@
     role="application"
     tabindex="0"
     aria-label="SoundRoom 2D audio environment. Use keyboard or mouse to interact with sound nodes."
-    class="canvas-grid relative border border-[var(--color-border-subtle)] dark:border-2 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] shadow-[var(--color-shadow-soft)]"
+    class="canvas-grid relative border border-border-subtle dark:border-2 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-focus shadow-soft"
     :class="`w-[${room.width}px] h-[${room.height}px]`"
     @dragover.prevent
     @drop="handleDrop"

--- a/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
@@ -2,11 +2,11 @@
   <section class="flex flex-col h-full">
   <ContextMenu ref="menuRef" :functionList="[{ label: 'Delete', function: deleteSound }]" />
 
-  <h5 class="text-sm font-semibold uppercase text-[var(--color-text-muted)]">
+  <h5 class="text-sm font-semibold uppercase text-text-muted">
     Sound Sources
   </h5>
 
-  <ul class="overflow-y-auto space-y-2 text-sm text-[var(--color-text-primary)]"
+  <ul class="overflow-y-auto space-y-2 text-sm text-text-primary"
   :class="{ 'flex-1 mt-4': soundLibrarySources.length > 0 }">
     <LibrarySource 
       v-for="s in soundLibrarySources"
@@ -20,7 +20,7 @@
   <button
     :disabled="soundLibrarySources.length == MAX_SOURCES"
     @click="() => { router.push('/sound-library') }"
-    class="w-full mt-4 bg-[var(--color-bg-surface)] text-xs rounded hover:bg-[var(--color-bg-elevated)] border border-[var(--color-border-subtle)] text-[var(--color-text-primary)]"
+    class="w-full mt-4 bg-surface-base text-xs rounded hover:bg-surface-raised border border-border-subtle text-text-primary"
   >
     + Add Source
   </button>

--- a/src/components/SoundRoom/SidebarLeft/ListenerReadout.vue
+++ b/src/components/SoundRoom/SidebarLeft/ListenerReadout.vue
@@ -1,6 +1,6 @@
 <template>
-  <section class="text-[var(--color-text-primary)]">
-    <h5 class="text-sm font-semibold uppercase text-[var(--color-text-muted)] mb-2">Listener</h5>
+  <section class="text-text-primary">
+    <h5 class="text-sm font-semibold uppercase text-text-muted mb-2">Listener</h5>
     <div class="text-xs space-y-1">
       <p>X: {{ store.listener.x }}</p>
       <p>Y: {{ store.listener.y }}</p>

--- a/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
+++ b/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-[var(--color-bg-elevated)] border-r border-[var(--color-border-subtle)] p-4 space-y-6 text-[var(--color-text-primary)]"
+    class="flex flex-col h-full bg-surface-raised border-r border-border-subtle p-4 space-y-6 text-text-primary"
     role="region"
     aria-labelledby="library-panel-label"
   >

--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -1,12 +1,12 @@
 <template>
-  <section class="text-[var(--color-text-primary)]">
-    <h5 class="text-sm font-semibold uppercase text-[var(--color-text-muted)] mb-2">
+  <section class="text-text-primary">
+    <h5 class="text-sm font-semibold uppercase text-text-muted mb-2">
       Selected Source
     </h5>
 
     <div v-if="selectedSource" class="space-y-6 flex flex-col items-center">
       <!-- Readouts -->
-      <div class="space-y-1 text-xs text-[var(--color-text-muted)]">
+      <div class="space-y-1 text-xs text-text-muted">
         <h4>{{ selectedSource.name }}</h4>
         <p>X: {{ cleanSourceXY.x }}</p>
         <p>Y: {{ cleanSourceXY.y }}</p>
@@ -33,22 +33,22 @@
       <div class="w-full space-y-2">
         <button
           @click="playPauseSource"
-          class="w-full bg-[var(--color-bg-surface)] text-xs rounded hover:bg-[var(--color-bg-elevated)] border border-[var(--color-border-subtle)] text-[var(--color-text-primary)]"
+          class="w-full bg-surface-base text-xs rounded hover:bg-surface-raised border border-border-subtle text-text-primary"
         >
           {{ playPauseLabel }}
         </button>
         <button
           @click="deleteSource"
-          class="w-full bg-[var(--color-bg-surface)] text-xs rounded hover:bg-[var(--color-bg-elevated)] border border-[var(--color-border-subtle)] text-[var(--color-text-primary)]"
+          class="w-full bg-surface-base text-xs rounded hover:bg-surface-raised border border-border-subtle text-text-primary"
         >
           Delete
         </button>
       </div>
 
-      <hr class="w-full border-[var(--color-border-subtle)]" />
+      <hr class="w-full border-border-subtle" />
 
       <!-- Scheduling Toggle -->
-      <div class="w-full flex items-center space-x-2 text-left px-1 text-[var(--color-text-muted)]">
+      <div class="w-full flex items-center space-x-2 text-left px-1 text-text-muted">
         <input
           type="checkbox"
           :checked="schedulingEnabled"
@@ -60,7 +60,7 @@
       </div>
       <p
         v-if="!canUseTimedLoops"
-        class="w-full px-1 text-left text-xs text-[var(--color-warning)]"
+        class="w-full px-1 text-left text-xs text-status-warning"
       >
         Upgrade to unlock timed loops for automated playback.
       </p>
@@ -68,7 +68,7 @@
       <!-- Scheduling Settings -->
       <div
         v-if="schedulingEnabled && canUseTimedLoops"
-        class="space-y-4 w-full text-xs text-[var(--color-text-muted)] px-1"
+        class="space-y-4 w-full text-xs text-text-muted px-1"
       >
         <!-- Mode -->
         <div class="flex flex-col space-y-1">
@@ -77,7 +77,7 @@
             :value="schedule.mode"
             @change="handleScheduleModeChange"
             @blur="commitScheduleEdit"
-            class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]">
+            class="px-2 py-1 rounded border border-border-subtle bg-surface-raised">
             <option value="interval">Interval</option>
             <option v-if="canUseAdvancedScheduling" value="count">Count</option>
             <option v-if="canUseAdvancedScheduling" value="interval+count">Interval + Count</option>
@@ -99,7 +99,7 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+              class="px-2 py-1 rounded border border-border-subtle bg-surface-raised"
             />
           </div>
           <div class="flex flex-col space-y-1">
@@ -116,9 +116,9 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+              class="px-2 py-1 rounded border border-border-subtle bg-surface-raised"
             />
-            <p v-if="schedule.gapMax < schedule.gapMin" class="text-[var(--color-danger)] text-xs">
+            <p v-if="schedule.gapMax < schedule.gapMin" class="text-status-danger text-xs">
               Gap Max cannot be smaller than Gap Min
             </p>
           </div>
@@ -140,7 +140,7 @@
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
               placeholder="Unlimited"
-              class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+              class="px-2 py-1 rounded border border-border-subtle bg-surface-raised"
             />
           </div>
           <div class="flex flex-col space-y-1">
@@ -156,7 +156,7 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+              class="px-2 py-1 rounded border border-border-subtle bg-surface-raised"
             />
           </div>
           <div class="flex flex-col space-y-1">
@@ -171,7 +171,7 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+              class="px-2 py-1 rounded border border-border-subtle bg-surface-raised"
             />
           </div>
         </div>

--- a/src/components/SoundRoom/SidebarRight/SidebarRight.vue
+++ b/src/components/SoundRoom/SidebarRight/SidebarRight.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-[var(--color-bg-elevated)] border-l border-[var(--color-border-subtle)] p-4 space-y-4 text-[var(--color-text-primary)]"
+    class="flex flex-col h-full bg-surface-raised border-l border-border-subtle p-4 space-y-4 text-text-primary"
     role="region"
     aria-labelledby="selected-sound-panel-label"
   >

--- a/src/components/SoundRoom/Toolbar.vue
+++ b/src/components/SoundRoom/Toolbar.vue
@@ -1,28 +1,28 @@
 <template>
-  <div class="flex items-center justify-between p-3 border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] space-x-10 w-full shadow-[var(--color-shadow-soft)] text-[var(--color-text-primary)]">
+  <div class="flex items-center justify-between p-3 border-border-subtle bg-surface-raised space-x-10 w-full shadow-soft text-text-primary">
           
     <div class="flex space-x-2 w-1/3">
       <BaseButton
       :disabled="audioEngine.soundSources.value.length === 0"
       @click="isPlaying ? audioEngine.pauseAll() : audioEngine.playAll()"
-      class="px-3 py-1 rounded text-sm bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)]"
+      class="px-3 py-1 rounded text-sm bg-surface-base hover:bg-surface-raised text-text-primary"
       > 
         
-        <component :is="isPlaying ? Pause : Play" class="h-4 w-4 fill-[var(--color-text-primary)]" />
+        <component :is="isPlaying ? Pause : Play" class="h-4 w-4 fill-text-primary" />
       </BaseButton>
       <BaseButton
         :disabled="actionStackEmpty || waiting"
         @click="actionManager.undoLastAction"
-        class="px-3 py-1 rounded text-sm bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)]"
+        class="px-3 py-1 rounded text-sm bg-surface-base hover:bg-surface-raised text-text-primary"
       >
-        <UndoRedo class="h-4 w-4 fill-[var(--color-text-primary)]"/>
+        <UndoRedo class="h-4 w-4 fill-text-primary"/>
       </BaseButton>
       <BaseButton
         :disabled="redoStackEmpty || waiting"
         @click="actionManager.redoLastAction"
-        class="px-3 py-1 rounded text-sm bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)]"
+        class="px-3 py-1 rounded text-sm bg-surface-base hover:bg-surface-raised text-text-primary"
       >
-        <UndoRedo class="h-4 w-4 scale-x-[-1] fill-[var(--color-text-primary)]"/>
+        <UndoRedo class="h-4 w-4 scale-x-[-1] fill-text-primary"/>
       </BaseButton>
     </div>
     <EditableRoomName
@@ -34,7 +34,7 @@
     />
     <div class="flex items-center justify-center space-x-2 w-1/3">
      
-      <span class="text-xs text-[var(--color-text-muted)]">Master</span>
+      <span class="text-xs text-text-muted">Master</span>
       <VueSlider 
         v-model="audioEngine.masterVolume.value"
         :min="0" 

--- a/src/components/ui/context/ContextMenu.vue
+++ b/src/components/ui/context/ContextMenu.vue
@@ -15,7 +15,7 @@
       <li
         v-for="(f, i) in functionList"
         :key="f.label"
-        class="px-2 py-1 rounded cursor-pointer hover:bg-[color-mix(in_srgb,var(--color-bg-surface)_85%,transparent)] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+        class="px-2 py-1 rounded cursor-pointer hover:bg-surface-base/85 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
         tabindex="0"
         role="menuitem"
         @click="() => handleClick(f.function)"

--- a/src/components/ui/input/BaseButton.vue
+++ b/src/components/ui/input/BaseButton.vue
@@ -3,9 +3,9 @@
   :type="type"
   :disabled="disabled"
   :class="[
-    'transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)] disabled:opacity-50 disabled:cursor-not-allowed',
-    variant === 'default' && 'px-4 py-2 rounded text-sm font-medium bg-[var(--color-accent)] hover:bg-[var(--color-accent-strong)] text-[var(--color-text-inverse)] shadow-[var(--color-shadow-soft)]',
-    variant === 'naked' && 'bg-transparent text-[var(--color-text-primary)] hover:text-[var(--color-accent-soft)]'
+    'transition focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base disabled:opacity-50 disabled:cursor-not-allowed',
+    variant === 'default' && 'px-4 py-2 rounded text-sm font-medium bg-accent hover:bg-accent-strong text-text-inverse shadow-soft',
+    variant === 'naked' && 'bg-transparent text-text-primary hover:text-[var(--color-accent-soft)]'
   ]"
   @click="(e) => $emit('click', e)"
 >
@@ -14,7 +14,7 @@
     </span>
     <span v-else class="flex items-center justify-center space-x-2">
       <svg
-        class="w-4 h-4 animate-spin text-[var(--color-text-inverse)]"
+        class="w-4 h-4 animate-spin text-text-inverse"
         fill="none"
         viewBox="0 0 24 24"
       >

--- a/src/components/ui/input/BaseInput.vue
+++ b/src/components/ui/input/BaseInput.vue
@@ -3,7 +3,7 @@
     <label
       v-if="label"
       :for="id"
-      class="text-sm font-medium text-[var(--color-text-secondary)]"
+      class="text-sm font-medium text-text-secondary"
     >
       {{ label }}
     </label>
@@ -16,10 +16,10 @@
       :autocomplete="autocomplete"
       :disabled="disabled"
       :class="[
-        'px-3 py-2 rounded border w-full text-sm focus:outline-none bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] border-[var(--color-border-subtle)] focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]',
+        'px-3 py-2 rounded border w-full text-sm focus:outline-none bg-surface-base text-text-primary border-border-subtle focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base',
         props.class,
         error
-          ? 'border-[var(--color-danger)] text-[var(--color-danger)] bg-[rgba(var(--color-danger-rgb),0.12)]'
+          ? 'border-status-danger text-status-danger bg-status-danger/12'
           : '',
       ]"
       v-model="internalValue"
@@ -31,7 +31,7 @@
     <p
       v-if="error"
       :id="errorId"
-      class="text-sm text-[var(--color-danger)]"
+      class="text-sm text-status-danger"
       role="alert"
       aria-live="assertive"
     >

--- a/src/components/ui/input/PasswordInput.vue
+++ b/src/components/ui/input/PasswordInput.vue
@@ -12,7 +12,7 @@
       @click.prevent="show = !show"
       :aria-label="show ? 'Hide password' : 'Show password'"
     >
-      <component :is="show ? EyeOpen : EyeClosed" class="w-5 h-5 text-[var(--color-text-muted)]" />
+      <component :is="show ? EyeOpen : EyeClosed" class="w-5 h-5 text-text-muted" />
     </BaseButton>
   </div>
 </template>

--- a/src/components/ui/loading/LoadingDiv.vue
+++ b/src/components/ui/loading/LoadingDiv.vue
@@ -2,11 +2,11 @@
   <transition name="fade" @after-leave="emit('done')">
     <div
       v-if="visible"
-      class="absolute top-0 left-0 right-0 bottom-0 flex items-center justify-center backdrop-blur-sm bg-[color-mix(in_srgb,var(--color-bg-app)_65%,transparent)] z-20"
+      class="absolute top-0 left-0 right-0 bottom-0 flex items-center justify-center backdrop-blur-sm bg-surface-app/65 z-20"
       :class="[props.class]"
     >
       <div
-        class="text-xl font-medium tracking-wide text-[var(--color-text-primary)] animate-pulse"
+        class="text-xl font-medium tracking-wide text-text-primary animate-pulse"
       >
         {{ text }}
       </div>

--- a/src/components/ui/loading/LoadingSpinner.vue
+++ b/src/components/ui/loading/LoadingSpinner.vue
@@ -1,5 +1,5 @@
 <template>
-  <svg class="animate-spin h-4 w-4 text-[var(--color-text-inverse)]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <svg class="animate-spin h-4 w-4 text-text-inverse" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
   </svg>

--- a/src/components/ui/modals/EntitlementUpsellModal.vue
+++ b/src/components/ui/modals/EntitlementUpsellModal.vue
@@ -7,7 +7,7 @@
     >
       <div class="modal-panel" role="dialog" aria-modal="true">
         <h2 class="text-2xl font-semibold mb-3">{{ title }}</h2>
-        <p class="text-[var(--color-text-muted)] mb-6">{{ message }}</p>
+        <p class="text-text-muted mb-6">{{ message }}</p>
         <div class="flex flex-wrap gap-3">
           <BaseButton @click="handleUpgrade">See plans</BaseButton>
           <BaseButton variant="naked" @click="handleClose">Maybe later</BaseButton>

--- a/src/components/ui/modals/Help.vue
+++ b/src/components/ui/modals/Help.vue
@@ -5,7 +5,7 @@
       <!-- Absolute Floating Header -->
       <div class="modal-header-float">
         <h1 class="text-2xl font-bold tracking-tight">Welcome to SoundRoom</h1>
-        <BaseButton @click="handleClose" class="text-sm hover:text-[var(--color-text-muted)]">Close</BaseButton>
+        <BaseButton @click="handleClose" class="text-sm hover:text-text-muted">Close</BaseButton>
       </div>
 
       <!-- Scrollable Content -->
@@ -94,13 +94,13 @@
               >
                 <BaseButton
                   @click="faq.open = !faq.open"
-                  class="w-full text-left font-medium text-[var(--color-text-primary)] focus:outline-none transition-colors"
+                  class="w-full text-left font-medium text-text-primary focus:outline-none transition-colors"
                 >
                   {{ faq.question }}
                 </BaseButton>
                 <p
                   v-if="faq.open"
-                  class="mt-2 text-sm text-[var(--color-text-muted)] leading-snug italic indent-3"
+                  class="mt-2 text-sm text-text-muted leading-snug italic indent-3"
                 >
                   <span
                     v-if="faq.isHtml"
@@ -133,7 +133,7 @@
                     v-model="form.name"
                     required
                     autocomplete="name"
-                    class="w-full px-3 py-2 border border-[var(--color-border-subtle)] rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
+                    class="w-full px-3 py-2 border border-border-subtle rounded bg-surface-base text-text-primary focus:outline-none focus:ring-2 focus:ring-focus focus:ring-offset-2 focus:ring-offset-surface-base text-sm"
                   />
                 </div>
 
@@ -145,7 +145,7 @@
                     v-model="form.email"
                     required
                     autocomplete="email"
-                    class="w-full px-3 py-2 border border-[var(--color-border-subtle)] rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
+                    class="w-full px-3 py-2 border border-border-subtle rounded bg-surface-base text-text-primary focus:outline-none focus:ring-2 focus:ring-focus focus:ring-offset-2 focus:ring-offset-surface-base text-sm"
                   />
                 </div>
               </div>
@@ -157,7 +157,7 @@
                     id="topic"
                     v-model="form.topic"
                     required
-                    class="w-full px-3 py-2 border border-[var(--color-border-subtle)] rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
+                    class="w-full px-3 py-2 border border-border-subtle rounded bg-surface-base text-text-primary focus:outline-none focus:ring-2 focus:ring-focus focus:ring-offset-2 focus:ring-offset-surface-base text-sm"
                   >
                     <option v-for="item in topicOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
                   </select>
@@ -168,7 +168,7 @@
                   <select
                     id="plan"
                     v-model="form.plan"
-                    class="w-full px-3 py-2 border border-[var(--color-border-subtle)] rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
+                    class="w-full px-3 py-2 border border-border-subtle rounded bg-surface-base text-text-primary focus:outline-none focus:ring-2 focus:ring-focus focus:ring-offset-2 focus:ring-offset-surface-base text-sm"
                   >
                     <option value="">Select your plan</option>
                     <option v-for="option in planOptions" :key="option" :value="option">{{ PLAN_LABELS[option] }}</option>
@@ -178,13 +178,13 @@
               </div>
 
               <div>
-                <label for="roomLink" class="block text-sm font-medium mb-1">Room link or ID <span class="text-xs text-[var(--color-text-muted)]">(optional)</span></label>
+                <label for="roomLink" class="block text-sm font-medium mb-1">Room link or ID <span class="text-xs text-text-muted">(optional)</span></label>
                 <input
                   type="text"
                   id="roomLink"
                   v-model="form.roomLink"
                   placeholder="Paste a RoomManager link or card ID"
-                  class="w-full px-3 py-2 border border-[var(--color-border-subtle)] rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
+                  class="w-full px-3 py-2 border border-border-subtle rounded bg-surface-base text-text-primary focus:outline-none focus:ring-2 focus:ring-focus focus:ring-offset-2 focus:ring-offset-surface-base text-sm"
                 />
               </div>
 
@@ -196,18 +196,18 @@
                   rows="4"
                   required
                   placeholder="Tell us what you were working on and what you expected to happen."
-                  class="w-full px-3 py-2 border border-[var(--color-border-subtle)] rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
+                  class="w-full px-3 py-2 border border-border-subtle rounded bg-surface-base text-text-primary focus:outline-none focus:ring-2 focus:ring-focus focus:ring-offset-2 focus:ring-offset-surface-base text-sm"
                 ></textarea>
               </div>
 
               <div>
-                <label for="reproSteps" class="block text-sm font-medium mb-1">Steps to reproduce <span class="text-xs text-[var(--color-text-muted)]">(optional)</span></label>
+                <label for="reproSteps" class="block text-sm font-medium mb-1">Steps to reproduce <span class="text-xs text-text-muted">(optional)</span></label>
                 <textarea
                   id="reproSteps"
                   v-model="form.reproSteps"
                   rows="3"
                   placeholder="Step-by-step details help us debug much faster."
-                  class="w-full px-3 py-2 border border-[var(--color-border-subtle)] rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
+                  class="w-full px-3 py-2 border border-border-subtle rounded bg-surface-base text-text-primary focus:outline-none focus:ring-2 focus:ring-focus focus:ring-offset-2 focus:ring-offset-surface-base text-sm"
                 ></textarea>
               </div>
 
@@ -216,7 +216,7 @@
               <BaseButton
                 type="submit"
                 :disabled="submitting"
-                class="bg-[var(--color-accent)] hover:bg-[var(--color-accent-strong)] disabled:opacity-60 disabled:cursor-not-allowed text-[var(--color-text-inverse)] px-4 py-2 rounded text-sm"
+                class="bg-accent hover:bg-accent-strong disabled:opacity-60 disabled:cursor-not-allowed text-text-inverse px-4 py-2 rounded text-sm"
               >
                 <span v-if="submitting">Sending…</span>
                 <span v-else>Send Message</span>
@@ -224,7 +224,7 @@
             </form>
           </div>
 
-          <div v-else class="p-4 rounded bg-[rgba(var(--color-success-rgb),0.12)] text-[var(--color-success)] space-y-2">
+          <div v-else class="p-4 rounded bg-status-success/12 text-status-success space-y-2">
             <p class="font-semibold">Thanks for contacting SoundRoom Support!</p>
             <p class="text-sm">We’ll reply from support@soundroom.live soon. Check for a subject line starting with [SUPPORT] in case it lands in spam.</p>
             <BaseButton class="text-sm" @click="prepareAnotherMessage">Send another message</BaseButton>

--- a/src/components/ui/modals/LoginSignup/AuthModal.vue
+++ b/src/components/ui/modals/LoginSignup/AuthModal.vue
@@ -41,7 +41,7 @@
       Continue with Google
     </BaseButton>
 
-    <p v-if="mode !== 'reset' && !hideGoogleButton" class="text-xs text-[var(--color-text-muted)] text-center">
+    <p v-if="mode !== 'reset' && !hideGoogleButton" class="text-xs text-text-muted text-center">
       By continuing, you agree to our
       <a href="/terms" target="_blank" class="underline">Terms</a> and
       <a href="/privacy" target="_blank" class="underline">Privacy Policy</a>.
@@ -58,7 +58,7 @@
       v-if="mode !== 'reset' && !signUpSuccess"
       :to="mode === 'login' ? '/signup' : '/login'"
       @click="emit('mode', mode === 'login' ? 'signup' : 'login')"
-      class="text-sm text-accent cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+      class="text-sm text-accent cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
     >
       {{ mode === 'login' ? 'Don\'t have an account? Sign Up' : 'Have an account? Sign In' }}
     </RouterLink>
@@ -67,7 +67,7 @@
       v-if="mode === 'login'"
       to="/reset"
       @click="$emit('mode', 'reset')"
-      class="text-sm text-accent cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+      class="text-sm text-accent cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
     >
       Forgot Password?
     </RouterLink>

--- a/src/components/ui/modals/LoginSignup/OrSpacer.vue
+++ b/src/components/ui/modals/LoginSignup/OrSpacer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex items-center w-full text-sm text-[var(--color-text-muted)]">
+  <div class="flex items-center w-full text-sm text-text-muted">
     <div class="flex-grow border-t border-border-subtle"></div>
     <span class="mx-3">or</span>
     <div class="flex-grow border-t border-border-subtle"></div>

--- a/src/components/ui/modals/LoginSignup/SignUpView.vue
+++ b/src/components/ui/modals/LoginSignup/SignUpView.vue
@@ -78,12 +78,12 @@
       </p>
       <span class="h-5"></span>
       <!-- TOS agreement -->
-      <div class="flex justify-center space-x-2 text-xs text-[var(--color-text-muted)]">
+      <div class="flex justify-center space-x-2 text-xs text-text-muted">
         <BaseInput
           id="tos"
           type="checkbox"
           v-model="agreedToTOS"
-          class="accent-[var(--color-accent)]"
+          class="accent-accent"
           :disabled="loading"
         />
         <label for="tos" class="leading-snug">

--- a/src/components/ui/modals/Onboarding.vue
+++ b/src/components/ui/modals/Onboarding.vue
@@ -9,11 +9,11 @@
 
       <!-- Body -->
       <div class="p-6 space-y-6 text-sm leading-relaxed">
-        <p class="text-[var(--color-text-secondary)]">
+        <p class="text-text-secondary">
           You’re all set. SoundRoom is your canvas for immersive 3D sound. Place audio sources, move your listener, and create rich soundscapes that evolve around you.
         </p>
 
-        <ul class="list-disc list-inside space-y-1 text-[var(--color-text-muted)]">
+        <ul class="list-disc list-inside space-y-1 text-text-muted">
           <li>Use <strong>+ Add Source</strong> to begin layering sounds.</li>
           <li>Drag and drop sounds onto the canvas.</li>
           <li>Move the listener with <strong>WASD</strong> or arrow keys.</li>
@@ -21,14 +21,14 @@
           <li>Undo/redo with <strong>U</strong> / <strong>R</strong>.</li>
         </ul>
 
-        <div class="rounded p-4 text-[var(--color-accent-strong)] border border-[rgba(var(--color-accent-rgb),0.35)] bg-[rgba(var(--color-accent-rgb),0.08)]">
+        <div class="rounded p-4 text-[var(--color-accent-strong)] border border-accent/35 bg-accent/8">
           <strong>Pro tip:</strong> You can layer ambience, nature, music, and directional audio for maximum effect.
         </div>
       </div>
 
       <!-- Footer -->
       <div class="flex justify-end p-4 border-t border-border-subtle">
-        <BaseButton @click="router.push('/')" class="text-sm px-4 py-2 font-medium rounded hover:text-[var(--color-text-muted)]">
+        <BaseButton @click="router.push('/')" class="text-sm px-4 py-2 font-medium rounded hover:text-text-muted">
           Let's Go
         </BaseButton>
       </div>

--- a/src/components/ui/modals/RoomManager/EditableRoomName.vue
+++ b/src/components/ui/modals/RoomManager/EditableRoomName.vue
@@ -3,7 +3,7 @@
     <template v-if="isEditing">
       <input
         v-model="localName"
-        class="w-full bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] px-2 py-1 rounded border border-border-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+        class="w-full bg-surface-raised text-text-primary px-2 py-1 rounded border border-border-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
         @blur="handleBlur"
         @keyup.enter="handleBlur"
         @keyup.esc="cancelEdit"

--- a/src/components/ui/modals/RoomManager/RoomCard.vue
+++ b/src/components/ui/modals/RoomManager/RoomCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="room-row p-4 border border-border-subtle rounded-lg shadow-sm hover:bg-[var(--color-bg-elevated)] transition bg-surface-base text-text-primary">
+  <div class="room-row p-4 border border-border-subtle rounded-lg shadow-sm hover:bg-surface-raised transition bg-surface-base text-text-primary">
     <img
       v-if="room.thumbnail"
       :src="room.thumbnail"

--- a/src/components/ui/modals/RoomManager/RoomManager.vue
+++ b/src/components/ui/modals/RoomManager/RoomManager.vue
@@ -26,7 +26,7 @@
         <!-- Floating Top Bar -->
         <div
           ref="headerBar"
-          class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[color-mix(in_srgb,var(--color-bg-surface)_70%,transparent)] backdrop-blur-md border-b border-border-subtle"
+          class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-surface-base/70 backdrop-blur-md border-b border-border-subtle"
         >
           <h2 class="text-2xl font-bold">RoomManager</h2>
           <BaseButton class="text-sm" @click="router.push('/')">Close</BaseButton>

--- a/src/components/ui/modals/SmallModalBase.vue
+++ b/src/components/ui/modals/SmallModalBase.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     @click.self="canClickOutside && emit('close')"
-    class="fixed inset-0 bg-[color-mix(in_srgb,var(--color-bg-app)_70%,transparent)] backdrop-blur-sm z-50 flex items-center justify-center"
+    class="fixed inset-0 bg-surface-app/70 backdrop-blur-sm z-50 flex items-center justify-center"
     role="dialog"
     aria-modal="true"
     :aria-labelledby="'modal-title'"
@@ -13,7 +13,7 @@
     >
       <!-- Header -->
       <div
-        class="top-0 left-0 right-0 z-10 flex justify-between items-center px-4 py-3 bg-[color-mix(in_srgb,var(--color-bg-surface)_80%,transparent)] backdrop-blur-md border-b border-border-subtle"
+        class="top-0 left-0 right-0 z-10 flex justify-between items-center px-4 py-3 bg-surface-base/80 backdrop-blur-md border-b border-border-subtle"
       >
         <h2 id="modal-title" class="text-lg font-semibold tracking-tight">
           {{ title }}
@@ -21,7 +21,7 @@
         <BaseButton
           v-if="showCloseButton"
           @click="emit('close')"
-          class="text-sm hover:text-[var(--color-text-muted)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+          class="text-sm hover:text-text-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-focus"
           aria-label="Close modal"
         >
           Close

--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex-1 relative overflow-hidden">
-    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[color-mix(in_srgb,var(--color-bg-surface)_70%,transparent)] backdrop-blur-md border-b border-border-subtle text-text-primary">
+    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-surface-base/70 backdrop-blur-md border-b border-border-subtle text-text-primary">
       <h2 class="text-2xl font-bold">SoundLibrary</h2>
       <BaseButton class="text-sm" @click="$emit('close')">Close</BaseButton>
     </div>

--- a/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGridItem.vue
@@ -24,7 +24,7 @@
     />
 
     <BaseButton
-      class="load-BaseButton text-xs px-3 py-1 rounded transition-colors mt-2 bg-[var(--color-bg-elevated)] hover:bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] border border-border-subtle"
+      class="load-BaseButton text-xs px-3 py-1 rounded transition-colors mt-2 bg-surface-raised hover:bg-surface-base text-text-primary border border-border-subtle"
       @click="handleToggle"
       :disabled="waiting || sound.send"
     >

--- a/src/components/ui/modals/SoundLibrary/UploadPanel.vue
+++ b/src/components/ui/modals/SoundLibrary/UploadPanel.vue
@@ -3,7 +3,7 @@
     <div class="modal-panel max-w-3xl mx-auto p-6 bg-surface-base text-text-primary rounded-xl shadow-lg overflow-y-auto max-h-[90vh] border border-border-subtle">
       <h2 class="text-xl font-bold mb-4">Upload Your Sounds</h2>
 
-      <div class="border border-dashed border-[var(--color-border-subtle)] rounded-lg p-6 text-center mb-6 bg-[color-mix(in_srgb,var(--color-bg-surface)_80%,transparent)]">
+      <div class="border border-dashed border-border-subtle rounded-lg p-6 text-center mb-6 bg-surface-base/80">
         <input
           type="file"
           accept="audio/*"
@@ -17,11 +17,11 @@
       </div>
 
       <div v-if="files.length > 0" class="space-y-4">
-        <div v-for="file in files" :key="file.id" class="bg-[var(--color-bg-surface)] rounded-md p-4 flex flex-col gap-2 border border-border-subtle">
+        <div v-for="file in files" :key="file.id" class="bg-surface-base rounded-md p-4 flex flex-col gap-2 border border-border-subtle">
           <div class="flex justify-between items-center">
             <input
               v-model="file.name"
-              class="flex-1 p-1 text-base border border-[var(--color-border-subtle)] rounded-md bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-elevated)]"
+              class="flex-1 p-1 text-base border border-border-subtle rounded-md bg-surface-raised text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-raised"
             />
             <BaseButton class="ml-2" @click="autoTag(file)" :disabled="file.tagging">
               <template v-if="file.tagging">
@@ -37,7 +37,7 @@
           <div class="flex items-center gap-2">
             <audio :src="file.previewUrl" controls class="w-full" />
           </div>
-          <div class="h-2 bg-[var(--color-border-subtle)] rounded overflow-hidden" v-if="uploading">
+          <div class="h-2 bg-border-subtle rounded overflow-hidden" v-if="uploading">
             <div
               class="h-full bg-status-success transition-all duration-300"
               :style="{ width: `${file.progress}%` }"
@@ -48,7 +48,7 @@
           <span
             v-for="(tag, index) in file.tags"
             :key="tag"
-            class="flex items-center bg-[var(--color-bg-elevated)] text-xs px-2 rounded text-[var(--color-text-primary)] border border-border-subtle"
+            class="flex items-center bg-surface-raised text-xs px-2 rounded text-text-primary border border-border-subtle"
           >
             {{ tag }}
             <label
@@ -69,7 +69,7 @@
             @keydown="','"
             @blur="addTag(file)"
             placeholder="Add tag..."
-            class="text-sm p-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] w-25 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-elevated)]"
+            class="text-sm p-1 rounded border border-border-subtle bg-surface-raised text-text-primary w-25 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-raised"
           />
         </div>
 

--- a/src/components/ui/modals/YesNoModal.vue
+++ b/src/components/ui/modals/YesNoModal.vue
@@ -13,7 +13,7 @@
       :id="`modal-desc-save`"
     >
       <p
-        class="text-lg font-medium text-[var(--color-text-primary)]"
+        class="text-lg font-medium text-text-primary"
         :id="`modal-title-save`"
       >
         {{ message }}

--- a/src/components/ui/overlays/PulsingOverlay.vue
+++ b/src/components/ui/overlays/PulsingOverlay.vue
@@ -2,10 +2,10 @@
   <transition name="fade" @after-leave="emit('done')">
     <div
       v-if="visible"
-      class="absolute inset-0 flex items-center justify-center backdrop-blur-sm bg-[color-mix(in_srgb,var(--color-bg-app)_70%,transparent)] z-50"
+      class="absolute inset-0 flex items-center justify-center backdrop-blur-sm bg-surface-app/70 z-50"
     >
       <div
-        class="text-xl font-medium tracking-wide text-[var(--color-text-primary)] animate-pulse"
+        class="text-xl font-medium tracking-wide text-text-primary animate-pulse"
       >
         {{ text }}
       </div>

--- a/src/components/ui/overlays/WelcomeOverlay.vue
+++ b/src/components/ui/overlays/WelcomeOverlay.vue
@@ -2,7 +2,7 @@
   <transition name="fade">
     <div
       v-if="visible"
-      class="absolute inset-0 z-50 flex items-center justify-center backdrop-blur-md bg-[color-mix(in_srgb,var(--color-bg-app)_70%,transparent)]"
+      class="absolute inset-0 z-50 flex items-center justify-center backdrop-blur-md bg-surface-app/70"
     >
       <div class="text-center space-y-4">
         <h1
@@ -12,7 +12,7 @@
         </h1>
         <p
           v-if="subtext"
-          class="text-lg text-[var(--color-text-muted)] opacity-80"
+          class="text-lg text-text-muted opacity-80"
         >
           {{ subtext }}
         </p>

--- a/src/components/ui/text/SoundSourceLabel.vue
+++ b/src/components/ui/text/SoundSourceLabel.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="absolute pointer-events-none w-20 overflow-hidden text-xs text-[var(--color-text-muted)]"
+    class="absolute pointer-events-none w-20 overflow-hidden text-xs text-text-muted"
     :style="{
       top: `${y}px`,
       left: `${x}px`,

--- a/src/constants/planThemes.js
+++ b/src/constants/planThemes.js
@@ -1,22 +1,22 @@
 export const PLAN_THEMES = {
   free: {
-    card: 'border border-[var(--color-border-subtle)] hover:border-[var(--color-border-strong)] focus-within:border-[var(--color-border-strong)] shadow-[var(--color-shadow-soft)] bg-[var(--color-bg-surface)]',
+    card: 'border border-border-subtle hover:border-border-strong focus-within:border-border-strong shadow-soft bg-surface-base',
     ring: '',
-    cta: 'bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface)] focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-app)]',
-    badge: 'bg-[rgba(var(--color-border-strong-rgb),0.85)] text-[var(--color-text-inverse)]',
+    cta: 'bg-surface-raised text-text-primary hover:bg-surface-base focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-app',
+    badge: 'bg-border-strong/85 text-text-inverse',
     soundHighlight: ''
   },
   basic: {
-    card: 'border border-[rgba(var(--color-accent-soft-rgb),0.65)] hover:border-[var(--color-accent)] focus-within:border-[var(--color-accent)] ring-1 ring-[rgba(var(--color-accent-rgb),0.4)] shadow-[0_8px_24px_rgba(var(--color-accent-rgb),0.08)] bg-[color-mix(in_srgb,var(--color-bg-surface)_94%,transparent)]',
-    cta: 'bg-[var(--color-accent)] text-[var(--color-text-inverse)] hover:bg-[var(--color-accent-strong)] focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-app)]',
-    badge: 'bg-[var(--color-accent-strong)] text-[var(--color-text-inverse)]',
-    soundHighlight: 'ring-2 ring-offset-2 ring-[rgba(var(--color-accent-rgb),0.65)] ring-offset-[var(--color-bg-app)] shadow-[0_0_0_4px_rgba(var(--color-accent-rgb),0.15)] border-[rgba(var(--color-accent-rgb),0.6)]'
+    card: 'border border-accent-soft/65 hover:border-accent focus-within:border-accent ring-1 ring-accent/40 shadow-accent bg-surface-base/94',
+    cta: 'bg-accent text-text-inverse hover:bg-accent-strong focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-app',
+    badge: 'bg-accent-strong text-text-inverse',
+    soundHighlight: 'ring-2 ring-offset-2 ring-accent/65 ring-offset-surface-app shadow-accent-outline border-accent/60'
   },
   pro: {
-    card: 'border border-[rgba(var(--color-accent-strong-rgb),0.6)] hover:border-[var(--color-accent-strong)] focus-within:border-[var(--color-accent-strong)] ring-1 ring-[rgba(var(--color-accent-strong-rgb),0.35)] shadow-[0_10px_28px_rgba(var(--color-accent-strong-rgb),0.1)] bg-[color-mix(in_srgb,var(--color-bg-elevated)_92%,transparent)]',
-    cta: 'bg-[var(--color-accent-strong)] text-[var(--color-text-inverse)] hover:bg-[var(--color-accent)] focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-app)]',
-    badge: 'bg-[var(--color-accent)] text-[var(--color-text-inverse)]',
-    soundHighlight: 'ring-2 ring-offset-2 ring-[rgba(var(--color-accent-strong-rgb),0.65)] ring-offset-[var(--color-bg-app)] shadow-[0_0_0_5px_rgba(var(--color-accent-strong-rgb),0.18)] border-[rgba(var(--color-accent-strong-rgb),0.7)]'
+    card: 'border border-accent-strong/60 hover:border-accent-strong focus-within:border-accent-strong ring-1 ring-accent-strong/35 shadow-accent-strong bg-surface-raised/92',
+    cta: 'bg-accent-strong text-text-inverse hover:bg-accent focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-app',
+    badge: 'bg-accent text-text-inverse',
+    soundHighlight: 'ring-2 ring-offset-2 ring-accent-strong/65 ring-offset-surface-app shadow-accent-strong-outline border-accent-strong/70'
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -5,21 +5,20 @@
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  color: var(--color-text-primary);
-  background-color: var(--color-bg-app);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  @apply text-text-primary bg-surface-app;
 }
 
 a {
   font-weight: 500;
-  color: var(--color-accent);
   text-decoration: inherit;
+  @apply text-accent;
 }
 a:hover {
-  color: var(--color-accent-soft);
+  @apply text-accent-soft;
 }
 
 body {
@@ -28,8 +27,7 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
-  color: var(--color-text-primary);
-  background: var(--color-bg-app);
+  @apply text-text-primary bg-surface-app;
 }
 
 h1 {
@@ -46,17 +44,14 @@ button {
   font-family: inherit;
   cursor: pointer;
   transition: border-color 0.25s, box-shadow 0.25s;
-  @apply bg-[var(--color-bg-surface)] text-[var(--color-text-primary)];
+  @apply bg-surface-base text-text-primary;
 }
 button:hover {
-  border-color: var(--color-border-subtle);
-  background-color: var(--color-bg-elevated);
+  @apply border-border-subtle bg-surface-raised;
 }
 button:focus,
 button:focus-visible {
-  outline: 2px solid var(--color-focus-ring);
-  outline-offset: 2px;
-  box-shadow: 0 0 0 4px rgba(var(--color-focus-ring-rgb), 0.25);
+  @apply outline-none ring-2 ring-focus ring-offset-2 ring-offset-surface-base;
 }
 
 .card {
@@ -72,32 +67,31 @@ button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
   pointer-events: none;
-  background-color: var(--color-disabled-bg);
-  color: var(--color-disabled-text);
+  @apply bg-disabled-bg text-disabled-text;
 }
 
 input[type="text"],
 input[type="email"],
 input[type="password"] {
-  @apply w-full p-3 border border-[var(--color-border-subtle)] rounded-lg bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)];
+  @apply w-full p-3 border border-border-subtle rounded-lg bg-surface-raised text-text-primary;
 }
 
 input:disabled {
-  @apply opacity-50 cursor-not-allowed bg-[var(--color-disabled-bg)] text-[var(--color-disabled-text)];
+  @apply opacity-50 cursor-not-allowed bg-disabled-bg text-disabled-text;
 }
 
 .modal-backdrop {
-  @apply fixed inset-0 bg-[color-mix(in_srgb,var(--color-text-inverse)_60%,transparent)] backdrop-blur-sm z-50 flex items-center justify-center;
+  @apply fixed inset-0 bg-text-inverse/60 backdrop-blur-sm z-50 flex items-center justify-center;
 }
 
 .modal-panel {
-  @apply bg-[var(--color-bg-app)] rounded-2xl w-[80vw] h-[80vh] shadow-[var(--color-shadow-soft)] border border-[var(--color-border-subtle)] overflow-hidden;
+  @apply bg-surface-app rounded-2xl w-[80vw] h-[80vh] shadow-soft border border-border-subtle overflow-hidden;
 }
 
 .modal-header-float {
-  @apply absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[color-mix(in_srgb,var(--color-bg-app)_85%,transparent)] backdrop-blur-md border-b border-[var(--color-border-subtle)];
+  @apply absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-surface-app/85 backdrop-blur-md border-b border-border-subtle;
 }
 
 .modal-header {
-  @apply top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[color-mix(in_srgb,var(--color-bg-app)_85%,transparent)] backdrop-blur-md border-b border-[var(--color-border-subtle)];
+  @apply top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-surface-app/85 backdrop-blur-md border-b border-border-subtle;
 }

--- a/src/views/AuthCallback.vue
+++ b/src/views/AuthCallback.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="auth-callback w-full bg-[var(--color-bg-app)] text-[var(--color-text-primary)]">
+  <div class="auth-callback w-full bg-surface-app text-text-muted">
   </div>
 </template>
 
@@ -48,12 +48,11 @@ onMounted(async () => {
 </script>
 
 <style scoped>
-.auth-callback {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100dvh;
-  font-size: 1.2rem;
-  color: var(--color-text-muted);
-}
+  .auth-callback {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100dvh;
+    font-size: 1.2rem;
+  }
 </style>

--- a/src/views/AuthError.vue
+++ b/src/views/AuthError.vue
@@ -13,33 +13,14 @@ function goHome() {
 </script>
 
 <template>
-  <div class="auth-error">
-    <h1>Login Failed</h1>
+  <div class="flex min-h-screen flex-col items-center justify-center gap-4 bg-surface-app text-center text-text-primary px-4">
+    <h1 class="text-3xl font-semibold">Login Failed</h1>
     <p>Something went wrong during login. Please try again.</p>
-    <button @click="goHome">Back to Home</button>
+    <button
+      class="mt-2 rounded bg-surface-muted px-4 py-2 font-bold text-text-primary transition hover:bg-surface-raised/90"
+      @click="goHome"
+    >
+      Back to Home
+    </button>
   </div>
 </template>
-
-<style scoped>
-.auth-error {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100dvh;
-  text-align: center;
-}
-button {
-  margin-top: 1rem;
-  padding: 0.5rem 1.2rem;
-  font-weight: bold;
-  border: none;
-  border-radius: 4px;
-  background-color: var(--color-surface-muted);
-  color: var(--color-text-primary);
-  cursor: pointer;
-}
-button:hover {
-  background-color: color-mix(in srgb, var(--color-bg-elevated) 90%, transparent);
-}
-</style>

--- a/src/views/LoggedOut.vue
+++ b/src/views/LoggedOut.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full flex flex-col items-center justify-center text-center px-6 py-12 bg-[var(--color-bg-app)] text-text-primary">
+  <div class="h-full flex flex-col items-center justify-center text-center px-6 py-12 bg-surface-app text-text-primary">
     <h2 class="text-2xl font-semibold mb-2">You've been signed out</h2>
     <p class="text-text-muted mb-6">We hope you come back soon.</p>
     <BaseButton @click="$router.push('/login')">Sign In Again</BaseButton>

--- a/src/views/ManagePlan.vue
+++ b/src/views/ManagePlan.vue
@@ -1,14 +1,14 @@
 <template>
-  <main class="flex-1 overflow-y-auto bg-[var(--color-bg-app)] text-[var(--color-text-primary)]">
+  <main class="flex-1 overflow-y-auto bg-surface-app text-text-primary">
     <div class="max-w-4xl mx-auto px-6 py-10 space-y-10">
       <section class="space-y-4">
         <div
           v-if="checkoutStatusMessage || checkoutErrorMessage || isProcessingCheckout"
           class="rounded-xl border p-4"
           :class="[
-            isProcessingCheckout ? 'border-[var(--color-accent-soft)] bg-[rgba(var(--color-accent-rgb),0.12)] text-[var(--color-text-primary)]' : '',
-            checkoutStatusMessage && !isProcessingCheckout ? 'border-[var(--color-success)] bg-[rgba(var(--color-success-rgb),0.12)] text-[var(--color-text-primary)]' : '',
-            checkoutErrorMessage ? 'border-[var(--color-danger)] bg-[rgba(var(--color-danger-rgb),0.12)] text-[var(--color-text-primary)]' : '',
+            isProcessingCheckout ? 'border-accent-soft bg-accent/12 text-text-primary' : '',
+            checkoutStatusMessage && !isProcessingCheckout ? 'border-status-success bg-status-success/12 text-text-primary' : '',
+            checkoutErrorMessage ? 'border-status-danger bg-status-danger/12 text-text-primary' : '',
           ]"
         >
           <p v-if="isProcessingCheckout" class="text-sm font-medium">Processing your plan change…</p>
@@ -18,7 +18,7 @@
         <div class="flex items-center justify-between gap-6 flex-wrap">
           <div class="space-y-2 w-full">
             <h1 class="text-3xl font-semibold tracking-tight">Manage Plan</h1>
-            <p class="text-sm text-[var(--color-text-muted)] w-full">
+            <p class="text-sm text-text-muted w-full">
               Review what is included in your subscription, explore upgrade options, or reach out for billing support.
             </p>
           </div>
@@ -32,24 +32,24 @@
         </div>
 
         <div
-          class="rounded-2xl p-6 shadow-sm border bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)]"
+          class="rounded-2xl p-6 shadow-sm border bg-surface-base/90"
           :class="planTheme.card"
         >
           <header class="flex flex-wrap items-center justify-between gap-4">
             <div class="space-y-1">
               <h2 class="text-2xl font-semibold">{{ currentPlan.name }}</h2>
-              <p class="text-sm text-[var(--color-text-muted)]">{{ currentPlan.tagline }}</p>
+              <p class="text-sm text-text-muted">{{ currentPlan.tagline }}</p>
             </div>
             <div class="text-right">
               <span class="text-lg font-semibold">{{ currentPlan.price }}</span>
-              <p class="text-xs text-[var(--color-text-muted)]">Billed monthly — cancel anytime.</p>
+              <p class="text-xs text-text-muted">Billed monthly — cancel anytime.</p>
             </div>
           </header>
 
           <div class="mt-6 grid gap-4 sm:grid-cols-2">
             <div v-for="feature in currentPlan.highlights" :key="feature" class="flex items-start gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-[var(--color-accent)]"></span>
-              <p class="text-sm text-[var(--color-text-secondary)]">{{ feature }}</p>
+              <span class="mt-1 h-2 w-2 rounded-full bg-accent"></span>
+              <p class="text-sm text-text-secondary">{{ feature }}</p>
             </div>
           </div>
 
@@ -80,15 +80,15 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl border border-border-subtle bg-surface-base/90 p-6 shadow-sm space-y-6">
         <header class="space-y-1">
           <h2 class="text-xl font-semibold">Billing & Receipts</h2>
-          <p class="text-sm text-[var(--color-text-muted)]">
+          <p class="text-sm text-text-muted">
             SoundRoom uses Stripe under the hood. Use the billing portal to view invoices, update payment details, or make changes to your plan anytime.
           </p>
         </header>
 
-        <div class="rounded-xl border border-dashed border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] px-5 py-6 text-sm text-[var(--color-text-secondary)]">
+        <div class="rounded-xl border border-dashed border-border-subtle bg-surface-base/90 px-5 py-6 text-sm text-text-secondary">
           <p>Need an invoice, tax receipt, or want to change your payment method?</p>
           <p class="mt-3">Email <a class="underline" :href="supportEmailHref">{{ SUPPORT_EMAIL }}</a> and include the email tied to your SoundRoom account.</p>
         </div>
@@ -105,23 +105,23 @@
           <BaseButton @click="contactBilling">
             Contact billing support
           </BaseButton>
-          <BaseButton variant="naked" class="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]" @click="openFAQ">
+          <BaseButton variant="naked" class="text-sm text-text-muted hover:text-text-primary" @click="openFAQ">
             View plan FAQ
           </BaseButton>
         </div>
       </section>
 
-      <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl border border-border-subtle bg-surface-base/90 p-6 shadow-sm space-y-6">
         <header class="space-y-1">
           <h2 class="text-xl font-semibold">Upcoming Features</h2>
-          <p class="text-sm text-[var(--color-text-muted)]">We are actively building deeper collaboration and scheduling tools. Here is what is landing next for paying members.</p>
+          <p class="text-sm text-text-muted">We are actively building deeper collaboration and scheduling tools. Here is what is landing next for paying members.</p>
         </header>
 
         <ul class="grid gap-4 md:grid-cols-2">
-          <li v-for="item in roadmapHighlights" :key="item.title" class="rounded-xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_92%,transparent)] p-5 space-y-2">
-            <p class="text-sm uppercase tracking-wide text-[var(--color-text-muted)]">{{ item.badge }}</p>
+          <li v-for="item in roadmapHighlights" :key="item.title" class="rounded-xl border border-border-subtle bg-surface-base/92 p-5 space-y-2">
+            <p class="text-sm uppercase tracking-wide text-text-muted">{{ item.badge }}</p>
             <h3 class="text-lg font-medium">{{ item.title }}</h3>
-            <p class="text-sm text-[var(--color-text-muted)]">{{ item.copy }}</p>
+            <p class="text-sm text-text-muted">{{ item.copy }}</p>
           </li>
         </ul>
       </section>

--- a/src/views/MobileComingSoon.vue
+++ b/src/views/MobileComingSoon.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fixed inset-0 bg-[var(--color-bg-app)] text-text-primary flex items-center justify-center text-center p-6 z-50">
+  <div class="fixed inset-0 bg-surface-app text-text-primary flex items-center justify-center text-center p-6 z-50">
     <div>
       <h1 class="text-2xl font-semibold mb-2">Mobile Version Coming Soon</h1>
       <p class="text-sm text-text-muted">Please visit us on desktop for the full experience.</p>

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full w-full flex flex-col items-center justify-center text-center px-6 py-12 bg-[var(--color-bg-app)] text-text-primary">
+  <div class="h-full w-full flex flex-col items-center justify-center text-center px-6 py-12 bg-surface-app text-text-primary">
     <p class="text-sm uppercase tracking-[0.2em] text-status-danger mb-3">404</p>
     <h1 class="text-3xl font-semibold mb-3">Page not found</h1>
     <p class="max-w-md text-text-muted mb-8">

--- a/src/views/Pricing/PlanComparisonTable.vue
+++ b/src/views/Pricing/PlanComparisonTable.vue
@@ -1,31 +1,31 @@
 <template>
   <div class="overflow-x-auto">
-    <table class="min-w-full divide-y divide-[var(--color-border-subtle)] text-sm">
-      <thead class="bg-[color-mix(in_srgb,var(--color-bg-surface)_85%,transparent)]">
+    <table class="min-w-full divide-y divide-border-subtle text-sm">
+      <thead class="bg-surface-base/85">
         <tr>
-          <th class="py-3 pl-4 pr-3 text-left font-semibold text-[var(--color-text-primary)]">Feature</th>
+          <th class="py-3 pl-4 pr-3 text-left font-semibold text-text-primary">Feature</th>
           <th
             v-for="plan in tablePlans"
             :key="plan.id"
-            class="py-3 px-3 text-left font-semibold text-[var(--color-text-primary)]"
+            class="py-3 px-3 text-left font-semibold text-text-primary"
           >
             {{ plan.name }}
           </th>
         </tr>
       </thead>
-      <tbody class="divide-y divide-[var(--color-border-subtle)] bg-surface-base">
+      <tbody class="divide-y divide-border-subtle bg-surface-base">
         <tr v-for="feature in features" :key="feature.key" class="align-top">
-          <th class="py-4 pl-4 pr-3 text-left font-medium text-[var(--color-text-primary)]">{{ feature.label }}</th>
+          <th class="py-4 pl-4 pr-3 text-left font-medium text-text-primary">{{ feature.label }}</th>
           <td
             v-for="plan in tablePlans"
             :key="plan.id"
-            class="py-4 px-3 text-[var(--color-text-secondary)]"
+            class="py-4 px-3 text-text-secondary"
           >
             <div class="space-y-1">
               <span :class="STATUS_TEXT_CLASSES[getStatus(plan, feature.key)]" class="font-medium">
                 {{ STATUS_LABELS[getStatus(plan, feature.key)] }}
               </span>
-              <p v-if="getDetail(plan, feature.key)" class="text-xs text-[var(--color-text-muted)]">
+              <p v-if="getDetail(plan, feature.key)" class="text-xs text-text-muted">
                 {{ getDetail(plan, feature.key) }}
               </p>
             </div>
@@ -47,8 +47,8 @@ const STATUS_LABELS = {
 
 const STATUS_TEXT_CLASSES = {
   included: 'text-status-success',
-  limited: 'text-[var(--color-warning)]',
-  unavailable: 'text-[var(--color-text-muted)]'
+  limited: 'text-status-warning',
+  unavailable: 'text-text-muted'
 }
 
 const props = defineProps({

--- a/src/views/Pricing/Pricing.vue
+++ b/src/views/Pricing/Pricing.vue
@@ -7,7 +7,7 @@
       </div>
           <div class="flex-1 overflow-hidden">
             <div class="h-full overflow-y-auto px-10 pt-24 pb-10 space-y-8">
-          <p class="text-sm text-[var(--color-text-muted)] max-w-2xl mx-auto text-center pt-4">
+          <p class="text-sm text-text-muted max-w-2xl mx-auto text-center pt-4">
             Pick the tier that matches how you build, perform, or collaborate inside SoundRoom.
           </p>
           <div class="grid gap-6 mx-auto max-w-6xl justify-items-center md:grid-cols-2 xl:grid-cols-3">
@@ -34,7 +34,7 @@
             {{ checkoutError }}
           </p>
           <div class="max-w-5xl mx-auto rounded-md border border-border-subtle bg-surface-base p-4 text-left shadow-sm" data-testid="pricing-feature-comparison">
-            <div class="text-sm font-semibold text-[var(--color-text-primary)]">Full feature comparison</div>
+            <div class="text-sm font-semibold text-text-primary">Full feature comparison</div>
             <PlanComparisonTable class="mt-4" :plans="basePlans" :features="FEATURE_DEFINITIONS" />
           </div>
         </div>

--- a/src/views/Pricing/PricingCard.vue
+++ b/src/views/Pricing/PricingCard.vue
@@ -5,7 +5,7 @@
     <div>
       <h2 class="text-xl font-bold mb-2">{{ title }}</h2>
       <p class="text-2xl font-semibold">{{ price }}</p>
-      <p v-if="tagline" class="mt-2 text-sm text-[var(--color-text-muted)]">{{ tagline }}</p>
+      <p v-if="tagline" class="mt-2 text-sm text-text-muted">{{ tagline }}</p>
       <div v-if="highlightItems.length" class="mt-5 flex flex-col gap-2 justify-center items-center pb-3">
         <span
           v-for="(feature, index) in highlightItems"
@@ -37,18 +37,18 @@ import { getPlanTheme } from '@/constants/planThemes'
 
 const STATUS_STYLES = {
   included: {
-    chip: 'border-[var(--color-success)] bg-[rgba(var(--color-success-rgb),0.15)] text-[var(--color-success)]',
+    chip: 'border-status-success bg-status-success/15 text-status-success',
     dot: 'bg-status-success'
   },
   limited: {
-    chip: 'border-[var(--color-warning)] bg-[rgba(var(--color-warning-rgb),0.15)] text-[var(--color-warning)]',
-    dot: 'bg-[var(--color-warning)]'
+    chip: 'border-status-warning bg-status-warning/15 text-status-warning',
+    dot: 'bg-status-warning'
   },
-  unavailable: {
-    chip: 'border-border-subtle bg-[var(--color-bg-elevated)] text-[var(--color-text-muted)]',
-    dot: 'bg-[var(--color-text-muted)]'
+    unavailable: {
+      chip: 'border-border-subtle bg-surface-raised text-text-muted',
+      dot: 'bg-text-muted'
+    }
   }
-}
 
 defineEmits(['select-plan'])
 
@@ -85,7 +85,7 @@ const props = defineProps({
   }
 })
 
-const BASE_CARD_CLASS = 'group rounded-sm p-6 shadow-md transition-all duration-200 ease-out transform flex flex-col justify-between bg-surface-base text-text-primary hover:bg-[var(--color-bg-elevated)] hover:shadow-xl hover:-translate-y-1 hover:scale-[1.03] focus-within:shadow-xl focus-within:-translate-y-1 focus-within:scale-[1.03]'
+const BASE_CARD_CLASS = 'group rounded-sm p-6 shadow-md transition-all duration-200 ease-out transform flex flex-col justify-between bg-surface-base text-text-primary hover:bg-surface-raised hover:shadow-xl hover:-translate-y-1 hover:scale-[1.03] focus-within:shadow-xl focus-within:-translate-y-1 focus-within:scale-[1.03]'
 
 const BASE_CTA_CLASS = 'w-full py-2 rounded-xl font-semibold transition border border-transparent disabled:opacity-50 disabled:cursor-not-allowed'
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -1,16 +1,16 @@
 <template>
-  <main class="flex-1 overflow-y-auto bg-[var(--color-bg-app)] text-[var(--color-text-primary)]">
+  <main class="flex-1 overflow-y-auto bg-surface-app text-text-primary">
     <div class="max-w-5xl mx-auto px-6 py-10 space-y-10">
       <section class="space-y-4">
         <div class="flex items-center justify-between gap-6 flex-wrap">
           <div class="space-y-2">
             <h1 class="text-3xl font-semibold tracking-tight">Settings</h1>
-            <p class="text-sm text-[var(--color-text-muted)] max-w-xl">
+            <p class="text-sm text-text-muted max-w-xl">
               Update how you appear in SoundRoom, adjust playback preferences, and keep your account secure.
             </p>
           </div>
-          <div class="flex items-center gap-3 rounded-full border border-border-subtle px-4 py-2 bg-[color-mix(in_srgb,var(--color-bg-surface)_85%,transparent)]">
-            <span class="text-xs uppercase tracking-wide text-[var(--color-text-muted)]">Plan</span>
+          <div class="flex items-center gap-3 rounded-full border border-border-subtle px-4 py-2 bg-surface-base/85">
+            <span class="text-xs uppercase tracking-wide text-text-muted">Plan</span>
             <span class="text-sm font-medium">{{ planLabel }}</span>
             <RouterLink v-if="tier.value === 'free'" :to="'/upgrade'" class="ml-2">
               <BaseButton type="button">
@@ -33,9 +33,9 @@
           v-if="planStatusMessage || planErrorMessage || isProcessingCheckout"
           class="rounded-xl border p-4"
           :class="[
-            isProcessingCheckout ? 'border-[var(--color-accent-soft)] bg-[rgba(var(--color-accent-rgb),0.12)] text-[var(--color-text-primary)]' : '',
-            planStatusMessage && !isProcessingCheckout ? 'border-[var(--color-success)] bg-[rgba(var(--color-success-rgb),0.12)] text-[var(--color-text-primary)]' : '',
-            planErrorMessage ? 'border-[var(--color-danger)] bg-[rgba(var(--color-danger-rgb),0.12)] text-[var(--color-text-primary)]' : '',
+            isProcessingCheckout ? 'border-accent-soft bg-accent/12 text-text-primary' : '',
+            planStatusMessage && !isProcessingCheckout ? 'border-status-success bg-status-success/12 text-text-primary' : '',
+            planErrorMessage ? 'border-status-danger bg-status-danger/12 text-text-primary' : '',
           ]"
         >
           <p v-if="isProcessingCheckout" class="text-sm font-medium">Processing your plan change…</p>
@@ -43,13 +43,13 @@
           <p v-else-if="planErrorMessage" class="text-sm font-medium">{{ planErrorMessage }}</p>
         </div>
 
-        <div class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_85%,transparent)] p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
+        <div class="rounded-2xl border border-border-subtle bg-surface-base/85 p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
           <div>
-            <p class="text-sm text-[var(--color-text-muted)]">Signed in as</p>
+            <p class="text-sm text-text-muted">Signed in as</p>
             <p class="text-lg font-medium break-all">{{ userEmail }}</p>
           </div>
           <div class="flex items-center gap-4">
-            <div class="relative w-16 h-16 rounded-full bg-[var(--color-bg-elevated)] flex items-center justify-center overflow-hidden text-xl font-semibold border border-border-subtle">
+            <div class="relative w-16 h-16 rounded-full bg-surface-raised flex items-center justify-center overflow-hidden text-xl font-semibold border border-border-subtle">
               <img
                 v-if="avatarPreview && !avatarFailed"
                 :src="avatarPreview"
@@ -60,23 +60,23 @@
               <span v-else>{{ avatarInitial }}</span>
             </div>
             <div>
-              <p class="text-sm text-[var(--color-text-muted)]">Display name</p>
+              <p class="text-sm text-text-muted">Display name</p>
               <p class="text-base font-medium">{{ profileForm.displayName || '—' }}</p>
             </div>
           </div>
         </div>
       </section>
 
-      <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_88%,transparent)] p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl border border-border-subtle bg-surface-base/88 p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Profile</h2>
-          <p class="text-sm text-[var(--color-text-muted)]">Set how teammates and collaborators see you.</p>
+          <p class="text-sm text-text-muted">Set how teammates and collaborators see you.</p>
         </header>
 
         <div v-if="isFetchingProfile" class="space-y-4 animate-pulse">
-          <div class="h-4 bg-[var(--color-bg-elevated)] rounded"></div>
-          <div class="h-4 bg-[var(--color-bg-elevated)] rounded w-2/3"></div>
-          <div class="h-40 bg-[var(--color-bg-elevated)] rounded"></div>
+          <div class="h-4 bg-surface-raised rounded"></div>
+          <div class="h-4 bg-surface-raised rounded w-2/3"></div>
+          <div class="h-40 bg-surface-raised rounded"></div>
         </div>
 
         <form v-else @submit.prevent="saveProfile" class="space-y-8">
@@ -114,7 +114,7 @@
           <div class="flex flex-wrap items-center justify-end gap-3">
             <button
               type="button"
-              class="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition"
+              class="text-sm text-text-muted hover:text-text-primary transition"
               @click="resetProfileForm"
               :disabled="profileSaving || !hasProfileChanges"
             >
@@ -136,34 +136,34 @@
 
       <ThemeSelector />
 
-      <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_88%,transparent)] p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl border border-border-subtle bg-surface-base/88 p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Playback Preferences</h2>
-          <p class="text-sm text-[var(--color-text-muted)]">These settings are stored locally in your browser.</p>
+          <p class="text-sm text-text-muted">These settings are stored locally in your browser.</p>
         </header>
 
         <div class="space-y-6">
           <div class="flex items-start justify-between gap-6">
             <div>
               <h3 class="text-base font-medium">Auto-resume sessions</h3>
-              <p class="text-sm text-[var(--color-text-muted)]">Automatically reload your last SoundRoom when you sign back in.</p>
+              <p class="text-sm text-text-muted">Automatically reload your last SoundRoom when you sign back in.</p>
             </div>
             <label class="relative inline-flex items-center cursor-pointer select-none">
               <input type="checkbox" class="sr-only peer" v-model="preferences.autoResumePlayback">
-              <span class="block w-12 h-6 rounded-full bg-[var(--color-border-subtle)] transition-colors peer-focus:outline peer-focus:outline-2 peer-focus:outline-[var(--color-focus-ring)] peer-checked:bg-[var(--color-accent-strong)]"></span>
-              <span class="absolute left-1 top-1 block w-4 h-4 rounded-full bg-[var(--color-text-inverse)] shadow transition-transform peer-checked:translate-x-6"></span>
+              <span class="block w-12 h-6 rounded-full bg-border-subtle transition-colors peer-focus:outline peer-focus:outline-2 peer-focus:outline-focus peer-checked:bg-accent-strong"></span>
+              <span class="absolute left-1 top-1 block w-4 h-4 rounded-full bg-text-inverse shadow transition-transform peer-checked:translate-x-6"></span>
             </label>
           </div>
 
           <div class="flex items-start justify-between gap-6">
             <div>
               <h3 class="text-base font-medium">Show interface tips</h3>
-              <p class="text-sm text-[var(--color-text-muted)]">Keep lightweight reminders visible for keyboard shortcuts and best practices.</p>
+              <p class="text-sm text-text-muted">Keep lightweight reminders visible for keyboard shortcuts and best practices.</p>
             </div>
             <label class="relative inline-flex items-center cursor-pointer select-none">
               <input type="checkbox" class="sr-only peer" v-model="preferences.showInterfaceTips">
-              <span class="block w-12 h-6 rounded-full bg-[var(--color-border-subtle)] transition-colors peer-focus:outline peer-focus:outline-2 peer-focus:outline-[var(--color-focus-ring)] peer-checked:bg-[var(--color-accent-strong)]"></span>
-              <span class="absolute left-1 top-1 block w-4 h-4 rounded-full bg-[var(--color-text-inverse)] shadow transition-transform peer-checked:translate-x-6"></span>
+              <span class="block w-12 h-6 rounded-full bg-border-subtle transition-colors peer-focus:outline peer-focus:outline-2 peer-focus:outline-focus peer-checked:bg-accent-strong"></span>
+              <span class="absolute left-1 top-1 block w-4 h-4 rounded-full bg-text-inverse shadow transition-transform peer-checked:translate-x-6"></span>
             </label>
           </div>
         </div>
@@ -171,7 +171,7 @@
         <div class="flex flex-wrap items-center justify-end gap-3">
           <button
             type="button"
-            class="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition"
+            class="text-sm text-text-muted hover:text-text-primary transition"
             @click="resetPreferences"
             :disabled="!hasPreferenceChanges"
           >
@@ -188,17 +188,17 @@
         <p v-if="preferenceMessage" class="text-sm text-status-success">{{ preferenceMessage }}</p>
       </section>
 
-      <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_88%,transparent)] p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl border border-border-subtle bg-surface-base/88 p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Security</h2>
-          <p class="text-sm text-[var(--color-text-muted)]">Keep your account protected and up to date.</p>
+          <p class="text-sm text-text-muted">Keep your account protected and up to date.</p>
         </header>
 
         <div class="space-y-6">
           <div class="flex flex-wrap items-start justify-between gap-6">
             <div>
               <h3 class="text-base font-medium">Password</h3>
-              <p class="text-sm text-[var(--color-text-muted)]">Use a strong password to protect your SoundRoom sessions and purchases.</p>
+              <p class="text-sm text-text-muted">Use a strong password to protect your SoundRoom sessions and purchases.</p>
             </div>
             <RouterLink to="/update-password">
               <BaseButton type="button">Update password</BaseButton>
@@ -208,7 +208,7 @@
           <div class="flex flex-wrap items-start justify-between gap-6">
             <div>
               <h3 class="text-base font-medium">Sign out</h3>
-              <p class="text-sm text-[var(--color-text-muted)]">Need to switch devices? Sign out to end your session on this browser.</p>
+              <p class="text-sm text-text-muted">Need to switch devices? Sign out to end your session on this browser.</p>
             </div>
             <BaseButton type="button" @click="signOutCurrentSession">Sign out of this device</BaseButton>
           </div>

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full bg-[var(--color-bg-app)] text-[var(--color-text-primary)] flex flex-col">
+  <div class="h-full bg-surface-app text-text-primary flex flex-col">
     <!-- Main Layout -->
     <div class="flex flex-1 overflow-hidden">
 
@@ -17,7 +17,7 @@
         <Toolbar/>
 
         <!-- Canvas Area -->
-        <div class="flex-1 relative overflow-hidden bg-[var(--color-bg-surface)] flex items-center justify-center border-t border-[var(--color-border-subtle)]">
+        <div class="flex-1 relative overflow-hidden bg-surface-base flex items-center justify-center border-t border-border-subtle">
           <div class="pointer-events-none absolute inset-0 canvas-vignette" aria-hidden="true"></div>
           <MainCanvasStage
             v-bind="{

--- a/src/views/UpdatePasswordPage.vue
+++ b/src/views/UpdatePasswordPage.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex flex-col items-center justify-center min-h-screen px-4 py-12 bg-[var(--color-bg-app)] text-text-primary transition-colors">
-    <div class="w-full max-w-sm space-y-6 bg-[var(--color-bg-surface)] rounded-2xl shadow-xl p-6 border border-border-subtle transition-colors">
+  <div class="flex flex-col items-center justify-center min-h-screen px-4 py-12 bg-surface-app text-text-primary transition-colors">
+    <div class="w-full max-w-sm space-y-6 bg-surface-base rounded-2xl shadow-xl p-6 border border-border-subtle transition-colors">
       <h2 class="text-2xl font-semibold text-center tracking-wide">Reset Your Password</h2>
 
       <PasswordInput

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,7 @@ module.exports = {
           app: withAlpha('--color-bg-app-rgb'),
           base: withAlpha('--color-bg-surface-rgb'),
           raised: withAlpha('--color-bg-elevated-rgb'),
+          muted: 'var(--color-surface-muted)',
         },
         border: {
           subtle: withAlpha('--color-border-subtle-rgb'),
@@ -38,10 +39,23 @@ module.exports = {
         },
         panel: withAlpha('--color-panel-rgb'),
         input: withAlpha('--color-input-rgb'),
+        focus: withAlpha('--color-focus-ring-rgb'),
+        disabled: {
+          bg: 'var(--color-disabled-bg)',
+          text: 'var(--color-disabled-text)',
+        },
+        outline: {
+          strong: 'var(--color-outline-strong)',
+          contrast: withAlpha('--color-outline-contrast-rgb'),
+        },
       },
       boxShadow: {
         soft: 'var(--color-shadow-soft)',
         strong: 'var(--color-shadow-strong)',
+        accent: '0 8px 24px rgba(var(--color-accent-rgb), 0.08)',
+        'accent-strong': '0 10px 28px rgba(var(--color-accent-strong-rgb), 0.1)',
+        'accent-outline': '0 0 0 4px rgba(var(--color-accent-rgb), 0.15)',
+        'accent-strong-outline': '0 0 0 5px rgba(var(--color-accent-strong-rgb), 0.18)',
       },
     },
   },


### PR DESCRIPTION
## Summary
- map design tokens from theme CSS into Tailwind theme entries
- replace inline CSS variable color usages with Tailwind utility classes across views and components
- simplify plan theme and modal styling with shared Tailwind shadows and focus rings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925377d07c4832fba7c52b90010b3b8)