### PR TITLE
Refine theme color variable mapping

### DIFF
--- a/src/components/Settings/ThemeSelector.vue
+++ b/src/components/Settings/ThemeSelector.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] p-6 shadow-sm space-y-6">
+  <section class="rounded-2xl sr-border sr-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] p-6 shadow-sm space-y-6">
     <header class="space-y-2">
       <h2 class="text-xl font-semibold">Appearance</h2>
       <p class="text-sm text-[var(--color-text-muted)]">Pick a theme and preview its palette.</p>
@@ -10,11 +10,11 @@
         v-for="theme in themes"
         :key="theme.name"
         type="button"
-        class="relative flex flex-col gap-3 rounded-xl border p-4 text-left transition duration-200"
+        class="relative flex flex-col gap-3 rounded-xl sr-border p-4 text-left transition duration-200"
         :class="[
           activeTheme === theme.name
-            ? 'border-[var(--color-accent-soft)] ring-2 ring-[color-mix(in_srgb,var(--color-accent)_65%,transparent)] shadow-md'
-            : 'border-border-subtle hover:border-[var(--color-border-strong)] hover:shadow-sm',
+            ? 'border-accent-soft ring-2 ring-[color-mix(in_srgb,var(--color-accent)_65%,transparent)] shadow-md'
+            : 'sr-border-subtle hover:sr-border-strong hover:shadow-sm',
           'bg-[color-mix(in_srgb,var(--color-bg-elevated)_86%,transparent)] hover:-translate-y-0.5 hover:scale-[1.01]'
         ]"
         :style="previewStyle(theme.name)"
@@ -33,10 +33,10 @@
           </span>
         </div>
 
-        <div class="relative h-20 w-full overflow-hidden rounded-xl border" :style="previewFrameStyle">
+        <div class="relative h-20 w-full overflow-hidden rounded-xl sr-border" :style="previewFrameStyle">
           <div class="absolute inset-0" :style="{ background: 'var(--preview-bg)' }"></div>
           <div
-            class="absolute inset-[12px] rounded-lg border"
+            class="absolute inset-[12px] rounded-lg sr-border"
             :style="{ background: 'var(--preview-surface)', borderColor: 'color-mix(in srgb, var(--preview-border) 70%, transparent)' }"
           ></div>
           <div class="absolute left-5 top-5 flex items-center gap-2">

--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -26,7 +26,7 @@
       <BaseButton
         @click="showSaveConfirm = true"
         :disabled="isSaving || !isRoomSaveable"
-        class="px-3 py-2 rounded bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] border border-[var(--color-border-subtle)] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+        class="px-3 py-2 rounded bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] sr-border sr-border-subtle transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
         type="button"
         aria-label="Open save room confirmation"
       >
@@ -36,7 +36,7 @@
       <BaseButton
         @click="showNewRoomConfirm = true"
         :disabled="isSaving || isRoomEmpty"
-        class="px-3 py-2 rounded bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] border border-[var(--color-border-subtle)] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+        class="px-3 py-2 rounded bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] sr-border sr-border-subtle transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
         type="button"
         aria-label="Open new room confirmation"
       >

--- a/src/components/SoundRoom/HeaderBar.vue
+++ b/src/components/SoundRoom/HeaderBar.vue
@@ -1,6 +1,6 @@
 <template>
   <PulsingOverlay v-if="isLoggingOut" :duration="2000" :text="'Logging out...'" @done="isLoggingOut = false" />
-  <header class="px-6 py-4 border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] flex items-center justify-between relative">
+  <header class="px-6 py-4 border-b sr-border-subtle bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] flex items-center justify-between relative">
     <h1 class="text-xl font-bold tracking-wide text-[var(--color-text-primary)]"><RouterLink to="/" style="text-decoration: none; color: inherit;">SoundRoom</RouterLink></h1>
     
     <div v-if="shouldShowNavButtons" class="relative">
@@ -21,7 +21,7 @@
           v-if="isMenuOpen"
           @mouseleave="closeMenu"
           ref="menuPanel"
-          class="absolute right-0 mt-2 w-44 rounded-lg shadow-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] py-2 z-50 flex flex-col divide-y divide-[var(--color-border-subtle)] overflow-hidden"
+          class="absolute right-0 mt-2 w-44 rounded-lg shadow-lg sr-border sr-border-subtle bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] py-2 z-50 flex flex-col divide-y divide-[var(--color-border-subtle)] overflow-hidden"
         >
           <template v-for="button in visibleButtons" :key="button.label">
             <button

--- a/src/components/SoundRoom/IRSelect.vue
+++ b/src/components/SoundRoom/IRSelect.vue
@@ -2,7 +2,7 @@
   <select
     v-model="selectedIR"
     @change="applyIR"
