### PR TITLE
Adjust theme toggle behavior for unauthenticated users

### DIFF
--- a/src/components/SoundRoom/HeaderBar.vue
+++ b/src/components/SoundRoom/HeaderBar.vue
@@ -43,6 +43,7 @@
 import { ref, watch, computed, onMounted, onBeforeUnmount } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useAuth } from '@/composables/useAuth';
+import { toggleTheme } from '@/utils/theme';
 import { supabase } from '@/utils/supabase';
 import PulsingOverlay from '@/components/ui/overlays/PulsingOverlay.vue';
 import HamburgerIcon from '@/assets/icons/hamburger.svg';
@@ -119,8 +120,8 @@ async function handleSignOut() {
 const headerButtons = computed(() => [
   {
     label: 'Switch Themes',
-    action: () => router.push('/settings'),
-    shouldShow: true,
+    action: () => toggleTheme(),
+    shouldShow: !isAuthenticated.value,
   },
   {
     label: 'Help',

--- a/src/components/SoundRoom/HeaderBar.vue
+++ b/src/components/SoundRoom/HeaderBar.vue
@@ -7,7 +7,7 @@
       <button
         ref="menuButton"
         type="button"
-        @click="toggleMenu"
+        @click.stop="toggleMenu"
         class="flex items-center justify-center w-12 h-12 !p-1 !bg-transparent text-[var(--color-text-primary)]"
         :aria-expanded="isMenuOpen"
         aria-haspopup="true"
@@ -65,6 +65,7 @@ const isLoggingOut = ref(false); // Track if logging out
 const authMode = ref('signup'); // 'login' | 'signup' | 'reset
 
 const toggleMenu = () => {
+  if (!visibleButtons.value.length) return
   isMenuOpen.value = !isMenuOpen.value
 }
 
@@ -117,41 +118,44 @@ async function handleSignOut() {
 
 }
 
-const headerButtons = computed(() => [
-  {
-    label: 'Switch Themes',
-    action: () => toggleTheme(),
-    shouldShow: !isAuthenticated.value,
-  },
-  {
-    label: 'Help',
-    action: () => router.push('/help'),
-    shouldShow: true
-  },
-  {
-    label: 'Sign In',
-    action: () => router.push('/login'),
-    shouldShow: !isAuthenticated.value
-  },
-  {
-    label: 'Upgrade',
-    action: () => router.push('/upgrade'),
-    shouldShow: isAuthenticated.value && tier.value === 'free'
-  },
-  {
-    label: 'Settings',
-    action: () => router.push('/settings'),
-    shouldShow: isAuthenticated.value
-  },
-  {
-    label: 'Sign Out',
-    action: () => handleSignOut(),
-    shouldShow: isAuthenticated.value
-  },
+const visibleButtons = computed(() => {
+  const authed = isAuthenticated.value
 
-])
+  const buttons = [
+    {
+      label: 'Switch Themes',
+      action: () => toggleTheme(),
+      shouldShow: !authed,
+    },
+    {
+      label: 'Help',
+      action: () => router.push('/help'),
+      shouldShow: true
+    },
+    {
+      label: 'Sign In',
+      action: () => router.push('/login'),
+      shouldShow: !authed
+    },
+    {
+      label: 'Upgrade',
+      action: () => router.push('/upgrade'),
+      shouldShow: authed && tier.value === 'free'
+    },
+    {
+      label: 'Settings',
+      action: () => router.push('/settings'),
+      shouldShow: authed
+    },
+    {
+      label: 'Sign Out',
+      action: () => handleSignOut(),
+      shouldShow: authed
+    },
+  ]
 
-const visibleButtons = computed(() => headerButtons.value.filter(button => button.shouldShow))
+  return buttons.filter(button => button.shouldShow)
+})
 
 watch(() => route.path, (val) => {
   showAuthModal.value = ['/login', '/signup', '/reset'].includes(val)

--- a/src/components/ui/input/BaseButton.vue
+++ b/src/components/ui/input/BaseButton.vue
@@ -4,7 +4,7 @@
   :disabled="disabled"
   :class="[
     'transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)] disabled:opacity-50 disabled:cursor-not-allowed',
-    variant === 'default' && 'px-4 py-2 rounded text-sm font-medium bg-[var(--color-accent)] hover:bg-[var(--color-accent-strong)] text-[var(--color-text-inverse)] shadow-[var(--color-shadow-soft)]',
+    variant === 'default' && 'px-4 py-2 rounded text-sm font-medium bg-[var(--color-accent)] hover:bg-[var(--color-accent-strong)] text-[var(--color-text-inverse)]',
     variant === 'naked' && 'bg-transparent text-[var(--color-text-primary)] hover:text-[var(--color-accent-soft)]'
   ]"
   @click="(e) => $emit('click', e)"


### PR DESCRIPTION
## Summary
- toggle theme directly from the header menu when the user is not authenticated
- hide the switch theme option for authenticated users so they use Settings instead

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69269e212974832f9615822314a8c275)