### PR TITLE
Fix light theme RGB tokens for sound source colors

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -166,8 +166,6 @@ const lightPalette = computed(() => ({
   bg2: getVar('--color-bg-elevated', 'var(--color-bg-elevated)'),
   nodeRed: getVar('--color-node-red', 'var(--color-node-red)'),
   nodeBlue: getVar('--color-node-blue', 'var(--color-node-blue)'),
-  coneRed: 'rgba(var(--color-danger-rgb), 0.12)',
-  coneBlue: 'rgba(var(--color-accent-rgb), 0.14)',
 }))
 
 const themeTokens = computed(() => ({
@@ -200,8 +198,9 @@ const selectedScale = computed(() => (props.selected ? 1.05 : 1))
 
 const outerConeFill = computed(() => {
   if (isDarkMode.value) return rgbaFromVar('--color-danger-rgb', 0.16, 'rgba(var(--color-danger-rgb), 0.16)')
-  const colors = lightPalette.value
-  return isScheduled.value ? colors.coneBlue : colors.coneRed
+  return isScheduled.value
+    ? rgbaFromVar('--color-node-blue-rgb', 0.14, 'rgba(var(--color-node-blue-rgb), 0.14)')
+    : rgbaFromVar('--color-node-red-rgb', 0.12, 'rgba(var(--color-node-red-rgb), 0.12)')
 })
 const outerConeStroke = computed(() => isDarkMode.value
   ? rgbaFromVar('--color-danger-rgb', 0.28, 'rgba(var(--color-danger-rgb), 0.28)')

--- a/src/styles/theme-tokens.css
+++ b/src/styles/theme-tokens.css
@@ -167,8 +167,8 @@
 
   /* RGB helpers for light theme */
   --color-danger-rgb: 187, 74, 74;
-  --color-node-blue-rgb: 63, 115, 232;
-  --color-node-red-rgb: 210, 90, 90;
+  --color-node-blue-rgb: 90, 140, 255;
+  --color-node-red-rgb: 232, 90, 90;
 
   /* Borders */
   --color-border-subtle: #c9ced6;
@@ -198,8 +198,8 @@
   /* UI specifics */
   --color-grid-line: rgba(0, 0, 0, 0.07);
 
-  --color-node-blue: #3f73e8;
-  --color-node-red: #d25a5a;
+  --color-node-blue: #5a8cff;
+  --color-node-red: #e85a5a;
 
   --color-node-highlight: rgba(47, 109, 253, 0.12);
   --color-selection-strong: #2f6dfd;

--- a/src/styles/theme-tokens.css
+++ b/src/styles/theme-tokens.css
@@ -165,6 +165,11 @@
   --color-bg-surface: #e9ecf2;
   --color-bg-elevated: #dde2eb;
 
+  /* RGB helpers for light theme */
+  --color-danger-rgb: 187, 74, 74;
+  --color-node-blue-rgb: 63, 115, 232;
+  --color-node-red-rgb: 210, 90, 90;
+
   /* Borders */
   --color-border-subtle: #c9ced6;
   --color-border-strong: #b1b7c3;


### PR DESCRIPTION
## Summary
- add missing RGB helper tokens for the light theme
- ensure sound source nodes use the correct light-mode color values

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926b21cf568832f915ee858f3935a5b)