-    class="px-2 py-1 w-32 rounded border text-sm bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] border-[var(--color-border-subtle)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]"
+    class="px-2 py-1 w-32 rounded sr-border text-sm bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] sr-border-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]"
   >
     <option v-for="ir in irOptions" :key="ir.value" :value="ir.value">
       {{ ir.label }}

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -120,10 +120,10 @@ const soundNodeTitleCoords = computed(() => {
 /* Grid spacing and line opacity can be tuned here to adjust density/visibility */
 .canvas-grid {
   background-size: 40px 40px; /* Adjust spacing between grid lines */
-  background-color: var(--lm-bg-1);
+  background-color: var(--color-bg-surface);
   background-image:
-    linear-gradient(to right, var(--lm-grid-line) 1px, transparent 1px),
-    linear-gradient(to bottom, var(--lm-grid-line) 1px, transparent 1px); /* Adjust line opacity */
+    linear-gradient(to right, var(--color-grid-line) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--color-grid-line) 1px, transparent 1px); /* Adjust line opacity */
 }
 
 [data-theme="dark"] .canvas-grid {

--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -4,7 +4,7 @@
     role="application"
     tabindex="0"
     aria-label="SoundRoom 2D audio environment. Use keyboard or mouse to interact with sound nodes."
-    class="canvas-grid relative border border-[var(--color-border-subtle)] dark:border-2 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] shadow-[var(--color-shadow-soft)]"
+    class="canvas-grid relative sr-border sr-border-subtle dark:sr-border-2 flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] shadow-[var(--color-shadow-soft)]"
     :class="`w-[${room.width}px] h-[${room.height}px]`"
     @dragover.prevent
     @drop="handleDrop"

--- a/src/components/SoundRoom/MainCanvasStage/ScheduledPlayRing.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ScheduledPlayRing.vue
@@ -61,7 +61,6 @@ const fallbackColor = computed(() => {
   const styles = getComputedStyle(document.documentElement)
   return (
     styles.getPropertyValue('--color-accent-strong')?.trim() ||
-    styles.getPropertyValue('--sr-primary')?.trim() ||
     `rgb(${styles.getPropertyValue('--color-accent-strong-rgb')?.trim() || 'var(--color-accent-strong-rgb)'})`
   )
 })

--- a/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarLeft/DraggableSourcePanel.vue
@@ -20,7 +20,7 @@
   <button
     :disabled="soundLibrarySources.length == MAX_SOURCES"
     @click="() => { router.push('/sound-library') }"
-    class="w-full mt-4 bg-[var(--color-bg-surface)] text-xs rounded hover:bg-[var(--color-bg-elevated)] border border-[var(--color-border-subtle)] text-[var(--color-text-primary)]"
+    class="w-full mt-4 bg-[var(--color-bg-surface)] text-xs rounded hover:bg-[var(--color-bg-elevated)] sr-border sr-border-subtle text-[var(--color-text-primary)]"
   >
     + Add Source
   </button>

--- a/src/components/SoundRoom/SidebarLeft/LibrarySource.vue
+++ b/src/components/SoundRoom/SidebarLeft/LibrarySource.vue
@@ -1,6 +1,6 @@
 <template>
   <li
-    class="cursor-move bg-surface-raised text-text-primary border border-border-subtle p-1 rounded text-center"
+    class="cursor-move bg-surface-raised text-text-primary sr-border sr-border-subtle p-1 rounded text-center"
     draggable="true"
   >
     {{ librarySource.name }}

--- a/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
+++ b/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-[var(--color-bg-elevated)] border-r border-[var(--color-border-subtle)] p-4 space-y-6 text-[var(--color-text-primary)]"
+    class="flex flex-col h-full bg-[var(--color-bg-elevated)] sr-border-r sr-border-subtle p-4 space-y-6 text-[var(--color-text-primary)]"
     role="region"
     aria-labelledby="library-panel-label"
   >

--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -33,19 +33,19 @@
       <div class="w-full space-y-2">
         <button
           @click="playPauseSource"
-          class="w-full bg-[var(--color-bg-surface)] text-xs rounded hover:bg-[var(--color-bg-elevated)] border border-[var(--color-border-subtle)] text-[var(--color-text-primary)]"
+          class="w-full bg-[var(--color-bg-surface)] text-xs rounded hover:bg-[var(--color-bg-elevated)] sr-border sr-border-subtle text-[var(--color-text-primary)]"
         >
           {{ playPauseLabel }}
         </button>
         <button
           @click="deleteSource"
-          class="w-full bg-[var(--color-bg-surface)] text-xs rounded hover:bg-[var(--color-bg-elevated)] border border-[var(--color-border-subtle)] text-[var(--color-text-primary)]"
+          class="w-full bg-[var(--color-bg-surface)] text-xs rounded hover:bg-[var(--color-bg-elevated)] sr-border sr-border-subtle text-[var(--color-text-primary)]"
         >
           Delete
         </button>
       </div>
 
-      <hr class="w-full border-[var(--color-border-subtle)]" />
+      <hr class="w-full sr-border sr-border-subtle" />
 
       <!-- Scheduling Toggle -->
       <div class="w-full flex items-center space-x-2 text-left px-1 text-[var(--color-text-muted)]">
@@ -77,7 +77,7 @@
             :value="schedule.mode"
             @change="handleScheduleModeChange"
             @blur="commitScheduleEdit"
-            class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]">
+            class="px-2 py-1 rounded sr-border sr-border-subtle bg-[var(--color-bg-elevated)]">
             <option value="interval">Interval</option>
             <option v-if="canUseAdvancedScheduling" value="count">Count</option>
             <option v-if="canUseAdvancedScheduling" value="interval+count">Interval + Count</option>
@@ -99,7 +99,7 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+              class="px-2 py-1 rounded sr-border sr-border-subtle bg-[var(--color-bg-elevated)]"
             />
           </div>
           <div class="flex flex-col space-y-1">
@@ -116,7 +116,7 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+              class="px-2 py-1 rounded sr-border sr-border-subtle bg-[var(--color-bg-elevated)]"
             />
             <p v-if="schedule.gapMax < schedule.gapMin" class="text-[var(--color-danger)] text-xs">
               Gap Max cannot be smaller than Gap Min
@@ -140,7 +140,7 @@
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
               placeholder="Unlimited"
-              class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+              class="px-2 py-1 rounded sr-border sr-border-subtle bg-[var(--color-bg-elevated)]"
             />
           </div>
           <div class="flex flex-col space-y-1">
@@ -156,7 +156,7 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+              class="px-2 py-1 rounded sr-border sr-border-subtle bg-[var(--color-bg-elevated)]"
             />
           </div>
           <div class="flex flex-col space-y-1">
@@ -171,7 +171,7 @@
               }"
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
-              class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+              class="px-2 py-1 rounded sr-border sr-border-subtle bg-[var(--color-bg-elevated)]"
             />
           </div>
         </div>

--- a/src/components/SoundRoom/SidebarRight/SidebarRight.vue
+++ b/src/components/SoundRoom/SidebarRight/SidebarRight.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-[var(--color-bg-elevated)] border-l border-[var(--color-border-subtle)] p-4 space-y-4 text-[var(--color-text-primary)]"
+    class="flex flex-col h-full bg-[var(--color-bg-elevated)] sr-border-l sr-border-subtle p-4 space-y-4 text-[var(--color-text-primary)]"
     role="region"
     aria-labelledby="selected-sound-panel-label"
   >

--- a/src/components/SoundRoom/Toolbar.vue
+++ b/src/components/SoundRoom/Toolbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex items-center justify-between p-3 border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] space-x-10 w-full shadow-[var(--color-shadow-soft)] text-[var(--color-text-primary)]">
+  <div class="flex items-center justify-between p-3 sr-border-subtle bg-[var(--color-bg-elevated)] space-x-10 w-full shadow-[var(--color-shadow-soft)] text-[var(--color-text-primary)]">
           
     <div class="flex space-x-2 w-1/3">
       <BaseButton

--- a/src/components/ui/input/BaseInput.vue
+++ b/src/components/ui/input/BaseInput.vue
@@ -16,10 +16,10 @@
       :autocomplete="autocomplete"
       :disabled="disabled"
       :class="[
-        'px-3 py-2 rounded border w-full text-sm focus:outline-none bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] border-[var(--color-border-subtle)] focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]',
+        'px-3 py-2 rounded sr-border sr-border-subtle w-full text-sm focus:outline-none bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)]',
         props.class,
         error
-          ? 'border-[var(--color-danger)] text-[var(--color-danger)] bg-[rgba(var(--color-danger-rgb),0.12)]'
+          ? 'border-status-danger text-[var(--color-danger)] bg-[rgba(var(--color-danger-rgb),0.12)]'
           : '',
       ]"
       v-model="internalValue"

--- a/src/components/ui/modals/Help.vue
+++ b/src/components/ui/modals/Help.vue
@@ -1,6 +1,6 @@
 <template>
   <div @click.self="handleClose" class="modal-backdrop">
-    <div class="bg-surface-base text-text-primary rounded-2xl w-[80vw] h-[80vh] relative flex flex-col overflow-hidden shadow-2xl border border-border-subtle">
+    <div class="bg-surface-base text-text-primary rounded-2xl w-[80vw] h-[80vh] relative flex flex-col overflow-hidden shadow-2xl sr-border sr-border-subtle">
       
       <!-- Absolute Floating Header -->
       <div class="modal-header-float">
