### PR TITLE
Fix dark theme preview palette

### DIFF
--- a/src/styles/theme-tokens.css
+++ b/src/styles/theme-tokens.css
@@ -8,7 +8,8 @@
 /* -----------------------------------------------------------
    ROOT = DARK THEME DEFAULTS
    ----------------------------------------------------------- */
-:root {
+:root,
+[data-theme="dark"] {
   color-scheme: dark;
 
   /* -----------------------------------------
@@ -151,14 +152,6 @@
   --sr-node-blue: var(--color-node-blue);
   --sr-outline-strong: var(--color-border-strong);
   --sr-outline-contrast: var(--color-outline-contrast);
-}
-
-/* -----------------------------------------------------------
-   DARK THEME OVERRIDES (OPTIONAL)
-   ----------------------------------------------------------- */
-[data-theme="dark"] {
-  color-scheme: dark;
-  /* no overrides needed — dark = default */
 }
 
 /* -----------------------------------------------------------


### PR DESCRIPTION
## Summary
- apply dark theme token defaults to elements tagged with `data-theme="dark"` so previews render correctly when the app is in light mode

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926999dd5e0832f80e34d7ddd304792)