### PR TITLE
Use theme color utilities

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,11 +7,11 @@
     <div class="flex-1 min-h-0 flex flex-col">
       <div
         v-if="globalError"
-        class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-[var(--color-bg-app)] text-[var(--color-text-primary)]"
+        class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-surface-app text-text-primary"
       >
         <p class="text-sm uppercase tracking-[0.2em] text-[var(--color-danger)] mb-3">Navigation error</p>
         <h2 class="text-2xl font-semibold mb-3">We couldn't load that page.</h2>
-        <p class="max-w-md text-[var(--color-text-muted)] mb-8">
+        <p class="max-w-md text-text-muted mb-8">
           {{ globalError.message }}
         </p>
         <div class="flex flex-wrap items-center justify-center gap-3">
@@ -20,7 +20,7 @@
           </BaseButton>
           <BaseButton
             variant="naked"
-            class="text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] text-sm font-medium"
+            class="text-text-secondary hover:text-text-primary text-sm font-medium"
             @click="returnHome"
           >
             Go back home
@@ -37,10 +37,10 @@
             </ErrorBoundary>
           </template>
           <template #fallback>
-            <div class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-[var(--color-bg-app)] text-[var(--color-text-primary)]">
+            <div class="flex-1 flex flex-col items-center justify-center text-center px-6 py-12 bg-surface-app text-text-primary">
               <p class="text-sm uppercase tracking-[0.2em] text-[var(--color-accent)] mb-3">Loading</p>
               <h2 class="text-2xl font-semibold mb-3">Preparing SoundRoom…</h2>
-              <p class="max-w-md text-[var(--color-text-muted)]">
+              <p class="max-w-md text-text-muted">
                 Hang tight while we load the experience.
               </p>
             </div>

--- a/src/components/ui/input/BaseButton.vue
+++ b/src/components/ui/input/BaseButton.vue
@@ -3,9 +3,9 @@
   :type="type"
   :disabled="disabled"
   :class="[
-    'transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg-surface)] disabled:opacity-50 disabled:cursor-not-allowed',
-    variant === 'default' && 'px-4 py-2 rounded text-sm font-medium bg-[var(--color-accent)] hover:bg-[var(--color-accent-strong)] text-[var(--color-text-inverse)]',
-    variant === 'naked' && 'bg-transparent text-[var(--color-text-primary)] hover:text-[var(--color-accent-soft)]'
+    'transition focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base disabled:opacity-50 disabled:cursor-not-allowed',
+    variant === 'default' && 'px-4 py-2 rounded text-sm font-medium bg-accent hover:bg-accent-strong text-text-inverse',
+    variant === 'naked' && 'bg-transparent text-text-primary hover:text-accent-soft'
   ]"
   @click="(e) => $emit('click', e)"
 >
@@ -14,7 +14,7 @@
     </span>
     <span v-else class="flex items-center justify-center space-x-2">
       <svg
-        class="w-4 h-4 animate-spin text-[var(--color-text-inverse)]"
+        class="w-4 h-4 animate-spin text-text-inverse"
         fill="none"
         viewBox="0 0 24 24"
       >

--- a/src/style.css
+++ b/src/style.css
@@ -22,6 +22,8 @@
   --color-status-warning: var(--color-warning);
   --color-status-danger: var(--color-danger);
 
+  --color-focus-ring: var(--color-focus-ring);
+
   --color-panel: var(--color-panel);
   --color-input: var(--color-input);
 }