@@ -85,7 +85,7 @@
           </section>
 
           <section>
-            <h2 class="text-lg font-semibold mb-4 border-b border-border-subtle pb-1">FAQ</h2>
+            <h2 class="text-lg font-semibold mb-4 sr-border-b sr-border-subtle pb-1">FAQ</h2>
             <ul>
               <li
                 v-for="(faq, i) in faqs"
@@ -133,7 +133,7 @@
                     v-model="form.name"
                     required
                     autocomplete="name"
-                    class="w-full px-3 py-2 border border-[var(--color-border-subtle)] rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
+                    class="w-full px-3 py-2 sr-border sr-border-subtle rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
                   />
                 </div>
 
@@ -145,7 +145,7 @@
                     v-model="form.email"
                     required
                     autocomplete="email"
-                    class="w-full px-3 py-2 border border-[var(--color-border-subtle)] rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
+                    class="w-full px-3 py-2 sr-border sr-border-subtle rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
                   />
                 </div>
               </div>
@@ -157,7 +157,7 @@
                     id="topic"
                     v-model="form.topic"
                     required
-                    class="w-full px-3 py-2 border border-[var(--color-border-subtle)] rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
+                    class="w-full px-3 py-2 sr-border sr-border-subtle rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
                   >
                     <option v-for="item in topicOptions" :key="item.value" :value="item.value">{{ item.label }}</option>
                   </select>
@@ -168,7 +168,7 @@
                   <select
                     id="plan"
                     v-model="form.plan"
-                    class="w-full px-3 py-2 border border-[var(--color-border-subtle)] rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
+                    class="w-full px-3 py-2 sr-border sr-border-subtle rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
                   >
                     <option value="">Select your plan</option>
                     <option v-for="option in planOptions" :key="option" :value="option">{{ PLAN_LABELS[option] }}</option>
@@ -184,7 +184,7 @@
                   id="roomLink"
                   v-model="form.roomLink"
                   placeholder="Paste a RoomManager link or card ID"
-                  class="w-full px-3 py-2 border border-[var(--color-border-subtle)] rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
+                  class="w-full px-3 py-2 sr-border sr-border-subtle rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
                 />
               </div>
 
@@ -196,7 +196,7 @@
                   rows="4"
                   required
                   placeholder="Tell us what you were working on and what you expected to happen."
-                  class="w-full px-3 py-2 border border-[var(--color-border-subtle)] rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
+                  class="w-full px-3 py-2 sr-border sr-border-subtle rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
                 ></textarea>
               </div>
 
@@ -207,7 +207,7 @@
                   v-model="form.reproSteps"
                   rows="3"
                   placeholder="Step-by-step details help us debug much faster."
-                  class="w-full px-3 py-2 border border-[var(--color-border-subtle)] rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
+                  class="w-full px-3 py-2 sr-border sr-border-subtle rounded bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg-surface)] text-sm"
                 ></textarea>
               </div>
 

--- a/src/components/ui/modals/Onboarding.vue
+++ b/src/components/ui/modals/Onboarding.vue
@@ -21,7 +21,7 @@
           <li>Undo/redo with <strong>U</strong> / <strong>R</strong>.</li>
         </ul>
 
-        <div class="rounded p-4 text-[var(--color-accent-strong)] border border-[rgba(var(--color-accent-rgb),0.35)] bg-[rgba(var(--color-accent-rgb),0.08)]">
+        <div class="rounded p-4 text-[var(--color-accent-strong)] sr-border border-accent bg-[rgba(var(--color-accent-rgb),0.08)]">
           <strong>Pro tip:</strong> You can layer ambience, nature, music, and directional audio for maximum effect.
         </div>
       </div>

--- a/src/components/ui/modals/SoundLibrary/UploadPanel.vue
+++ b/src/components/ui/modals/SoundLibrary/UploadPanel.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="modal-backdrop z-50" @click.self="$emit('close')">
-    <div class="modal-panel max-w-3xl mx-auto p-6 bg-surface-base text-text-primary rounded-xl shadow-lg overflow-y-auto max-h-[90vh] border border-border-subtle">
+    <div class="modal-panel max-w-3xl mx-auto p-6 bg-surface-base text-text-primary rounded-xl shadow-lg overflow-y-auto max-h-[90vh] sr-border sr-border-subtle">
       <h2 class="text-xl font-bold mb-4">Upload Your Sounds</h2>
 
-      <div class="border border-dashed border-[var(--color-border-subtle)] rounded-lg p-6 text-center mb-6 bg-[color-mix(in_srgb,var(--color-bg-surface)_80%,transparent)]">
+      <div class="sr-border border-dashed sr-border-subtle rounded-lg p-6 text-center mb-6 bg-[color-mix(in_srgb,var(--color-bg-surface)_80%,transparent)]">
         <input
           type="file"
           accept="audio/*"
@@ -17,11 +17,11 @@
       </div>
 
       <div v-if="files.length > 0" class="space-y-4">
-        <div v-for="file in files" :key="file.id" class="bg-[var(--color-bg-surface)] rounded-md p-4 flex flex-col gap-2 border border-border-subtle">
+        <div v-for="file in files" :key="file.id" class="bg-[var(--color-bg-surface)] rounded-md p-4 flex flex-col gap-2 sr-border sr-border-subtle">
           <div class="flex justify-between items-center">
             <input
               v-model="file.name"
-              class="flex-1 p-1 text-base border border-[var(--color-border-subtle)] rounded-md bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-elevated)]"
+              class="flex-1 p-1 text-base sr-border sr-border-subtle rounded-md bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-elevated)]"
             />
             <BaseButton class="ml-2" @click="autoTag(file)" :disabled="file.tagging">
               <template v-if="file.tagging">
@@ -48,7 +48,7 @@
           <span
             v-for="(tag, index) in file.tags"
             :key="tag"
-            class="flex items-center bg-[var(--color-bg-elevated)] text-xs px-2 rounded text-[var(--color-text-primary)] border border-border-subtle"
+            class="flex items-center bg-[var(--color-bg-elevated)] text-xs px-2 rounded text-[var(--color-text-primary)] sr-border sr-border-subtle"
           >
             {{ tag }}
             <label
@@ -69,7 +69,7 @@
             @keydown="','"
             @blur="addTag(file)"
             placeholder="Add tag..."
-            class="text-sm p-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] w-25 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-elevated)]"
+            class="text-sm p-1 rounded sr-border sr-border-subtle bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] w-25 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-elevated)]"
           />
         </div>
 

