### PR TITLE
Add theme base handling for consistent theme previews

### DIFF
--- a/src/components/Settings/ThemeSelector.vue
+++ b/src/components/Settings/ThemeSelector.vue
@@ -119,8 +119,24 @@ import { useAuth } from '@/composables/useAuth'
 const { tier, isAuthenticated, user } = useAuth()
 
 const BUILTIN_THEMES = [
-  { id: 'builtin-dark', name: 'dark', label: 'Dark', type: 'builtin', required_plan: 'free', css_vars: {} },
-  { id: 'builtin-light', name: 'light', label: 'Light', type: 'builtin', required_plan: 'free', css_vars: {} }
+  {
+    id: 'builtin-dark',
+    name: 'dark',
+    label: 'Dark',
+    type: 'builtin',
+    required_plan: 'free',
+    theme_base: 'dark',
+    css_vars: {}
+  },
+  {
+    id: 'builtin-light',
+    name: 'light',
+    label: 'Light',
+    type: 'builtin',
+    required_plan: 'free',
+    theme_base: 'light',
+    css_vars: {}
+  }
 ]
 
 const availableThemes = ref([...BUILTIN_THEMES])
@@ -140,7 +156,8 @@ const formatLabel = (theme) => theme
 const normalizeTheme = (theme) => ({
   ...theme,
   label: theme.label || formatLabel(theme.name),
-  type: theme.type || 'database'
+  type: theme.type || 'database',
+  theme_base: theme.theme_base || theme.name || 'dark'
 })
 
 const themeKey = (theme) => (theme?.type === 'builtin' ? theme?.name : theme?.id)
@@ -190,7 +207,8 @@ const previewStyle = (theme) => {
 const readPalette = (theme) => {
   if (typeof document === 'undefined' || !theme) return null
   const probe = document.createElement('div')
-  probe.dataset.theme = theme.type === 'builtin' ? theme.name : activeBaseTheme.value
+  const baseTheme = theme.type === 'builtin' ? theme.name : theme.theme_base || 'dark'
+  probe.dataset.theme = baseTheme
   probe.style.position = 'absolute'
   probe.style.opacity = '0'
   probe.style.pointerEvents = 'none'
@@ -232,6 +250,7 @@ const selectTheme = (theme) => {
     activeBaseTheme.value = setTheme(theme.name, { clearOverrides: true })
     clearThemeVars()
   } else {
+    activeBaseTheme.value = setTheme(theme.theme_base || 'dark', { clearOverrides: true })
     applyThemeVars(theme.css_vars || {})
   }
 }

--- a/src/composables/useThemeBootstrap.js
+++ b/src/composables/useThemeBootstrap.js
@@ -1,6 +1,6 @@
 import { onMounted, watch } from 'vue'
 import { fetchUserTheme } from '@/utils/themeApi'
-import { applyThemeVars, clearThemeVars } from '@/utils/theme'
+import { applyThemeVars, clearThemeVars, setTheme } from '@/utils/theme'
 import { useAuth } from '@/composables/useAuth'
 
 export function useThemeBootstrap() {
@@ -15,6 +15,7 @@ export function useThemeBootstrap() {
 
       const theme = await fetchUserTheme()
       if (theme?.css_vars) {
+        setTheme(theme.theme_base || 'dark', { clearOverrides: true })
         applyThemeVars(theme.css_vars)
       } else {
         clearThemeVars()

--- a/src/utils/themeApi.js
+++ b/src/utils/themeApi.js
@@ -3,7 +3,7 @@ import { supabase } from '@/utils/supabase'
 export async function fetchAllThemes() {
   const { data, error } = await supabase
     .from('themes')
-    .select('id, name, required_plan, css_vars')
+    .select('id, name, required_plan, theme_base, css_vars')
     .order('name', { ascending: true })
 
   if (error) throw error
@@ -18,7 +18,7 @@ export async function fetchUserTheme() {
 
   const { data, error } = await supabase
     .from('users')
-    .select('theme_id, theme:theme_id ( id, name, required_plan, css_vars )')
+    .select('theme_id, theme:theme_id ( id, name, required_plan, theme_base, css_vars )')
     .eq('id', userId)
     .single()
 


### PR DESCRIPTION
## Summary
- include the new `theme_base` column when loading themes and use it to drive base mode selection
- apply the appropriate base theme before hydrating CSS variable overrides for saved themes
- render theme selector previews against each theme's base so previews stay consistent across light/dark mode

## Testing
- `npm run test:unit` *(fails: vitest binary not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926ca351c78832fb6a81bf5c0f8731d)