@@ -71,7 +73,7 @@ button {
   font-family: inherit;
   cursor: pointer;
   transition: border-color 0.25s, box-shadow 0.25s;
-  @apply bg-[var(--color-bg-surface)] text-[var(--color-text-primary)];
+  @apply bg-surface-base text-text-primary;
 }
 button:hover {
   border-color: var(--color-border-subtle);
@@ -104,7 +106,7 @@ button:disabled {
 input[type="text"],
 input[type="email"],
 input[type="password"] {
-  @apply w-full p-3 border border-[var(--color-border-subtle)] rounded-lg bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)];
+  @apply w-full p-3 border border-border-subtle rounded-lg bg-surface-raised text-text-primary;
 }
 
 input:disabled {
@@ -116,7 +118,7 @@ input:disabled {
 }
 
 .modal-panel {
-  @apply bg-[var(--color-bg-app)] rounded-2xl w-[80vw] h-[80vh] shadow-[var(--color-shadow-soft)] border border-[var(--color-border-subtle)] overflow-hidden;
+  @apply bg-surface-app rounded-2xl w-[80vw] h-[80vh] shadow-[var(--color-shadow-soft)] border border-border-subtle overflow-hidden;
 }
 
 .modal-header-float {

--- a/src/views/AuthCallback.vue
+++ b/src/views/AuthCallback.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="auth-callback w-full bg-[var(--color-bg-app)] text-[var(--color-text-primary)]">
+  <div class="auth-callback w-full bg-surface-app text-text-primary">
   </div>
 </template>
 

--- a/src/views/LoggedOut.vue
+++ b/src/views/LoggedOut.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full flex flex-col items-center justify-center text-center px-6 py-12 bg-[var(--color-bg-app)] text-text-primary">
+  <div class="h-full flex flex-col items-center justify-center text-center px-6 py-12 bg-surface-app text-text-primary">
     <h2 class="text-2xl font-semibold mb-2">You've been signed out</h2>
     <p class="text-text-muted mb-6">We hope you come back soon.</p>
     <BaseButton @click="$router.push('/login')">Sign In Again</BaseButton>

--- a/src/views/ManagePlan.vue
+++ b/src/views/ManagePlan.vue
@@ -1,14 +1,14 @@
 <template>
-  <main class="flex-1 overflow-y-auto bg-[var(--color-bg-app)] text-[var(--color-text-primary)]">
+  <main class="flex-1 overflow-y-auto bg-surface-app text-text-primary">
     <div class="max-w-4xl mx-auto px-6 py-10 space-y-10">
       <section class="space-y-4">
         <div
           v-if="checkoutStatusMessage || checkoutErrorMessage || isProcessingCheckout"
           class="rounded-xl border p-4"
           :class="[
-            isProcessingCheckout ? 'border-[var(--color-accent-soft)] bg-[rgba(var(--color-accent-rgb),0.12)] text-[var(--color-text-primary)]' : '',
-            checkoutStatusMessage && !isProcessingCheckout ? 'border-[var(--color-success)] bg-[rgba(var(--color-success-rgb),0.12)] text-[var(--color-text-primary)]' : '',
-            checkoutErrorMessage ? 'border-[var(--color-danger)] bg-[rgba(var(--color-danger-rgb),0.12)] text-[var(--color-text-primary)]' : '',
+            isProcessingCheckout ? 'border-accent-soft bg-[rgba(var(--color-accent-rgb),0.12)] text-text-primary' : '',
+            checkoutStatusMessage && !isProcessingCheckout ? 'border-status-success bg-[rgba(var(--color-success-rgb),0.12)] text-text-primary' : '',
+            checkoutErrorMessage ? 'border-status-danger bg-[rgba(var(--color-danger-rgb),0.12)] text-text-primary' : '',
           ]"
         >
           <p v-if="isProcessingCheckout" class="text-sm font-medium">Processing your plan change…</p>
@@ -18,7 +18,7 @@
         <div class="flex items-center justify-between gap-6 flex-wrap">
           <div class="space-y-2 w-full">
             <h1 class="text-3xl font-semibold tracking-tight">Manage Plan</h1>
-            <p class="text-sm text-[var(--color-text-muted)] w-full">
+            <p class="text-sm text-text-muted w-full">
               Review what is included in your subscription, explore upgrade options, or reach out for billing support.
             </p>
           </div>
@@ -38,18 +38,18 @@
           <header class="flex flex-wrap items-center justify-between gap-4">
             <div class="space-y-1">
               <h2 class="text-2xl font-semibold">{{ currentPlan.name }}</h2>
-              <p class="text-sm text-[var(--color-text-muted)]">{{ currentPlan.tagline }}</p>
+              <p class="text-sm text-text-muted">{{ currentPlan.tagline }}</p>
             </div>
             <div class="text-right">
               <span class="text-lg font-semibold">{{ currentPlan.price }}</span>
-              <p class="text-xs text-[var(--color-text-muted)]">Billed monthly — cancel anytime.</p>
+              <p class="text-xs text-text-muted">Billed monthly — cancel anytime.</p>
             </div>
           </header>
 
           <div class="mt-6 grid gap-4 sm:grid-cols-2">
             <div v-for="feature in currentPlan.highlights" :key="feature" class="flex items-start gap-3">
-              <span class="mt-1 h-2 w-2 rounded-full bg-[var(--color-accent)]"></span>
-              <p class="text-sm text-[var(--color-text-secondary)]">{{ feature }}</p>
+              <span class="mt-1 h-2 w-2 rounded-full bg-accent"></span>
+              <p class="text-sm text-text-secondary">{{ feature }}</p>
             </div>
           </div>
 
@@ -83,12 +83,12 @@
       <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] p-6 shadow-sm space-y-6">
         <header class="space-y-1">
           <h2 class="text-xl font-semibold">Billing & Receipts</h2>
