### PR TITLE
Fix sound library category button styling

### DIFF
--- a/src/components/ui/input/BaseButton.vue
+++ b/src/components/ui/input/BaseButton.vue
@@ -4,8 +4,8 @@
   :disabled="disabled"
   :class="[
     'transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)] disabled:opacity-50 disabled:cursor-not-allowed',
-    variant === 'default' && 'px-4 py-2 rounded text-sm font-medium bg-[var(--color-accent)] hover:bg-[var(--color-accent-strong)] text-[var(--color-text-inverse)] shadow-[var(--color-shadow-soft)]',
-    variant === 'naked' && 'bg-transparent text-[var(--color-text-primary)] hover:text-[var(--color-accent-soft)]'
+    !unstyled && variant === 'default' && 'px-4 py-2 rounded text-sm font-medium bg-[var(--color-accent)] hover:bg-[var(--color-accent-strong)] text-[var(--color-text-inverse)] shadow-[var(--color-shadow-soft)]',
+    !unstyled && variant === 'naked' && 'bg-transparent text-[var(--color-text-primary)] hover:text-[var(--color-accent-soft)]'
   ]"
   @click="(e) => $emit('click', e)"
 >
@@ -45,6 +45,10 @@ defineProps({
   },
   disabled: Boolean,
   loading: Boolean,
+  unstyled: {
+    type: Boolean,
+    default: false,
+  },
   variant: {
     type: String,
     default: 'default', // or 'naked'

--- a/src/components/ui/modals/SoundLibrary/CategoryList.vue
+++ b/src/components/ui/modals/SoundLibrary/CategoryList.vue
@@ -5,6 +5,7 @@
       v-if="isAuthenticated"
       :key="'your-sounds'"
       @click="handleSelectYourSounds"
+      unstyled
       :class="['sound-lib-button', { active: active === 'your-sounds', locked: !canUpload }]"
     >
       <span class="button-inner">
@@ -17,6 +18,7 @@
       v-for="cat in categories"
       :key="cat.id"
       @click="$emit('update:active', cat.id)"
+      unstyled
       :class="['sound-lib-button', { active: active === cat.id }]"
     >
       {{ cat.label }}

--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex-1 relative overflow-hidden">
-    <div class="absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[color-mix(in_srgb,var(--color-bg-surface)_70%,transparent)] backdrop-blur-md border-b border-border-subtle text-text-primary">
+    <div class="modal-header-float text-text-primary">
       <h2 class="text-2xl font-bold">SoundLibrary</h2>
       <BaseButton class="text-sm" @click="$emit('close')">Close</BaseButton>
     </div>


### PR DESCRIPTION
## Summary
- add an `unstyled` option to `BaseButton` to opt out of the default accent styling
- apply the unstyled buttons to the sound library category list so its custom colors take effect

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692574dbf834832fa0307ced0e487672)