### PR TITLE
Add global glassmorphism styling across UI

### DIFF
--- a/src/components/Settings/ThemeSelector.vue
+++ b/src/components/Settings/ThemeSelector.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] p-6 shadow-sm space-y-6">
+  <section class="glass-panel space-y-6 p-6">
     <header class="space-y-2">
       <h2 class="text-xl font-semibold">Appearance</h2>
       <p class="text-sm text-[var(--color-text-muted)]">Pick a theme and preview its palette.</p>
@@ -10,12 +10,12 @@
           v-for="theme in themes"
           :key="themeKey(theme)"
           type="button"
-          class="relative flex flex-col gap-3 rounded-xl border p-4 text-left transition duration-200"
+          class="relative flex flex-col gap-3 rounded-xl border p-4 text-left transition duration-200 glass-surface"
           :class="[
             activeThemeKey === themeKey(theme)
               ? 'border-[var(--color-accent-soft)] ring-2 ring-[color-mix(in_srgb,var(--color-accent)_65%,transparent)] shadow-md'
               : 'border-border-subtle hover:border-[var(--color-border-strong)] hover:shadow-sm',
-            'bg-[color-mix(in_srgb,var(--color-bg-elevated)_86%,transparent)] hover:-translate-y-0.5 hover:scale-[1.01]'
+            'hover:-translate-y-0.5 hover:scale-[1.01]'
           ]"
           :style="previewStyle(theme)"
           @click="selectTheme(theme)"
@@ -47,7 +47,7 @@
             </span>
           </div>
 
-          <div class="relative h-20 w-full overflow-hidden rounded-xl border" :style="previewFrameStyle">
+          <div class="relative h-20 w-full overflow-hidden rounded-xl border glass-frame" :style="previewFrameStyle">
             <div class="absolute inset-0" :style="{ background: 'var(--preview-bg)' }"></div>
             <div
               class="absolute inset-[12px] rounded-lg border"

--- a/src/components/SoundRoom/FooterBar.vue
+++ b/src/components/SoundRoom/FooterBar.vue
@@ -21,12 +21,13 @@
   />
 
   <!-- Footer Buttons -->
-  <div class="relative flex items-center justify-between h-15 p-2">
+  <div class="glass-surface relative flex items-center justify-between h-15 p-2 rounded-none">
     <div class="flex space-x-3">
       <BaseButton
         @click="showSaveConfirm = true"
         :disabled="isSaving || !isRoomSaveable"
-        class="px-3 py-2 rounded bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] border border-[var(--color-border-subtle)] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+        variant="secondary"
+        class="px-3 py-2 text-sm"
         type="button"
         aria-label="Open save room confirmation"
       >
@@ -36,7 +37,8 @@
       <BaseButton
         @click="showNewRoomConfirm = true"
         :disabled="isSaving || isRoomEmpty"
-        class="px-3 py-2 rounded bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] border border-[var(--color-border-subtle)] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+        variant="secondary"
+        class="px-3 py-2 text-sm"
         type="button"
         aria-label="Open new room confirmation"
       >

--- a/src/components/SoundRoom/HeaderBar.vue
+++ b/src/components/SoundRoom/HeaderBar.vue
@@ -1,6 +1,6 @@
 <template>
   <PulsingOverlay v-if="isLoggingOut" :duration="2000" :text="'Logging out...'" @done="isLoggingOut = false" />
-  <header class="px-6 py-4 border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] flex items-center justify-between relative">
+  <header class="glass-surface px-6 py-4 border-b text-[var(--color-text-primary)] flex items-center justify-between relative rounded-none">
     <h1 class="text-xl font-bold tracking-wide text-[var(--color-text-primary)]"><RouterLink to="/" style="text-decoration: none; color: inherit;">SoundRoom</RouterLink></h1>
     
     <div v-if="shouldShowNavButtons" class="relative">

--- a/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
+++ b/src/components/SoundRoom/SidebarLeft/SidebarLeft.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-[var(--color-bg-elevated)] border-r border-[var(--color-border-subtle)] p-4 space-y-6 text-[var(--color-text-primary)]"
+    class="glass-surface flex flex-col h-full border-r p-4 space-y-6 text-[var(--color-text-primary)] rounded-none"
     role="region"
     aria-labelledby="library-panel-label"
   >