-          <p class="text-sm text-[var(--color-text-muted)]">
+          <p class="text-sm text-text-muted">
             SoundRoom uses Stripe under the hood. Use the billing portal to view invoices, update payment details, or make changes to your plan anytime.
           </p>
         </header>
 
-        <div class="rounded-xl border border-dashed border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] px-5 py-6 text-sm text-[var(--color-text-secondary)]">
+        <div class="rounded-xl border border-dashed border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] px-5 py-6 text-sm text-text-secondary">
           <p>Need an invoice, tax receipt, or want to change your payment method?</p>
           <p class="mt-3">Email <a class="underline" :href="supportEmailHref">{{ SUPPORT_EMAIL }}</a> and include the email tied to your SoundRoom account.</p>
         </div>
@@ -105,7 +105,7 @@
           <BaseButton @click="contactBilling">
             Contact billing support
           </BaseButton>
-          <BaseButton variant="naked" class="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]" @click="openFAQ">
+          <BaseButton variant="naked" class="text-sm text-text-muted hover:text-text-primary" @click="openFAQ">
             View plan FAQ
           </BaseButton>
         </div>
@@ -114,14 +114,14 @@
       <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] p-6 shadow-sm space-y-6">
         <header class="space-y-1">
           <h2 class="text-xl font-semibold">Upcoming Features</h2>
-          <p class="text-sm text-[var(--color-text-muted)]">We are actively building deeper collaboration and scheduling tools. Here is what is landing next for paying members.</p>
+          <p class="text-sm text-text-muted">We are actively building deeper collaboration and scheduling tools. Here is what is landing next for paying members.</p>
         </header>
 
         <ul class="grid gap-4 md:grid-cols-2">
           <li v-for="item in roadmapHighlights" :key="item.title" class="rounded-xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_92%,transparent)] p-5 space-y-2">
-            <p class="text-sm uppercase tracking-wide text-[var(--color-text-muted)]">{{ item.badge }}</p>
+            <p class="text-sm uppercase tracking-wide text-text-muted">{{ item.badge }}</p>
             <h3 class="text-lg font-medium">{{ item.title }}</h3>
-            <p class="text-sm text-[var(--color-text-muted)]">{{ item.copy }}</p>
+            <p class="text-sm text-text-muted">{{ item.copy }}</p>
           </li>
         </ul>
       </section>