--- a/src/constants/planThemes.js
+++ b/src/constants/planThemes.js
@@ -1,22 +1,22 @@
 export const PLAN_THEMES = {
   free: {
-    card: 'border border-[var(--color-border-subtle)] hover:border-[var(--color-border-strong)] focus-within:border-[var(--color-border-strong)] shadow-[var(--color-shadow-soft)] bg-[var(--color-bg-surface)]',
+    card: 'sr-border sr-border-subtle hover:sr-border-strong focus-within:sr-border-strong shadow-[var(--color-shadow-soft)] bg-[var(--color-bg-surface)]',
     ring: '',
     cta: 'bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface)] focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-app)]',
     badge: 'bg-[rgba(var(--color-border-strong-rgb),0.85)] text-[var(--color-text-inverse)]',
     soundHighlight: ''
   },
   basic: {
-    card: 'border border-[rgba(var(--color-accent-soft-rgb),0.65)] hover:border-[var(--color-accent)] focus-within:border-[var(--color-accent)] ring-1 ring-[rgba(var(--color-accent-rgb),0.4)] shadow-[0_8px_24px_rgba(var(--color-accent-rgb),0.08)] bg-[color-mix(in_srgb,var(--color-bg-surface)_94%,transparent)]',
+    card: 'sr-border border-accent-soft hover:border-accent focus-within:border-accent ring-1 ring-[rgba(var(--color-accent-rgb),0.4)] shadow-[0_8px_24px_rgba(var(--color-accent-rgb),0.08)] bg-[color-mix(in_srgb,var(--color-bg-surface)_94%,transparent)]',
     cta: 'bg-[var(--color-accent)] text-[var(--color-text-inverse)] hover:bg-[var(--color-accent-strong)] focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-app)]',
     badge: 'bg-[var(--color-accent-strong)] text-[var(--color-text-inverse)]',
-    soundHighlight: 'ring-2 ring-offset-2 ring-[rgba(var(--color-accent-rgb),0.65)] ring-offset-[var(--color-bg-app)] shadow-[0_0_0_4px_rgba(var(--color-accent-rgb),0.15)] border-[rgba(var(--color-accent-rgb),0.6)]'
+    soundHighlight: 'ring-2 ring-offset-2 ring-[rgba(var(--color-accent-rgb),0.65)] ring-offset-[var(--color-bg-app)] shadow-[0_0_0_4px_rgba(var(--color-accent-rgb),0.15)] border-accent'
   },
   pro: {
-    card: 'border border-[rgba(var(--color-accent-strong-rgb),0.6)] hover:border-[var(--color-accent-strong)] focus-within:border-[var(--color-accent-strong)] ring-1 ring-[rgba(var(--color-accent-strong-rgb),0.35)] shadow-[0_10px_28px_rgba(var(--color-accent-strong-rgb),0.1)] bg-[color-mix(in_srgb,var(--color-bg-elevated)_92%,transparent)]',
+    card: 'sr-border border-accent-strong hover:border-accent-strong focus-within:border-accent-strong ring-1 ring-[rgba(var(--color-accent-strong-rgb),0.35)] shadow-[0_10px_28px_rgba(var(--color-accent-strong-rgb),0.1)] bg-[color-mix(in_srgb,var(--color-bg-elevated)_92%,transparent)]',
     cta: 'bg-[var(--color-accent-strong)] text-[var(--color-text-inverse)] hover:bg-[var(--color-accent)] focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-app)]',
     badge: 'bg-[var(--color-accent)] text-[var(--color-text-inverse)]',
-    soundHighlight: 'ring-2 ring-offset-2 ring-[rgba(var(--color-accent-strong-rgb),0.65)] ring-offset-[var(--color-bg-app)] shadow-[0_0_0_5px_rgba(var(--color-accent-strong-rgb),0.18)] border-[rgba(var(--color-accent-strong-rgb),0.7)]'
+    soundHighlight: 'ring-2 ring-offset-2 ring-[rgba(var(--color-accent-strong-rgb),0.65)] ring-offset-[var(--color-bg-app)] shadow-[0_0_0_5px_rgba(var(--color-accent-strong-rgb),0.18)] border-accent-strong'
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -80,8 +80,7 @@ button:disabled {
 input[type="text"],
 input[type="email"],
 input[type="password"] {
-  @apply w-full p-3 border rounded-lg;
-  border-color: var(--color-border-subtle);
+  @apply w-full p-3 sr-border sr-border-subtle rounded-lg;
   background-color: var(--color-bg-elevated);
   color: var(--color-text-primary);
 }
@@ -98,20 +97,17 @@ input:disabled {
 }
 
 .modal-panel {
-  @apply rounded-2xl w-[80vw] h-[80vh] border overflow-hidden;
+  @apply rounded-2xl w-[80vw] h-[80vh] sr-border sr-border-subtle overflow-hidden;
   background-color: var(--color-bg-app);
-  border-color: var(--color-border-subtle);
   box-shadow: var(--color-shadow-soft);
 }
 
 .modal-header-float {
-  @apply absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 backdrop-blur-md border-b;
+  @apply absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 backdrop-blur-md sr-border-b sr-border-subtle;
   background: color-mix(in srgb, var(--color-bg-app) 85%, transparent);
-  border-color: var(--color-border-subtle);
 }
 
 .modal-header {
-  @apply top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 backdrop-blur-md border-b;
+  @apply top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 backdrop-blur-md sr-border-b sr-border-subtle;
   background: color-mix(in srgb, var(--color-bg-app) 85%, transparent);
-  border-color: var(--color-border-subtle);
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,5 @@
-@import "tailwindcss";
 @import "./styles/theme-tokens.css";
+@import "tailwindcss";
 
 :root {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
@@ -46,7 +46,8 @@ button {
   font-family: inherit;
   cursor: pointer;
   transition: border-color 0.25s, box-shadow 0.25s;
-  @apply bg-[var(--color-bg-surface)] text-[var(--color-text-primary)];
+  background-color: var(--color-bg-surface);
+  color: var(--color-text-primary);
 }
 button:hover {
   border-color: var(--color-border-subtle);
@@ -79,25 +80,38 @@ button:disabled {
 input[type="text"],
 input[type="email"],
 input[type="password"] {
-  @apply w-full p-3 border border-[var(--color-border-subtle)] rounded-lg bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)];
+  @apply w-full p-3 border rounded-lg;
+  border-color: var(--color-border-subtle);
+  background-color: var(--color-bg-elevated);
+  color: var(--color-text-primary);
 }
 
 input:disabled {
-  @apply opacity-50 cursor-not-allowed bg-[var(--color-disabled-bg)] text-[var(--color-disabled-text)];
+  @apply opacity-50 cursor-not-allowed;
+  background-color: var(--color-disabled-bg);
+  color: var(--color-disabled-text);
 }
 
 .modal-backdrop {
-  @apply fixed inset-0 bg-[color-mix(in_srgb,var(--color-text-inverse)_60%,transparent)] backdrop-blur-sm z-50 flex items-center justify-center;
+  @apply fixed inset-0 backdrop-blur-sm z-50 flex items-center justify-center;
+  background: color-mix(in srgb, var(--color-text-inverse) 60%, transparent);
 }
 
 .modal-panel {
-  @apply bg-[var(--color-bg-app)] rounded-2xl w-[80vw] h-[80vh] shadow-[var(--color-shadow-soft)] border border-[var(--color-border-subtle)] overflow-hidden;
+  @apply rounded-2xl w-[80vw] h-[80vh] border overflow-hidden;
+  background-color: var(--color-bg-app);
+  border-color: var(--color-border-subtle);
+  box-shadow: var(--color-shadow-soft);
 }
 
 .modal-header-float {
-  @apply absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[color-mix(in_srgb,var(--color-bg-app)_85%,transparent)] backdrop-blur-md border-b border-[var(--color-border-subtle)];
+  @apply absolute top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 backdrop-blur-md border-b;
+  background: color-mix(in srgb, var(--color-bg-app) 85%, transparent);
+  border-color: var(--color-border-subtle);
 }
 
 .modal-header {
-  @apply top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[color-mix(in_srgb,var(--color-bg-app)_85%,transparent)] backdrop-blur-md border-b border-[var(--color-border-subtle)];
+  @apply top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 backdrop-blur-md border-b;
+  background: color-mix(in srgb, var(--color-bg-app) 85%, transparent);
+  border-color: var(--color-border-subtle);
 }

--- a/src/styles/theme-tokens.css
+++ b/src/styles/theme-tokens.css
@@ -125,32 +125,6 @@
   --color-body-stroke-rgb: 60, 70, 85;
   --color-detail-fill-rgb: 70, 80, 95;
   --color-detail-gradient-rgb: 140, 150, 165;
-
-  /* -----------------------------------------
-     LEGACY ALIASES (for safety)
-     ----------------------------------------- */
-  --lm-bg-0: var(--color-bg-app);
-  --lm-bg-1: var(--color-bg-surface);
-  --lm-bg-2: var(--color-bg-elevated);
-  --lm-border: var(--color-border-subtle);
-  --lm-text-0: var(--color-text-primary);
-  --lm-text-1: var(--color-text-muted);
-  --lm-grid-line: var(--color-grid-line);
-
-  --sr-white: var(--base-white);
-  --sr-white-rgb: var(--base-white-rgb);
-  --sr-black: var(--base-black);
-  --sr-black-rgb: var(--base-black-rgb);
-
-  --sr-primary: var(--color-accent);
-  --sr-accent-danger: var(--color-danger);
-  --sr-surface-muted: var(--color-surface-muted);
-  --sr-text-muted: var(--color-text-muted);
-  --sr-text-strong: var(--color-text-primary);
-  --sr-node-red: var(--color-node-red);
-  --sr-node-blue: var(--color-node-blue);
-  --sr-outline-strong: var(--color-border-strong);
-  --sr-outline-contrast: var(--color-outline-contrast);
 }
 
 /* -----------------------------------------------------------
@@ -169,29 +143,44 @@
 
   /* Backgrounds */
   --color-bg-app: #f6f6f8;
+  --color-bg-app-rgb: 246, 246, 248;
   --color-bg-surface: #efeff2;
+  --color-bg-surface-rgb: 239, 239, 242;
   --color-bg-elevated: #e5e5ea;
+  --color-bg-elevated-rgb: 229, 229, 234;
 
   /* Borders */
   --color-border-subtle: #d3d3da;
+  --color-border-subtle-rgb: 211, 211, 218;
   --color-border-strong: #b9b9c3;
+  --color-border-strong-rgb: 185, 185, 195;
 
   /* Text */
   --color-text-primary: #1c1c20;
+  --color-text-primary-rgb: 28, 28, 32;
   --color-text-secondary: #34343d;
+  --color-text-secondary-rgb: 52, 52, 61;
   --color-text-muted: #595965;
+  --color-text-muted-rgb: 89, 89, 101;
 
   --color-text-inverse: #ffffff;
+  --color-text-inverse-rgb: 255, 255, 255;
 
   /* Accent — cobalt values stay consistent */
   --color-accent: #2f6dfd;
+  --color-accent-rgb: 47, 109, 253;
   --color-accent-soft: #6fa2ff;
+  --color-accent-soft-rgb: 111, 162, 255;
   --color-accent-strong: #1f4fc6;
+  --color-accent-strong-rgb: 31, 79, 198;
 
   /* Status */
   --color-success: #238c6c;
+  --color-success-rgb: 35, 140, 108;
   --color-warning: #bb812a;
+  --color-warning-rgb: 187, 129, 42;
   --color-danger: #c44545;
+  --color-danger-rgb: 196, 69, 69;
 
   /* Shadows */
   --color-shadow-soft: 0 8px 24px rgba(0, 0, 0, 0.16);
@@ -201,7 +190,9 @@
   --color-grid-line: rgba(0, 0, 0, 0.08);
 
   --color-node-blue: #3f73e8;
+  --color-node-blue-rgb: 63, 115, 232;
   --color-node-red: #d86b6b;
+  --color-node-red-rgb: 216, 107, 107;
 
   --color-node-highlight: rgba(47, 109, 253, 0.12);
   --color-selection-strong: #2f6dfd;
@@ -210,11 +201,21 @@
   --color-surface-muted: #e6ebf3;
 
   --color-panel: #ffffff;
+  --color-panel-rgb: 255, 255, 255;
   --color-input: #ffffff;
+  --color-input-rgb: 255, 255, 255;
 
   --color-disabled-bg: #e3e7ee;
   --color-disabled-text: #9aa6ba;
 
   --color-outline-strong: #3a4860;
   --color-detail-stroke: #334155;
+
+  --color-outline-contrast: #131317;
+  --color-outline-contrast-rgb: 19, 19, 23;
+
+  --color-body-fill-rgb: 150, 165, 185;
+  --color-body-stroke-rgb: 60, 70, 85;
+  --color-detail-fill-rgb: 70, 80, 95;
+  --color-detail-gradient-rgb: 140, 150, 165;
 }

--- a/src/views/ManagePlan.vue
+++ b/src/views/ManagePlan.vue
@@ -4,11 +4,11 @@
       <section class="space-y-4">
         <div
           v-if="checkoutStatusMessage || checkoutErrorMessage || isProcessingCheckout"
-          class="rounded-xl border p-4"
+          class="rounded-xl sr-border sr-border-subtle p-4"
           :class="[
-            isProcessingCheckout ? 'border-[var(--color-accent-soft)] bg-[rgba(var(--color-accent-rgb),0.12)] text-[var(--color-text-primary)]' : '',
-            checkoutStatusMessage && !isProcessingCheckout ? 'border-[var(--color-success)] bg-[rgba(var(--color-success-rgb),0.12)] text-[var(--color-text-primary)]' : '',
-            checkoutErrorMessage ? 'border-[var(--color-danger)] bg-[rgba(var(--color-danger-rgb),0.12)] text-[var(--color-text-primary)]' : '',
+            isProcessingCheckout ? 'border-accent-soft bg-[rgba(var(--color-accent-rgb),0.12)] text-[var(--color-text-primary)]' : '',
+            checkoutStatusMessage && !isProcessingCheckout ? 'border-status-success bg-[rgba(var(--color-success-rgb),0.12)] text-[var(--color-text-primary)]' : '',
+            checkoutErrorMessage ? 'border-status-danger bg-[rgba(var(--color-danger-rgb),0.12)] text-[var(--color-text-primary)]' : '',
           ]"
         >
           <p v-if="isProcessingCheckout" class="text-sm font-medium">Processing your plan change…</p>
@@ -32,7 +32,7 @@
         </div>
 
         <div
-          class="rounded-2xl p-6 shadow-sm border bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)]"
+          class="rounded-2xl p-6 shadow-sm sr-border sr-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)]"
           :class="planTheme.card"
         >
           <header class="flex flex-wrap items-center justify-between gap-4">
@@ -80,7 +80,7 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl sr-border sr-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] p-6 shadow-sm space-y-6">
         <header class="space-y-1">
           <h2 class="text-xl font-semibold">Billing & Receipts</h2>
           <p class="text-sm text-[var(--color-text-muted)]">
@@ -88,7 +88,7 @@
           </p>
         </header>
 
-        <div class="rounded-xl border border-dashed border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] px-5 py-6 text-sm text-[var(--color-text-secondary)]">
+        <div class="rounded-xl sr-border border-dashed sr-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] px-5 py-6 text-sm text-[var(--color-text-secondary)]">
           <p>Need an invoice, tax receipt, or want to change your payment method?</p>
           <p class="mt-3">Email <a class="underline" :href="supportEmailHref">{{ SUPPORT_EMAIL }}</a> and include the email tied to your SoundRoom account.</p>
         </div>
@@ -111,14 +111,14 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl sr-border sr-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] p-6 shadow-sm space-y-6">
         <header class="space-y-1">
           <h2 class="text-xl font-semibold">Upcoming Features</h2>
           <p class="text-sm text-[var(--color-text-muted)]">We are actively building deeper collaboration and scheduling tools. Here is what is landing next for paying members.</p>
         </header>
 
         <ul class="grid gap-4 md:grid-cols-2">