--- a/src/components/SoundRoom/SidebarRight/SidebarRight.vue
+++ b/src/components/SoundRoom/SidebarRight/SidebarRight.vue
@@ -1,6 +1,6 @@
 <template>
   <aside
-    class="flex flex-col h-full bg-[var(--color-bg-elevated)] border-l border-[var(--color-border-subtle)] p-4 space-y-4 text-[var(--color-text-primary)]"
+    class="glass-surface flex flex-col h-full border-l p-4 space-y-4 text-[var(--color-text-primary)] rounded-none"
     role="region"
     aria-labelledby="selected-sound-panel-label"
   >

--- a/src/components/SoundRoom/Toolbar.vue
+++ b/src/components/SoundRoom/Toolbar.vue
@@ -1,26 +1,29 @@
 <template>
-  <div class="flex items-center justify-between p-3 border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] space-x-10 w-full shadow-[var(--color-shadow-soft)] text-[var(--color-text-primary)]">
+  <div class="glass-surface flex items-center justify-between p-3 space-x-10 w-full text-[var(--color-text-primary)] rounded-none">
           
     <div class="flex space-x-2 w-1/3">
       <BaseButton
       :disabled="audioEngine.soundSources.value.length === 0"
       @click="isPlaying ? audioEngine.pauseAll() : audioEngine.playAll()"
-      class="px-3 py-1 rounded text-sm bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)]"
-      > 
+      variant="secondary"
+      class="px-3 py-1 text-sm"
+      >
         
         <component :is="isPlaying ? Pause : Play" class="h-4 w-4 fill-[var(--color-text-primary)]" />
       </BaseButton>
       <BaseButton
         :disabled="actionStackEmpty || waiting"
         @click="actionManager.undoLastAction"
-        class="px-3 py-1 rounded text-sm bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)]"
+        variant="secondary"
+        class="px-3 py-1 text-sm"
       >
         <UndoRedo class="h-4 w-4 fill-[var(--color-text-primary)]"/>
       </BaseButton>
       <BaseButton
         :disabled="redoStackEmpty || waiting"
         @click="actionManager.redoLastAction"
-        class="px-3 py-1 rounded text-sm bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)]"
+        variant="secondary"
+        class="px-3 py-1 text-sm"
       >
         <UndoRedo class="h-4 w-4 scale-x-[-1] fill-[var(--color-text-primary)]"/>
       </BaseButton>

--- a/src/components/ui/input/BaseButton.vue
+++ b/src/components/ui/input/BaseButton.vue
@@ -1,20 +1,16 @@
 <template>
   <button
-  :type="type"
-  :disabled="disabled"
-  :class="[
-    'transition focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base disabled:opacity-50 disabled:cursor-not-allowed',
-    variant === 'default' && 'px-4 py-2 rounded text-sm font-medium bg-accent hover:bg-accent-strong text-text-inverse',
-    variant === 'naked' && 'bg-transparent text-text-primary hover:text-accent-soft'
-  ]"
-  @click="(e) => $emit('click', e)"
->
+    :type="type"
+    :disabled="disabled"
+    :class="computedClasses"
+    @click="(e) => $emit('click', e)"
+  >
     <span v-if="!loading">
       <slot />
     </span>
     <span v-else class="flex items-center justify-center space-x-2">
       <svg
-        class="w-4 h-4 animate-spin text-text-inverse"
+        class="w-4 h-4 animate-spin"
         fill="none"
         viewBox="0 0 24 24"
       >
@@ -38,7 +34,9 @@
 </template>
 
 <script setup>