--- a/src/views/MobileComingSoon.vue
+++ b/src/views/MobileComingSoon.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fixed inset-0 bg-[var(--color-bg-app)] text-text-primary flex items-center justify-center text-center p-6 z-50">
+  <div class="fixed inset-0 bg-surface-app text-text-primary flex items-center justify-center text-center p-6 z-50">
     <div>
       <h1 class="text-2xl font-semibold mb-2">Mobile Version Coming Soon</h1>
       <p class="text-sm text-text-muted">Please visit us on desktop for the full experience.</p>

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full w-full flex flex-col items-center justify-center text-center px-6 py-12 bg-[var(--color-bg-app)] text-text-primary">
+  <div class="h-full w-full flex flex-col items-center justify-center text-center px-6 py-12 bg-surface-app text-text-primary">
     <p class="text-sm uppercase tracking-[0.2em] text-status-danger mb-3">404</p>
     <h1 class="text-3xl font-semibold mb-3">Page not found</h1>
     <p class="max-w-md text-text-muted mb-8">

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -1,16 +1,16 @@
 <template>
-  <main class="flex-1 overflow-y-auto bg-[var(--color-bg-app)] text-[var(--color-text-primary)]">
+  <main class="flex-1 overflow-y-auto bg-surface-app text-text-primary">
     <div class="max-w-5xl mx-auto px-6 py-10 space-y-10">
       <section class="space-y-4">
         <div class="flex items-center justify-between gap-6 flex-wrap">
           <div class="space-y-2">
             <h1 class="text-3xl font-semibold tracking-tight">Settings</h1>
-            <p class="text-sm text-[var(--color-text-muted)] max-w-xl">
+            <p class="text-sm text-text-muted max-w-xl">
               Update how you appear in SoundRoom, adjust playback preferences, and keep your account secure.
             </p>
           </div>
           <div class="flex items-center gap-3 rounded-full border border-border-subtle px-4 py-2 bg-[color-mix(in_srgb,var(--color-bg-surface)_85%,transparent)]">
-            <span class="text-xs uppercase tracking-wide text-[var(--color-text-muted)]">Plan</span>
+            <span class="text-xs uppercase tracking-wide text-text-muted">Plan</span>
             <span class="text-sm font-medium">{{ planLabel }}</span>
             <RouterLink v-if="tier.value === 'free'" :to="'/upgrade'" class="ml-2">
               <BaseButton type="button">
@@ -33,9 +33,9 @@
           v-if="planStatusMessage || planErrorMessage || isProcessingCheckout"
           class="rounded-xl border p-4"
           :class="[
-            isProcessingCheckout ? 'border-[var(--color-accent-soft)] bg-[rgba(var(--color-accent-rgb),0.12)] text-[var(--color-text-primary)]' : '',
-            planStatusMessage && !isProcessingCheckout ? 'border-[var(--color-success)] bg-[rgba(var(--color-success-rgb),0.12)] text-[var(--color-text-primary)]' : '',
-            planErrorMessage ? 'border-[var(--color-danger)] bg-[rgba(var(--color-danger-rgb),0.12)] text-[var(--color-text-primary)]' : '',
+            isProcessingCheckout ? 'border-accent-soft bg-[rgba(var(--color-accent-rgb),0.12)] text-text-primary' : '',
+            planStatusMessage && !isProcessingCheckout ? 'border-status-success bg-[rgba(var(--color-success-rgb),0.12)] text-text-primary' : '',
+            planErrorMessage ? 'border-status-danger bg-[rgba(var(--color-danger-rgb),0.12)] text-text-primary' : '',
           ]"
         >
           <p v-if="isProcessingCheckout" class="text-sm font-medium">Processing your plan change…</p>
@@ -45,11 +45,11 @@
 
         <div class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_85%,transparent)] p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
           <div>
-            <p class="text-sm text-[var(--color-text-muted)]">Signed in as</p>
+            <p class="text-sm text-text-muted">Signed in as</p>
             <p class="text-lg font-medium break-all">{{ userEmail }}</p>
           </div>
           <div class="flex items-center gap-4">