-          <li v-for="item in roadmapHighlights" :key="item.title" class="rounded-xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_92%,transparent)] p-5 space-y-2">
+          <li v-for="item in roadmapHighlights" :key="item.title" class="rounded-xl sr-border sr-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_92%,transparent)] p-5 space-y-2">
             <p class="text-sm uppercase tracking-wide text-[var(--color-text-muted)]">{{ item.badge }}</p>
             <h3 class="text-lg font-medium">{{ item.title }}</h3>
             <p class="text-sm text-[var(--color-text-muted)]">{{ item.copy }}</p>

--- a/src/views/Pricing/Pricing.vue
+++ b/src/views/Pricing/Pricing.vue
@@ -33,7 +33,7 @@
           >
             {{ checkoutError }}
           </p>
-          <div class="max-w-5xl mx-auto rounded-md border border-border-subtle bg-surface-base p-4 text-left shadow-sm" data-testid="pricing-feature-comparison">
+          <div class="max-w-5xl mx-auto rounded-md sr-border sr-border-subtle bg-surface-base p-4 text-left shadow-sm" data-testid="pricing-feature-comparison">
             <div class="text-sm font-semibold text-[var(--color-text-primary)]">Full feature comparison</div>
             <PlanComparisonTable class="mt-4" :plans="basePlans" :features="FEATURE_DEFINITIONS" />
           </div>