-defineProps({
+import { computed } from 'vue'
+
+const props = defineProps({
   type: {
     type: String,
     default: 'button',
@@ -47,8 +45,22 @@ defineProps({
   loading: Boolean,
   variant: {
     type: String,
-    default: 'default', // or 'naked'
+    default: 'default', // 'naked' | 'secondary' | 'subtle' | 'ghost'
   },
 })
 defineEmits(['click'])
+
+const computedClasses = computed(() => {
+  const base = 'transition focus:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base disabled:opacity-50 disabled:cursor-not-allowed'
+
+  const variants = {
+    default: 'px-4 py-2 rounded text-sm font-medium bg-accent hover:bg-accent-strong text-text-inverse',
+    naked: 'bg-transparent text-text-primary hover:text-accent-soft',
+    secondary: 'glass-button text-sm font-medium',
+    subtle: 'glass-button text-sm font-medium text-text-muted hover:text-text-primary',
+    ghost: 'glass-button-ghost text-sm font-medium text-text-primary',
+  }
+
+  return [base, variants[props.variant] ?? variants.default]
+})
 </script>

--- a/src/components/ui/modals/EntitlementUpsellModal.vue
+++ b/src/components/ui/modals/EntitlementUpsellModal.vue
@@ -5,7 +5,7 @@
       class="modal-backdrop"
       @click.self="handleClose"
     >
-      <div class="modal-panel" role="dialog" aria-modal="true">
+      <div class="modal-panel glass-panel max-w-[min(480px,90vw)]" role="dialog" aria-modal="true">
         <h2 class="text-2xl font-semibold mb-3">{{ title }}</h2>
         <p class="text-[var(--color-text-muted)] mb-6">{{ message }}</p>
         <div class="flex flex-wrap gap-3">
@@ -39,21 +39,11 @@ function handleUpgrade() {
 
 <style scoped>
 .modal-backdrop {
-  position: fixed;
-  inset: 0;
-  background-color: rgba(var(--base-black-rgb), 0.45);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1100;
+  background-color: color-mix(in srgb, var(--glass-bg) 70%, rgba(var(--base-black-rgb), 0.35));
+  backdrop-filter: blur(14px);
 }
 
 .modal-panel {
-  width: min(480px, 90vw);
-  background-color: var(--color-bg-surface);
-  color: var(--color-text-primary);
-  border-radius: 16px;
-  padding: 32px;
-  box-shadow: var(--color-shadow-strong);
+  @apply w-full text-text-primary p-8 shadow-[var(--color-shadow-strong)];
 }
 </style>

--- a/src/components/ui/modals/SmallModalBase.vue
+++ b/src/components/ui/modals/SmallModalBase.vue
@@ -1,19 +1,19 @@
 <template>
   <div
     @click.self="canClickOutside && emit('close')"
-    class="fixed inset-0 bg-[color-mix(in_srgb,var(--color-bg-app)_70%,transparent)] backdrop-blur-sm z-50 flex items-center justify-center"
+    class="fixed inset-0 bg-[color-mix(in_srgb,var(--color-bg-app)_70%,transparent)] backdrop-blur-md z-50 flex items-center justify-center"
     role="dialog"
     aria-modal="true"
     :aria-labelledby="'modal-title'"
   >
     <div
       ref="modalContent"
-      class="bg-surface-base text-text-primary rounded-2xl w-[90vw] max-w-md h-auto max-h-[85vh] shadow-xl border border-border-subtle relative overflow-hidden"
+      class="glass-panel text-text-primary w-[90vw] max-w-md h-auto max-h-[85vh] relative overflow-hidden"
       tabindex="-1"
     >
       <!-- Header -->
       <div
-        class="top-0 left-0 right-0 z-10 flex justify-between items-center px-4 py-3 bg-[color-mix(in_srgb,var(--color-bg-surface)_80%,transparent)] backdrop-blur-md border-b border-border-subtle"
+        class="top-0 left-0 right-0 z-10 flex justify-between items-center px-4 py-3 glass-surface rounded-none border-b"
       >
         <h2 id="modal-title" class="text-lg font-semibold tracking-tight">
           {{ title }}

--- a/src/style.css
+++ b/src/style.css
@@ -119,7 +119,8 @@ input:disabled {
 }
 
 .modal-panel {
-  @apply glass-panel w-[80vw] h-[80vh] overflow-hidden;
+  @apply bg-[var(--glass-bg)] border border-[var(--glass-border)] backdrop-blur-md shadow-[var(--color-shadow-soft)] rounded-2xl w-[80vw] h-[80vh] overflow-hidden;
+  background-color: color-mix(in srgb, var(--color-bg-surface) 72%, transparent);
 }
 
 .modal-header-float {
@@ -160,7 +161,8 @@ input:disabled {
   .glass-panel,
   .glass-frame,
   .glass-button,
-  .glass-button-ghost {
+  .glass-button-ghost,
+  .modal-panel {
     background-color: color-mix(in srgb, var(--color-bg-surface) 80%, transparent);
   }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -114,11 +114,12 @@ input:disabled {
 }
 
 .modal-backdrop {
-  @apply fixed inset-0 bg-[color-mix(in_srgb,var(--color-text-inverse)_60%,transparent)] backdrop-blur-sm z-50 flex items-center justify-center;
+  @apply fixed inset-0 z-50 flex items-center justify-center backdrop-blur-md;
+  background: color-mix(in srgb, var(--glass-bg) 70%, rgba(var(--base-black-rgb), 0.35));
 }
 
 .modal-panel {
-  @apply bg-surface-app rounded-2xl w-[80vw] h-[80vh] shadow-[var(--color-shadow-soft)] border border-border-subtle overflow-hidden;
+  @apply glass-panel w-[80vw] h-[80vh] overflow-hidden;
 }
 
 .modal-header-float {
@@ -127,4 +128,39 @@ input:disabled {
 
 .modal-header {
   @apply top-0 left-0 right-0 z-10 flex justify-between items-center px-6 py-4 bg-[color-mix(in_srgb,var(--color-bg-app)_85%,transparent)] backdrop-blur-md border-b border-[var(--color-border-subtle)];
+}
+
+@layer components {
+  .glass-surface {
+    @apply bg-[var(--glass-bg)] border border-[var(--glass-border)] backdrop-blur-md shadow-[var(--color-shadow-soft)];
+    background-color: color-mix(in srgb, var(--color-bg-surface) 72%, transparent);
+  }
+
+  .glass-panel {
+    @apply glass-surface rounded-2xl;
+  }
+
+  .glass-frame {
+    @apply glass-surface rounded-xl;
+  }
+
+  .glass-button {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 bg-[var(--glass-bg)] border border-[var(--glass-border)] backdrop-blur-md shadow-[var(--color-shadow-soft)] transition duration-200;
+    background-color: color-mix(in srgb, var(--color-bg-surface) 72%, transparent);
+  }
+
+  .glass-button-ghost {
+    @apply glass-button bg-transparent hover:bg-[var(--glass-bg)];
+    background-color: color-mix(in srgb, var(--color-bg-surface) 60%, transparent);
+  }
+}
+
+@supports not (backdrop-filter: blur(2px)) {
+  .glass-surface,
+  .glass-panel,
+  .glass-frame,
+  .glass-button,
+  .glass-button-ghost {
+    background-color: color-mix(in srgb, var(--color-bg-surface) 80%, transparent);
+  }
 }

--- a/src/styles/theme-tokens.css
+++ b/src/styles/theme-tokens.css
@@ -105,6 +105,12 @@
   --color-selection-strong: #2f6dfd;
   --color-selection-soft: rgba(47, 109, 253, 0.18);
 
+  /* -----------------------------------------
+     GLASS TOKENS (global)
+     ----------------------------------------- */
+  --glass-bg: rgba(var(--base-white-rgb), 0.06);
+  --glass-border: rgba(var(--color-border-subtle-rgb), 0.5);
+
   --color-surface-muted: #20232b;
 
   --color-panel: #0d0f15;
@@ -172,6 +178,7 @@
 
   /* Borders */
   --color-border-subtle: #c9ced6;
+  --color-border-subtle-rgb: 201, 206, 214;
   --color-border-strong: #b1b7c3;
 
   /* Text */
@@ -215,4 +222,8 @@
 
   --color-outline-strong: #3c4961;
   --color-detail-stroke: #354156;
+
+  /* Glass tokens */
+  --glass-bg: rgba(255, 255, 255, 0.45);
+  --glass-border: rgba(var(--color-border-subtle-rgb), 0.5);
 }

--- a/src/views/ManagePlan.vue
+++ b/src/views/ManagePlan.vue
@@ -32,7 +32,7 @@
         </div>
 
         <div
-          class="rounded-2xl p-6 shadow-sm border bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)]"
+          class="glass-panel p-6 shadow-sm"
           :class="planTheme.card"
         >
           <header class="flex flex-wrap items-center justify-between gap-4">
@@ -80,7 +80,7 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] p-6 shadow-sm space-y-6">
+      <section class="glass-panel p-6 shadow-sm space-y-6">
         <header class="space-y-1">
           <h2 class="text-xl font-semibold">Billing & Receipts</h2>
           <p class="text-sm text-text-muted">
@@ -88,7 +88,7 @@
           </p>
         </header>
 
-        <div class="rounded-xl border border-dashed border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] px-5 py-6 text-sm text-text-secondary">
+        <div class="glass-surface rounded-xl border-dashed px-5 py-6 text-sm text-text-secondary">
           <p>Need an invoice, tax receipt, or want to change your payment method?</p>
           <p class="mt-3">Email <a class="underline" :href="supportEmailHref">{{ SUPPORT_EMAIL }}</a> and include the email tied to your SoundRoom account.</p>
         </div>
@@ -111,14 +111,14 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_90%,transparent)] p-6 shadow-sm space-y-6">
+      <section class="glass-panel p-6 shadow-sm space-y-6">
         <header class="space-y-1">
           <h2 class="text-xl font-semibold">Upcoming Features</h2>
           <p class="text-sm text-text-muted">We are actively building deeper collaboration and scheduling tools. Here is what is landing next for paying members.</p>
         </header>
 
         <ul class="grid gap-4 md:grid-cols-2">
-          <li v-for="item in roadmapHighlights" :key="item.title" class="rounded-xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_92%,transparent)] p-5 space-y-2">
+          <li v-for="item in roadmapHighlights" :key="item.title" class="glass-surface rounded-xl p-5 space-y-2">
             <p class="text-sm uppercase tracking-wide text-text-muted">{{ item.badge }}</p>
             <h3 class="text-lg font-medium">{{ item.title }}</h3>
             <p class="text-sm text-text-muted">{{ item.copy }}</p>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -9,7 +9,7 @@
               Update how you appear in SoundRoom, adjust playback preferences, and keep your account secure.
             </p>
           </div>
-          <div class="flex items-center gap-3 rounded-full border border-border-subtle px-4 py-2 bg-[color-mix(in_srgb,var(--color-bg-surface)_85%,transparent)]">
+          <div class="glass-surface rounded-full flex items-center gap-3 px-4 py-2">
             <span class="text-xs uppercase tracking-wide text-text-muted">Plan</span>
             <span class="text-sm font-medium">{{ planLabel }}</span>
             <RouterLink v-if="tier.value === 'free'" :to="'/upgrade'" class="ml-2">
@@ -43,7 +43,7 @@
           <p v-else-if="planErrorMessage" class="text-sm font-medium">{{ planErrorMessage }}</p>
         </div>
 
-        <div class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_85%,transparent)] p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
+        <div class="glass-panel p-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6">
           <div>
             <p class="text-sm text-text-muted">Signed in as</p>
             <p class="text-lg font-medium break-all">{{ userEmail }}</p>
@@ -67,7 +67,7 @@
         </div>
       </section>
 
-      <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_88%,transparent)] p-6 shadow-sm space-y-6">
+      <section class="glass-panel space-y-6 p-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Profile</h2>
           <p class="text-sm text-text-muted">Set how teammates and collaborators see you.</p>
@@ -136,7 +136,7 @@
 
       <ThemeSelector />
 
-      <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_88%,transparent)] p-6 shadow-sm space-y-6">
+      <section class="glass-panel space-y-6 p-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Playback Preferences</h2>
           <p class="text-sm text-text-muted">These settings are stored locally in your browser.</p>
@@ -188,7 +188,7 @@
         <p v-if="preferenceMessage" class="text-sm text-status-success">{{ preferenceMessage }}</p>
       </section>
 
-      <section class="rounded-2xl border border-border-subtle bg-[color-mix(in_srgb,var(--color-bg-surface)_88%,transparent)] p-6 shadow-sm space-y-6">
+      <section class="glass-panel space-y-6 p-6">
         <header class="space-y-2">
           <h2 class="text-xl font-semibold">Security</h2>
           <p class="text-sm text-text-muted">Keep your account protected and up to date.</p>

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -17,7 +17,7 @@
         <Toolbar/>
 
         <!-- Canvas Area -->
-        <div class="flex-1 relative overflow-hidden bg-[var(--color-bg-surface)] flex items-center justify-center border-t border-[var(--color-border-subtle)]">
+        <div class="glass-surface flex-1 relative overflow-hidden flex items-center justify-center border-t rounded-none">
           <div class="pointer-events-none absolute inset-0 canvas-vignette" aria-hidden="true"></div>
           <MainCanvasStage
             v-bind="{


### PR DESCRIPTION
## Summary
- add global glassmorphism tokens and component utilities applied independent of theme data
- refresh headers, sidebars, panels, buttons, and modals to use reusable glass styles
- update canvas and theme previews with translucent surfaces and responsive fallbacks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69276798e474832fa65d17acc08fd474)