-            <div class="relative w-16 h-16 rounded-full bg-[var(--color-bg-elevated)] flex items-center justify-center overflow-hidden text-xl font-semibold border border-border-subtle">
+            <div class="relative w-16 h-16 rounded-full bg-surface-raised flex items-center justify-center overflow-hidden text-xl font-semibold border border-border-subtle">
               <img
                 v-if="avatarPreview && !avatarFailed"
                 :src="avatarPreview"
@@ -60,7 +60,7 @@
               <span v-else>{{ avatarInitial }}</span>
             </div>
             <div>
-              <p class="text-sm text-[var(--color-text-muted)]">Display name</p>
+              <p class="text-sm text-text-muted">Display name</p>
               <p class="text-base font-medium">{{ profileForm.displayName || '—' }}</p>
             </div>
           </div>
@@ -70,7 +70,7 @@
       <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_88%,transparent)] p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Profile</h2>
-          <p class="text-sm text-[var(--color-text-muted)]">Set how teammates and collaborators see you.</p>
+          <p class="text-sm text-text-muted">Set how teammates and collaborators see you.</p>
         </header>
 
         <div v-if="isFetchingProfile" class="space-y-4 animate-pulse">
@@ -114,7 +114,7 @@
           <div class="flex flex-wrap items-center justify-end gap-3">
             <button
               type="button"
-              class="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition"
+              class="text-sm text-text-muted hover:text-text-primary transition"
               @click="resetProfileForm"
               :disabled="profileSaving || !hasProfileChanges"
             >
@@ -139,31 +139,31 @@
       <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_88%,transparent)] p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Playback Preferences</h2>
-          <p class="text-sm text-[var(--color-text-muted)]">These settings are stored locally in your browser.</p>
+          <p class="text-sm text-text-muted">These settings are stored locally in your browser.</p>
         </header>
 
         <div class="space-y-6">
           <div class="flex items-start justify-between gap-6">
             <div>
               <h3 class="text-base font-medium">Auto-resume sessions</h3>
-              <p class="text-sm text-[var(--color-text-muted)]">Automatically reload your last SoundRoom when you sign back in.</p>
+              <p class="text-sm text-text-muted">Automatically reload your last SoundRoom when you sign back in.</p>
             </div>
             <label class="relative inline-flex items-center cursor-pointer select-none">
               <input type="checkbox" class="sr-only peer" v-model="preferences.autoResumePlayback">
-              <span class="block w-12 h-6 rounded-full bg-[var(--color-border-subtle)] transition-colors peer-focus:outline peer-focus:outline-2 peer-focus:outline-[var(--color-focus-ring)] peer-checked:bg-[var(--color-accent-strong)]"></span>
-              <span class="absolute left-1 top-1 block w-4 h-4 rounded-full bg-[var(--color-text-inverse)] shadow transition-transform peer-checked:translate-x-6"></span>
+              <span class="block w-12 h-6 rounded-full bg-[var(--color-border-subtle)] transition-colors peer-focus:outline peer-focus:outline-2 peer-focus:outline-[var(--color-focus-ring)] peer-checked:bg-accent-strong"></span>
+              <span class="absolute left-1 top-1 block w-4 h-4 rounded-full bg-text-inverse shadow transition-transform peer-checked:translate-x-6"></span>
             </label>
           </div>
 
           <div class="flex items-start justify-between gap-6">
             <div>
               <h3 class="text-base font-medium">Show interface tips</h3>
-              <p class="text-sm text-[var(--color-text-muted)]">Keep lightweight reminders visible for keyboard shortcuts and best practices.</p>
+              <p class="text-sm text-text-muted">Keep lightweight reminders visible for keyboard shortcuts and best practices.</p>
             </div>
             <label class="relative inline-flex items-center cursor-pointer select-none">
               <input type="checkbox" class="sr-only peer" v-model="preferences.showInterfaceTips">