--- a/src/views/Pricing/PricingCard.vue
+++ b/src/views/Pricing/PricingCard.vue
@@ -10,7 +10,7 @@
         <span
           v-for="(feature, index) in highlightItems"
           :key="index"
-          class="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold"
+          class="inline-flex items-center gap-2 rounded-full sr-border px-3 py-1 text-xs font-semibold"
           :class="STATUS_STYLES[feature.status]?.chip"
         >
           <span class="h-2 w-2 rounded-full" :class="STATUS_STYLES[feature.status]?.dot"></span>
@@ -37,15 +37,15 @@ import { getPlanTheme } from '@/constants/planThemes'
 
 const STATUS_STYLES = {
   included: {
-    chip: 'border-[var(--color-success)] bg-[rgba(var(--color-success-rgb),0.15)] text-[var(--color-success)]',
+    chip: 'border-status-success bg-[rgba(var(--color-success-rgb),0.15)] text-status-success',
     dot: 'bg-status-success'
   },
   limited: {
-    chip: 'border-[var(--color-warning)] bg-[rgba(var(--color-warning-rgb),0.15)] text-[var(--color-warning)]',
-    dot: 'bg-[var(--color-warning)]'
+    chip: 'border-status-warning bg-[rgba(var(--color-warning-rgb),0.15)] text-[var(--color-warning)]',
+    dot: 'bg-status-warning'
   },
   unavailable: {
-    chip: 'border-border-subtle bg-[var(--color-bg-elevated)] text-[var(--color-text-muted)]',
+    chip: 'sr-border-subtle bg-[var(--color-bg-elevated)] text-[var(--color-text-muted)]',
     dot: 'bg-[var(--color-text-muted)]'
   }
 }
@@ -87,7 +87,7 @@ const props = defineProps({
 
 const BASE_CARD_CLASS = 'group rounded-sm p-6 shadow-md transition-all duration-200 ease-out transform flex flex-col justify-between bg-surface-base text-text-primary hover:bg-[var(--color-bg-elevated)] hover:shadow-xl hover:-translate-y-1 hover:scale-[1.03] focus-within:shadow-xl focus-within:-translate-y-1 focus-within:scale-[1.03]'
 
-const BASE_CTA_CLASS = 'w-full py-2 rounded-xl font-semibold transition border border-transparent disabled:opacity-50 disabled:cursor-not-allowed'
+const BASE_CTA_CLASS = 'w-full py-2 rounded-xl font-semibold transition sr-border border-transparent disabled:opacity-50 disabled:cursor-not-allowed'
 
 const planTheme = computed(() => getPlanTheme(props.planId))
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -9,7 +9,7 @@
               Update how you appear in SoundRoom, adjust playback preferences, and keep your account secure.
             </p>
           </div>
-          <div class="flex items-center gap-3 rounded-full border border-border-subtle px-4 py-2 bg-[color-mix(in_srgb,var(--color-bg-surface)_85%,transparent)]">
+          <div class="flex items-center gap-3 rounded-full sr-border sr-border-subtle px-4 py-2 bg-[color-mix(in_srgb,var(--color-bg-surface)_85%,transparent)]">
             <span class="text-xs uppercase tracking-wide text-[var(--color-text-muted)]">Plan</span>
             <span class="text-sm font-medium">{{ planLabel }}</span>
             <RouterLink v-if="tier.value === 'free'" :to="'/upgrade'" class="ml-2">
@@ -31,11 +31,11 @@
 
         <div
           v-if="planStatusMessage || planErrorMessage || isProcessingCheckout"
-          class="rounded-xl border p-4"
+          class="rounded-xl sr-border sr-border-subtle p-4"
           :class="[
-            isProcessingCheckout ? 'border-[var(--color-accent-soft)] bg-[rgba(var(--color-accent-rgb),0.12)] text-[var(--color-text-primary)]' : '',
-            planStatusMessage && !isProcessingCheckout ? 'border-[var(--color-success)] bg-[rgba(var(--color-success-rgb),0.12)] text-[var(--color-text-primary)]' : '',
-            planErrorMessage ? 'border-[var(--color-danger)] bg-[rgba(var(--color-danger-rgb),0.12)] text-[var(--color-text-primary)]' : '',
+            isProcessingCheckout ? 'border-accent-soft bg-[rgba(var(--color-accent-rgb),0.12)] text-[var(--color-text-primary)]' : '',
+            planStatusMessage && !isProcessingCheckout ? 'border-status-success bg-[rgba(var(--color-success-rgb),0.12)] text-[var(--color-text-primary)]' : '',
+            planErrorMessage ? 'border-status-danger bg-[rgba(var(--color-danger-rgb),0.12)] text-[var(--color-text-primary)]' : '',
           ]"
         >
           <p v-if="isProcessingCheckout" class="text-sm font-medium">Processing your plan change…</p>
@@ -43,13 +43,13 @@
           <p v-else-if="planErrorMessage" class="text-sm font-medium">{{ planErrorMessage }}</p>
         </div>
 
-        <div class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_85%,transparent)] p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
+        <div class="rounded-2xl sr-border sr-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_85%,transparent)] p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
           <div>
             <p class="text-sm text-[var(--color-text-muted)]">Signed in as</p>
             <p class="text-lg font-medium break-all">{{ userEmail }}</p>
           </div>
           <div class="flex items-center gap-4">
