### PR TITLE
Handle deleted uploads across rooms

### DIFF
--- a/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
@@ -59,6 +59,8 @@ import { registerSoundRoomActions } from '@/composables/useSoundRoomActions'
 import { storeToRefs } from 'pinia'
 import deleteAudio from '@/utils/deleteAudio'
 import { annotateSoundAccess } from '@/utils/soundEntitlements'
+import { purgeSoundCache, removeDeletedSoundFromRooms } from '@/utils/soundIntegrity'
+import { buildStorageKey } from '@/utils/downloadAudio'
 
 
 const { user, isAuthenticated, tier } = useAuth()
@@ -180,11 +182,17 @@ async function doDeleteSound() {
   if (!soundToDelete.value) return
   const s = soundToDelete.value
   try {
+    const cacheEntry = soundLibrarySources.value.find(sound => sound.libraryId == s.libraryId)
     if (soundLibrarySources.value.find(sound => sound.libraryId == s.libraryId)) {
       await actionStore.deleteLibrarySoundSource(s)
     }
+    const storageKey = s.bucket && s.path ? buildStorageKey(s.plan_tier ?? 'users', s.bucket, s.path) : cacheEntry?.storageKey
     await deleteAudio(s.bucket, s.path, s.plan_tier ?? 'users')
     await supabase.from('sound_files').delete().eq('id', s.libraryId)
+    await purgeSoundCache(s.libraryId)
+    if (storageKey) await purgeSoundCache(storageKey)
+    if (cacheEntry?.audioPath) await purgeSoundCache(cacheEntry.audioPath)
+    await removeDeletedSoundFromRooms(s.libraryId)
     await refreshUserSounds()
   } catch (error) {
     console.error('Failed to delete user sound:', error)

--- a/src/composables/useSaveAndLoadRoom.js
+++ b/src/composables/useSaveAndLoadRoom.js
@@ -409,7 +409,7 @@ export function useSaveAndLoadRoom() {
       isLoadingRoom.value = false;
       return
     } else {
-      const roomData = JSON.parse(stored);
+      let roomData = JSON.parse(stored);
       const ids = roomData.soundLibrarySources.map(s => s.libraryId);
       const { accessible: dbSounds, lockedIds, missingIds } = await getSoundsFromDB(ids);
       const { successes: downloaded, failedIds } = await downloadMultipleAudio(dbSounds);

--- a/src/composables/useSaveAndLoadRoom.js
+++ b/src/composables/useSaveAndLoadRoom.js
@@ -17,6 +17,7 @@ import { useAuth } from "@/composables/useAuth";
 import { ref } from "vue";
 import { useEntitlements } from '@/composables/useEntitlements'
 import { annotateSoundAccess } from '@/utils/soundEntitlements'
+import { filterRoomByAvailableSounds } from '@/utils/soundIntegrity'
 
 /**
  * Manage saving and loading of rooms from Supabase or local storage.
@@ -237,23 +238,28 @@ export function useSaveAndLoadRoom() {
       return false;
     }
     
-    const roomData = data.room_config;
+    let roomData = data.room_config;
     const resolvedRoomId = data?.id ?? (roomId ?? roomData?.room?.id ?? null);
     roomData.room.id = resolvedRoomId; // Set the room ID from the database
     roomData.room.name = data.name; // Set the room name from the database
-    const ids = roomData.soundLibrarySources.map(s => s.libraryId);
-    const dbSounds = await getSoundsFromDB(ids);
-    const downloaded = await downloadMultipleAudio(dbSounds);
+    const ids = roomData?.soundLibrarySources?.map(s => s.libraryId) ?? [];
+    const { accessible: dbSounds, lockedIds, missingIds } = await getSoundsFromDB(ids);
+    const { successes: downloaded, failedIds } = await downloadMultipleAudio(dbSounds);
 
-    const finalSources = ids.map(id => {
-      const audioPath = downloaded.find(p => p.id === id)?.audioPath;
-      const soundMatch = dbSounds.find(d => d.id === id);
+    const downloadedMap = new Map(downloaded.map(entry => [entry.id, entry.audioPath]));
+    const availableIds = new Set(downloaded.map(entry => entry.id));
+    const { roomData: cleanedRoom, removed } = filterRoomByAvailableSounds(roomData, availableIds)
+    roomData = cleanedRoom
 
-      const coneInner = roomData.audioEngine.soundSources.find(src => src.libraryId === id)?.state?.coneInner ?? soundMatch?.coneInner ?? 60;
-      const coneOuter = roomData.audioEngine.soundSources.find(src => src.libraryId === id)?.state?.coneOuter ?? soundMatch?.coneOuter ?? 180;
+    const finalSources = roomData.soundLibrarySources.map(({ libraryId }) => {
+      const audioPath = downloadedMap.get(libraryId);
+      const soundMatch = dbSounds.find(d => d.id === libraryId);
+
+      const coneInner = roomData.audioEngine.soundSources.find(src => src.libraryId === libraryId)?.state?.coneInner ?? soundMatch?.coneInner ?? 60;
+      const coneOuter = roomData.audioEngine.soundSources.find(src => src.libraryId === libraryId)?.state?.coneOuter ?? soundMatch?.coneOuter ?? 180;
 
       if (!audioPath || !soundMatch) {
-        console.warn(`Missing data for libraryId ${id}`);
+        console.warn(`Missing data for libraryId ${libraryId}`);
         return null; // or skip it entirely if you'd prefer
       }
 
@@ -264,7 +270,7 @@ export function useSaveAndLoadRoom() {
         : null
 
       return {
-        libraryId: id,
+        libraryId,
         audioPath,
         coneInner,
         coneOuter,
@@ -274,10 +280,21 @@ export function useSaveAndLoadRoom() {
         plan_tier: planTier,
         base,
         storageKey,
-        fileId: id ?? storageKey
+        fileId: libraryId ?? storageKey
       };
     }).filter(Boolean); // remove nulls if any
     soundLibrarySources.value = finalSources;
+
+    const missingUploadCount = missingIds.length + failedIds.length
+    if (lockedIds.length > 0) {
+      console.info(`Skipped ${lockedIds.length} locked sound(s) while loading room.`)
+    }
+    if (removed > 0 && missingUploadCount === 0 && lockedIds.length === 0) {
+      console.info(`Removed ${removed} unavailable sound source(s) while loading room.`)
+    }
+    if (missingUploadCount > 0) {
+      window.alert('1 or more sources were removed because the upload no longer exists.')
+    }
 
 
     roomData.audioEngine.soundSources.forEach(src => {
@@ -340,7 +357,7 @@ export function useSaveAndLoadRoom() {
    * @returns {Promise<Array>} list of sound records
    */
   async function getSoundsFromDB(ids) {
-    if (!ids?.length) return []
+    if (!ids?.length) return { accessible: [], lockedIds: [], missingIds: [] }
 
     const { data, error } = await supabase
       .from("sound_files")
@@ -349,7 +366,7 @@ export function useSaveAndLoadRoom() {
 
     if (error) {
       console.warn("Failed to list files:", error);
-      return []
+      return { accessible: [], lockedIds: [], missingIds: ids }
     }
 
     const context = {
@@ -358,14 +375,15 @@ export function useSaveAndLoadRoom() {
     }
 
     const annotated = (data ?? []).map(sound => annotateSoundAccess(sound, context))
+    const locked = annotated.filter(sound => sound.locked).map(sound => sound.id)
     const accessible = annotated.filter(sound => !sound.locked)
+    const missingIds = ids.filter(id => !annotated.find(sound => sound.id === id))
 
-    const skipped = annotated.length - accessible.length
-    if (skipped > 0) {
-      console.info(`Skipped ${skipped} sound(s) due to plan entitlements.`)
+    if (locked.length > 0) {
+      console.info(`Skipped ${locked.length} sound(s) due to plan entitlements.`)
     }
 
-    return accessible;
+    return { accessible, lockedIds: locked, missingIds }
   }
   /**
    * Persist the current room to browser localStorage for offline usage.
@@ -393,25 +411,42 @@ export function useSaveAndLoadRoom() {
     } else {
       const roomData = JSON.parse(stored);
       const ids = roomData.soundLibrarySources.map(s => s.libraryId);
-      const dbSounds = await getSoundsFromDB(ids);
-      const downloaded = await downloadMultipleAudio(dbSounds);
+      const { accessible: dbSounds, lockedIds, missingIds } = await getSoundsFromDB(ids);
+      const { successes: downloaded, failedIds } = await downloadMultipleAudio(dbSounds);
 
-      const finalSources = ids.map(id => {
-        const audioPath = downloaded.find(p => p.id === id)?.audioPath;
-        const soundMatch = dbSounds.find(d => d.id === id);
-        const name = soundMatch.name;
-        const bucket = soundMatch.bucket;
-        const path = soundMatch.path;
+      const downloadedMap = new Map(downloaded.map(entry => [entry.id, entry.audioPath]));
+      const availableIds = new Set(downloaded.map(entry => entry.id));
+      const { roomData: cleanedRoom, removed } = filterRoomByAvailableSounds(roomData, availableIds)
+      roomData = cleanedRoom
+
+      const finalSources = roomData.soundLibrarySources.map(({ libraryId }) => {
+        const audioPath = downloadedMap.get(libraryId);
+        const soundMatch = dbSounds.find(d => d.id === libraryId);
+        const name = soundMatch?.name;
+        const bucket = soundMatch?.bucket;
+        const path = soundMatch?.path;
         const planTier = soundMatch?.plan_tier;
         const base = soundMatch?.base ?? planTier ?? 'users';
         const storageKey = bucket && path ? buildStorageKey(base, bucket, path) : null;
-        const coneInner = roomData.audioEngine.soundSources.find(src => src.libraryId === id)?.state?.coneInner ?? soundMatch?.coneInner ?? 60;
-        const coneOuter = roomData.audioEngine.soundSources.find(src => src.libraryId === id)?.state?.coneOuter ?? soundMatch?.coneOuter ?? 180;
-        if (!audioPath) console.warn(`Missing audioPath for libraryId ${id}`);
-        return { libraryId: id, audioPath, name, path, bucket, coneInner, coneOuter, plan_tier: planTier, base, storageKey, fileId: id ?? storageKey };
-      });
+        const coneInner = roomData.audioEngine.soundSources.find(src => src.libraryId === libraryId)?.state?.coneInner ?? soundMatch?.coneInner ?? 60;
+        const coneOuter = roomData.audioEngine.soundSources.find(src => src.libraryId === libraryId)?.state?.coneOuter ?? soundMatch?.coneOuter ?? 180;
+        if (!audioPath || !soundMatch) console.warn(`Missing audioPath for libraryId ${libraryId}`);
+        if (!audioPath || !soundMatch) return null
+        return { libraryId, audioPath, name, path, bucket, coneInner, coneOuter, plan_tier: planTier, base, storageKey, fileId: libraryId ?? storageKey };
+      }).filter(Boolean);
 
       soundLibrarySources.value = finalSources;
+
+      const missingUploadCount = missingIds.length + failedIds.length
+      if (lockedIds.length > 0) {
+        console.info(`Skipped ${lockedIds.length} locked sound(s) while loading room.`)
+      }
+      if (removed > 0 && missingUploadCount === 0 && lockedIds.length === 0) {
+        console.info(`Removed ${removed} unavailable sound source(s) while loading room.`)
+      }
+      if (missingUploadCount > 0) {
+        window.alert('1 or more sources were removed because the upload no longer exists.')
+      }
 
       roomData.audioEngine.soundSources.forEach(src => {
         const match = finalSources.find(a => a.libraryId === src.libraryId);

--- a/src/composables/useSoundRoomActions.js
+++ b/src/composables/useSoundRoomActions.js
@@ -4,6 +4,7 @@ import { useAudioEngineStore } from '@/stores/useAudioEngineStore'
 import { useListenerStore } from '@/stores/useListenerStore'
 import { useAudioCacheStore } from '@/stores/useAudioCacheStore'
 import { storeToRefs } from 'pinia'
+import { isSoundAvailable } from '@/utils/soundIntegrity'
 
 let actionsRegistered = false
 let registeredActionManager = null
@@ -69,7 +70,15 @@ function registerCanvasActions() {
    *
    * @param {Object} payload - action payload
    */
-  const addSoundSource = (payload) => {
+  const addSoundSource = async (payload) => {
+    const libraryId = payload?.src?.libraryId
+    if (libraryId && !soundLibrarySources.value.find(s => s.libraryId === libraryId)) {
+      const available = await isSoundAvailable(libraryId)
+      if (!available) {
+        console.warn(`Skipping add for deleted sound ${libraryId}`)
+        return
+      }
+    }
     const libraryEntry = soundLibrarySources.value.find(s => s.libraryId === payload.src.libraryId)
     if (libraryEntry) {
       payload.src.audioPath = libraryEntry.audioPath
@@ -98,7 +107,7 @@ function registerCanvasActions() {
   }
 
   actionManager.value.registerActionHandlers('add_canvas_sound_source',
-    addSoundSource,
+    async payload => await addSoundSource(payload),
     deleteSoundSource
   )
 
@@ -192,6 +201,13 @@ function registerDraggableActions() {
    */
   const addDraggableSoundSource = async (payload) => {
     if (maxLibSourcesReached(soundLibrarySources)) return;
+    if (payload?.src?.libraryId) {
+      const available = await isSoundAvailable(payload.src.libraryId)
+      if (!available) {
+        console.warn(`Cannot restore deleted sound ${payload.src.libraryId}`)
+        return
+      }
+    }
     // download blob and re-instate draggable source
     const { blobUrl } = await downloadAudio(
       payload.src.bucket,

--- a/src/utils/downloadAudio.js
+++ b/src/utils/downloadAudio.js
@@ -109,19 +109,27 @@ export async function downloadMultipleAudio(
   populateAudio = false,
   stopPlayback = null
 ) {
-  const results = await Promise.all(
+  const successes = []
+  const failedIds = []
+
+  await Promise.all(
     sourcesList.map(async (src) => {
-      const result = await downloadAudio(
-        src.bucket,
-        src.path,
-        src.base,
-        populateAudio,
-        stopPlayback,
-        src.id
-      )
-      return result ? { id: src.id, audioPath: result.blobUrl } : null
+      try {
+        const result = await downloadAudio(
+          src.bucket,
+          src.path,
+          src.base,
+          populateAudio,
+          stopPlayback,
+          src.id
+        )
+        if (result) successes.push({ id: src.id, audioPath: result.blobUrl })
+      } catch (error) {
+        console.warn(`Failed to download sound ${src.id}:`, error)
+        failedIds.push(src.id)
+      }
     })
   )
 
-  return results.filter(Boolean) // filter out any failed downloads
+  return { successes, failedIds }
 }

--- a/src/utils/soundIntegrity.js
+++ b/src/utils/soundIntegrity.js
@@ -1,0 +1,207 @@
+import { supabase } from '@/utils/supabase'
+import { useAuth } from '@/composables/useAuth'
+import { useAudioCacheStore } from '@/stores/useAudioCacheStore'
+import { useAudioEngineStore } from '@/stores/useAudioEngineStore'
+import { storeToRefs } from 'pinia'
+
+/**
+ * Check whether a sound record still exists and is accessible.
+ * Missing records imply the upload has been deleted.
+ *
+ * @param {string} soundId
+ * @returns {Promise<boolean>}
+ */
+export async function isSoundAvailable(soundId) {
+  if (!soundId) return false
+
+  const { data, error } = await supabase
+    .from('sound_files')
+    .select('id')
+    .eq('id', soundId)
+    .single()
+
+  if (error) {
+    console.warn('Unable to verify sound availability:', error)
+    return false
+  }
+
+  return Boolean(data?.id)
+}
+
+/**
+ * Remove cached blobs and object URLs associated with a sound.
+ *
+ * @param {string} urlOrId
+ * @returns {Promise<void>}
+ */
+export async function purgeSoundCache(urlOrId) {
+  if (!urlOrId) return
+
+  try {
+    const cacheStore = useAudioCacheStore()
+    cacheStore?.audioCacheManager?.value?.remove?.(urlOrId)
+  } catch (err) {
+    console.warn('Failed to purge audio cache entry:', err)
+  }
+
+  if (typeof urlOrId === 'string' && urlOrId.startsWith('blob:')) {
+    try {
+      URL.revokeObjectURL(urlOrId)
+    } catch (err) {
+      console.warn('Unable to revoke object URL:', err)
+    }
+  }
+}
+
+/**
+ * Remove references to a deleted sound from persisted rooms and
+ * any currently loaded state.
+ *
+ * @param {string} soundId
+ * @returns {Promise<{ updated: number, removedLocally: number }>} counts of changes applied
+ */
+export async function removeDeletedSoundFromRooms(soundId) {
+  const { user } = useAuth()
+  const cacheStore = useAudioCacheStore()
+  const engineStore = useAudioEngineStore()
+  const { soundLibrarySources } = storeToRefs(cacheStore)
+  const { audioEngine } = storeToRefs(engineStore)
+
+  // Clean up active state so the node disappears immediately
+  let removedLocally = 0
+  const localIndex = soundLibrarySources.value.findIndex(src => src.libraryId === soundId)
+  if (localIndex !== -1) {
+    soundLibrarySources.value.splice(localIndex, 1)
+    removedLocally++
+  }
+
+  if (audioEngine.value?.soundSources?.value) {
+    const currentSources = audioEngine.value.soundSources.value
+    for (let i = currentSources.length - 1; i >= 0; i--) {
+      if (currentSources[i]?.libraryId === soundId) {
+        audioEngine.value.deleteSoundSource({ index: i, src: currentSources[i] })
+        removedLocally++
+      }
+    }
+  }
+
+  // Update any locally cached room draft
+  const stored = localStorage.getItem('tempSoundRoomData')
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored)
+      const { roomData: cleanedDraft, removed } = stripSoundFromRoom(parsed, soundId)
+      if (removed > 0) {
+        localStorage.setItem('tempSoundRoomData', JSON.stringify(cleanedDraft))
+      }
+    } catch (err) {
+      console.warn('Unable to clean local draft after deletion:', err)
+    }
+  }
+
+  // If the user is not signed in we cannot touch saved rooms
+  if (!user.value?.id) return { updated: 0, removedLocally }
+
+  const { data, error } = await supabase
+    .from('rooms')
+    .select('id, room_config')
+    .eq('owner_id', user.value.id)
+
+  if (error) {
+    console.error('Failed to clean rooms after sound deletion:', error)
+    return { updated: 0, removedLocally }
+  }
+
+  let updated = 0
+  const rooms = data ?? []
+
+  for (const room of rooms) {
+    const { roomData: cleanedConfig, removed } = stripSoundFromRoom(room.room_config, soundId)
+    if (removed > 0) {
+      updated++
+      const { error: updateError } = await supabase
+        .from('rooms')
+        .update({ room_config: cleanedConfig, thumbnail: null })
+        .eq('id', room.id)
+      if (updateError) {
+        console.warn('Unable to update room after removing deleted sound:', updateError)
+      }
+    }
+  }
+
+  return { updated, removedLocally }
+}
+
+/**
+ * Remove a single sound reference from a room configuration.
+ *
+ * @param {Object} roomConfig
+ * @param {string} soundId
+ * @returns {{ roomData: Object, removed: number }}
+ */
+export function stripSoundFromRoom(roomConfig, soundId) {
+  if (!roomConfig || !soundId) {
+    return { roomData: roomConfig, removed: 0 }
+  }
+
+  const currentLibrary = roomConfig.soundLibrarySources ?? []
+  const currentEngineSources = roomConfig.audioEngine?.soundSources ?? []
+
+  const filteredLibrary = currentLibrary.filter(src => src.libraryId !== soundId)
+  const filteredEngine = currentEngineSources.filter(src => src.libraryId !== soundId)
+
+  const removed = (currentLibrary.length - filteredLibrary.length) + (currentEngineSources.length - filteredEngine.length)
+
+  return {
+    roomData: {
+      ...roomConfig,
+      soundLibrarySources: filteredLibrary,
+      audioEngine: {
+        ...(roomConfig.audioEngine ?? {}),
+        soundSources: filteredEngine
+      }
+    },
+    removed
+  }
+}
+
+/**
+ * Filter a room configuration so that only sounds present in `availableIds`
+ * remain. This is used when hydrating rooms to drop deleted or missing uploads.
+ *
+ * @param {Object} roomConfig
+ * @param {Set<string>} availableIds
+ * @returns {{ roomData: Object, removed: number }}
+ */
+export function filterRoomByAvailableSounds(roomConfig, availableIds) {
+  if (!roomConfig) {
+    return { roomData: roomConfig, removed: 0 }
+  }
+
+  // When no ids are available we remove all sources to prevent stale nodes
+  const allowAll = availableIds && availableIds.size > 0
+  const predicate = allowAll
+    ? (src) => availableIds.has(src.libraryId)
+    : () => false
+
+  const currentLibrary = roomConfig.soundLibrarySources ?? []
+  const currentEngineSources = roomConfig.audioEngine?.soundSources ?? []
+
+  const filteredLibrary = currentLibrary.filter(predicate)
+  const filteredEngine = currentEngineSources.filter(predicate)
+
+  const removed = (currentLibrary.length - filteredLibrary.length) + (currentEngineSources.length - filteredEngine.length)
+
+  return {
+    roomData: {
+      ...roomConfig,
+      soundLibrarySources: filteredLibrary,
+      audioEngine: {
+        ...(roomConfig.audioEngine ?? {}),
+        soundSources: filteredEngine
+      }
+    },
+    removed
+  }
+}
+


### PR DESCRIPTION
## Summary
- add utilities to verify/purge sounds and strip deleted uploads from saved rooms and local state
- harden room loading to drop missing or inaccessible uploads, warn users, and avoid hydrating invalid nodes
- purge caches and saved room references when deleting user sounds and guard undo/redo actions for removed files

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b25ba88d8832fab838532848e7571)