-              <span class="block w-12 h-6 rounded-full bg-[var(--color-border-subtle)] transition-colors peer-focus:outline peer-focus:outline-2 peer-focus:outline-[var(--color-focus-ring)] peer-checked:bg-[var(--color-accent-strong)]"></span>
-              <span class="absolute left-1 top-1 block w-4 h-4 rounded-full bg-[var(--color-text-inverse)] shadow transition-transform peer-checked:translate-x-6"></span>
+              <span class="block w-12 h-6 rounded-full bg-[var(--color-border-subtle)] transition-colors peer-focus:outline peer-focus:outline-2 peer-focus:outline-[var(--color-focus-ring)] peer-checked:bg-accent-strong"></span>
+              <span class="absolute left-1 top-1 block w-4 h-4 rounded-full bg-text-inverse shadow transition-transform peer-checked:translate-x-6"></span>
             </label>
           </div>
         </div>
@@ -171,7 +171,7 @@
         <div class="flex flex-wrap items-center justify-end gap-3">
           <button
             type="button"
-            class="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition"
+            class="text-sm text-text-muted hover:text-text-primary transition"
             @click="resetPreferences"
             :disabled="!hasPreferenceChanges"
           >
@@ -191,14 +191,14 @@
       <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_88%,transparent)] p-6 shadow-sm space-y-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Security</h2>
-          <p class="text-sm text-[var(--color-text-muted)]">Keep your account protected and up to date.</p>
+          <p class="text-sm text-text-muted">Keep your account protected and up to date.</p>
         </header>
 
         <div class="space-y-6">
           <div class="flex flex-wrap items-start justify-between gap-6">
             <div>
               <h3 class="text-base font-medium">Password</h3>
-              <p class="text-sm text-[var(--color-text-muted)]">Use a strong password to protect your SoundRoom sessions and purchases.</p>
+              <p class="text-sm text-text-muted">Use a strong password to protect your SoundRoom sessions and purchases.</p>
             </div>
             <RouterLink to="/update-password">
               <BaseButton type="button">Update password</BaseButton>
@@ -208,7 +208,7 @@
           <div class="flex flex-wrap items-start justify-between gap-6">
             <div>
               <h3 class="text-base font-medium">Sign out</h3>
-              <p class="text-sm text-[var(--color-text-muted)]">Need to switch devices? Sign out to end your session on this browser.</p>
+              <p class="text-sm text-text-muted">Need to switch devices? Sign out to end your session on this browser.</p>
             </div>
             <BaseButton type="button" @click="signOutCurrentSession">Sign out of this device</BaseButton>
           </div>

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full bg-[var(--color-bg-app)] text-[var(--color-text-primary)] flex flex-col">
+  <div class="h-full bg-surface-app text-text-primary flex flex-col">
     <!-- Main Layout -->
     <div class="flex flex-1 overflow-hidden">
 

--- a/src/views/UpdatePasswordPage.vue
+++ b/src/views/UpdatePasswordPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col items-center justify-center min-h-screen px-4 py-12 bg-[var(--color-bg-app)] text-text-primary transition-colors">
+  <div class="flex flex-col items-center justify-center min-h-screen px-4 py-12 bg-surface-app text-text-primary transition-colors">
     <div class="w-full max-w-sm space-y-6 bg-[var(--color-bg-surface)] rounded-2xl shadow-xl p-6 border border-border-subtle transition-colors">
       <h2 class="text-2xl font-semibold text-center tracking-wide">Reset Your Password</h2>
 


### PR DESCRIPTION
## Summary
- add a focus ring token to the theme palette so color utilities cover interactive states
- switch common views and buttons from raw CSS variable color values to Tailwind theme color utilities
- rely on shared theme color utilities for buttons, layouts, and form surfaces

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926ad5467b4832fa9281a38f6785527)