-            <div class="relative w-16 h-16 rounded-full bg-[var(--color-bg-elevated)] flex items-center justify-center overflow-hidden text-xl font-semibold border border-border-subtle">
+            <div class="relative w-16 h-16 rounded-full bg-[var(--color-bg-elevated)] flex items-center justify-center overflow-hidden text-xl font-semibold sr-border sr-border-subtle">
               <img
                 v-if="avatarPreview && !avatarFailed"
                 :src="avatarPreview"
@@ -67,7 +67,7 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_88%,transparent)] p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl sr-border sr-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_88%,transparent)] p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Profile</h2>
           <p class="text-sm text-[var(--color-text-muted)]">Set how teammates and collaborators see you.</p>
@@ -136,7 +136,7 @@
 
       <ThemeSelector />
 
-      <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_88%,transparent)] p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl sr-border sr-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_88%,transparent)] p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Playback Preferences</h2>
           <p class="text-sm text-[var(--color-text-muted)]">These settings are stored locally in your browser.</p>
@@ -188,7 +188,7 @@
         <p v-if="preferenceMessage" class="text-sm text-status-success">{{ preferenceMessage }}</p>
       </section>
 
-      <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_88%,transparent)] p-6 shadow-sm space-y-6">
+      <section class="rounded-2xl sr-border sr-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_88%,transparent)] p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Security</h2>
           <p class="text-sm text-[var(--color-text-muted)]">Keep your account protected and up to date.</p>

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -17,7 +17,7 @@
         <Toolbar/>
 
         <!-- Canvas Area -->
-        <div class="flex-1 relative overflow-hidden bg-[var(--color-bg-surface)] flex items-center justify-center border-t border-[var(--color-border-subtle)]">
+        <div class="flex-1 relative overflow-hidden bg-[var(--color-bg-surface)] flex items-center justify-center sr-border-t sr-border-subtle">
           <div class="pointer-events-none absolute inset-0 canvas-vignette" aria-hidden="true"></div>
           <MainCanvasStage
             v-bind="{

