### PR TITLE
Default to dark theme by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark" class="dark">
 <head>
   <!-- Primary Meta -->
   <title>SoundRoom</title>

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -7,12 +7,7 @@ function resolveInitialTheme() {
   if (typeof window === 'undefined') return DEFAULT_THEME
 
   const stored = localStorage.getItem(THEME_KEY)
-  if (SUPPORTED_THEMES.includes(stored)) return stored
-
-  const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches
-  if (typeof prefersDark === 'boolean') {
-    return prefersDark ? 'dark' : 'light'
-  }
+  if (stored === 'light') return stored
 
   return DEFAULT_THEME
 }


### PR DESCRIPTION
## Summary
- default initial theme resolution to dark unless the user explicitly saved light
- set initial html attributes to data-theme="dark" with a dark class to activate dark utilities on load

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692564710f18832f85f0598149115e95)