--- a/src/views/UpdatePasswordPage.vue
+++ b/src/views/UpdatePasswordPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col items-center justify-center min-h-screen px-4 py-12 bg-[var(--color-bg-app)] text-text-primary transition-colors">
-    <div class="w-full max-w-sm space-y-6 bg-[var(--color-bg-surface)] rounded-2xl shadow-xl p-6 border border-border-subtle transition-colors">
+    <div class="w-full max-w-sm space-y-6 bg-[var(--color-bg-surface)] rounded-2xl shadow-xl p-6 sr-border sr-border-subtle transition-colors">
       <h2 class="text-2xl font-semibold text-center tracking-wide">Reset Your Password</h2>
 
       <PasswordInput

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,40 +5,41 @@ module.exports = {
   darkMode: ['class', '[data-theme="dark"]'],
   important: true,
   theme: {
-    extend: {
-      colors: {
-        transparent: 'transparent',
-        current: 'currentColor',
-        white: withAlpha('--base-white-rgb'),
-        black: withAlpha('--base-black-rgb'),
-        surface: {
-          app: withAlpha('--color-bg-app-rgb'),
-          base: withAlpha('--color-bg-surface-rgb'),
-          raised: withAlpha('--color-bg-elevated-rgb'),
-        },
-        border: {
-          subtle: withAlpha('--color-border-subtle-rgb'),
-          strong: withAlpha('--color-border-strong-rgb'),
-        },
-        text: {
-          primary: withAlpha('--color-text-primary-rgb'),
-          secondary: withAlpha('--color-text-secondary-rgb'),
-          muted: withAlpha('--color-text-muted-rgb'),
-          inverse: withAlpha('--color-text-inverse-rgb'),
-        },
-        accent: {
-          soft: withAlpha('--color-accent-soft-rgb'),
-          DEFAULT: withAlpha('--color-accent-rgb'),
-          strong: withAlpha('--color-accent-strong-rgb'),
-        },
-        status: {
-          success: withAlpha('--color-success-rgb'),
-          warning: withAlpha('--color-warning-rgb'),
-          danger: withAlpha('--color-danger-rgb'),
-        },
-        panel: withAlpha('--color-panel-rgb'),
-        input: withAlpha('--color-input-rgb'),
+    colors: {
+      transparent: 'transparent',
+      current: 'currentColor',
+      inherit: 'inherit',
+      white: withAlpha('--base-white-rgb'),
+      black: withAlpha('--base-black-rgb'),
+      surface: {
+        app: withAlpha('--color-bg-app-rgb'),
+        base: withAlpha('--color-bg-surface-rgb'),
+        raised: withAlpha('--color-bg-elevated-rgb'),
       },
+      border: {
+        subtle: withAlpha('--color-border-subtle-rgb'),
+        strong: withAlpha('--color-border-strong-rgb'),
+      },
+      text: {
+        primary: withAlpha('--color-text-primary-rgb'),
+        secondary: withAlpha('--color-text-secondary-rgb'),
+        muted: withAlpha('--color-text-muted-rgb'),
+        inverse: withAlpha('--color-text-inverse-rgb'),
+      },
+      accent: {
+        soft: withAlpha('--color-accent-soft-rgb'),
+        DEFAULT: withAlpha('--color-accent-rgb'),
+        strong: withAlpha('--color-accent-strong-rgb'),
+      },
+      status: {
+        success: withAlpha('--color-success-rgb'),
+        warning: withAlpha('--color-warning-rgb'),
+        danger: withAlpha('--color-danger-rgb'),
+      },
+      panel: withAlpha('--color-panel-rgb'),
+      input: withAlpha('--color-input-rgb'),
+    },
+    extend: {
       boxShadow: {
         soft: 'var(--color-shadow-soft)',
         strong: 'var(--color-shadow-strong)',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,13 @@
+const plugin = require('tailwindcss/plugin')
+
 const resolveVar = (token) => () => `var(${token})`
 
 module.exports = {
   darkMode: ['class', '[data-theme="dark"]'],
   important: false,
+  corePlugins: {
+    borderWidth: false,
+  },
   theme: {
     colors: {
       transparent: 'transparent',
@@ -45,4 +50,19 @@ module.exports = {
       },
     },
   },
+  plugins: [
+    plugin(({ addUtilities }) => {
+      addUtilities({
+        '.sr-border': { borderWidth: '1px', borderStyle: 'solid' },
+        '.sr-border-2': { borderWidth: '2px', borderStyle: 'solid' },
+        '.sr-border-none': { borderWidth: '0' },
+        '.sr-border-t': { borderTopWidth: '1px', borderStyle: 'solid' },
+        '.sr-border-r': { borderRightWidth: '1px', borderStyle: 'solid' },
+        '.sr-border-b': { borderBottomWidth: '1px', borderStyle: 'solid' },
+        '.sr-border-l': { borderLeftWidth: '1px', borderStyle: 'solid' },
+        '.sr-border-subtle': { borderColor: 'rgb(var(--color-border-subtle-rgb) / 1)' },
+        '.sr-border-strong': { borderColor: 'rgb(var(--color-border-strong-rgb) / 1)' },
+      })
+    }),
+  ],
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,43 +1,40 @@
-// tailwind.config.js
-const withAlpha = (variable) => `rgb(var(${variable}) / <alpha-value>)`
-
 module.exports = {
   darkMode: ['class', '[data-theme="dark"]'],
-  important: true,
+  important: false,
   theme: {
     colors: {
       transparent: 'transparent',
       current: 'currentColor',
       inherit: 'inherit',
-      white: withAlpha('--base-white-rgb'),
-      black: withAlpha('--base-black-rgb'),
+      white: 'var(--base-white)',
+      black: 'var(--base-black)',
       surface: {
-        app: withAlpha('--color-bg-app-rgb'),
-        base: withAlpha('--color-bg-surface-rgb'),
-        raised: withAlpha('--color-bg-elevated-rgb'),
+        app: 'var(--color-bg-app)',
+        base: 'var(--color-bg-surface)',
+        raised: 'var(--color-bg-elevated)',
       },
       border: {
-        subtle: withAlpha('--color-border-subtle-rgb'),
-        strong: withAlpha('--color-border-strong-rgb'),
+        subtle: 'var(--color-border-subtle)',
+        strong: 'var(--color-border-strong)',
       },
       text: {
-        primary: withAlpha('--color-text-primary-rgb'),
-        secondary: withAlpha('--color-text-secondary-rgb'),
-        muted: withAlpha('--color-text-muted-rgb'),
-        inverse: withAlpha('--color-text-inverse-rgb'),
+        primary: 'var(--color-text-primary)',
+        secondary: 'var(--color-text-secondary)',
+        muted: 'var(--color-text-muted)',
+        inverse: 'var(--color-text-inverse)',
       },
       accent: {
-        soft: withAlpha('--color-accent-soft-rgb'),
-        DEFAULT: withAlpha('--color-accent-rgb'),
-        strong: withAlpha('--color-accent-strong-rgb'),
+        soft: 'var(--color-accent-soft)',
+        DEFAULT: 'var(--color-accent)',
+        strong: 'var(--color-accent-strong)',
       },
       status: {
-        success: withAlpha('--color-success-rgb'),
-        warning: withAlpha('--color-warning-rgb'),
-        danger: withAlpha('--color-danger-rgb'),
+        success: 'var(--color-success)',
+        warning: 'var(--color-warning)',
+        danger: 'var(--color-danger)',
       },
-      panel: withAlpha('--color-panel-rgb'),
-      input: withAlpha('--color-input-rgb'),
+      panel: 'var(--color-panel)',
+      input: 'var(--color-input)',
     },
     extend: {
       boxShadow: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+const resolveVar = (token) => () => `var(${token})`
+
 module.exports = {
   darkMode: ['class', '[data-theme="dark"]'],
   important: false,
@@ -6,35 +8,35 @@ module.exports = {
       transparent: 'transparent',
       current: 'currentColor',
       inherit: 'inherit',
-      white: 'var(--base-white)',
-      black: 'var(--base-black)',
+      white: resolveVar('--base-white'),
+      black: resolveVar('--base-black'),
       surface: {
-        app: 'var(--color-bg-app)',
-        base: 'var(--color-bg-surface)',
-        raised: 'var(--color-bg-elevated)',
+        app: resolveVar('--color-bg-app'),
+        base: resolveVar('--color-bg-surface'),
+        raised: resolveVar('--color-bg-elevated'),
       },
       border: {
-        subtle: 'var(--color-border-subtle)',
-        strong: 'var(--color-border-strong)',
+        subtle: resolveVar('--color-border-subtle'),
+        strong: resolveVar('--color-border-strong'),
       },
       text: {
-        primary: 'var(--color-text-primary)',
-        secondary: 'var(--color-text-secondary)',
-        muted: 'var(--color-text-muted)',
-        inverse: 'var(--color-text-inverse)',
+        primary: resolveVar('--color-text-primary'),
+        secondary: resolveVar('--color-text-secondary'),
+        muted: resolveVar('--color-text-muted'),
+        inverse: resolveVar('--color-text-inverse'),
       },
       accent: {
-        soft: 'var(--color-accent-soft)',
-        DEFAULT: 'var(--color-accent)',
-        strong: 'var(--color-accent-strong)',
+        soft: resolveVar('--color-accent-soft'),
+        DEFAULT: resolveVar('--color-accent'),
+        strong: resolveVar('--color-accent-strong'),
       },
       status: {
-        success: 'var(--color-success)',
-        warning: 'var(--color-warning)',
-        danger: 'var(--color-danger)',
+        success: resolveVar('--color-success'),
+        warning: resolveVar('--color-warning'),
+        danger: resolveVar('--color-danger'),
       },
-      panel: 'var(--color-panel)',
-      input: 'var(--color-input)',
+      panel: resolveVar('--color-panel'),
+      input: resolveVar('--color-input'),
     },
     extend: {
       boxShadow: {


### PR DESCRIPTION
## Summary
- remove legacy color aliases, expand light theme overrides, and keep tokens as the source of truth
- map Tailwind color utilities directly to CSS variables and adjust imports to preserve runtime theming
- update component styles to consume the unified tokens without build-time color baking

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692581aa6248832f883c91c8fe82bb25)