### PR TITLE
Refactor theme management and sync Konva theme updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,29 @@
     }
   }
   </script>
+
+  <script>
+    (function applyPersistedTheme() {
+      if (typeof document === 'undefined') return
+      try {
+        const root = document.documentElement
+        const storedState = localStorage.getItem('theme:state')
+        const parsed = storedState ? JSON.parse(storedState) : null
+        const fallback = localStorage.getItem('theme') || 'dark'
+        const theme = parsed?.theme || fallback || 'dark'
+        const cssVars = parsed?.cssVars || {}
+
+        root.dataset.theme = theme
+        root.classList.toggle('dark', theme === 'dark')
+
+        Object.entries(cssVars).forEach(([key, value]) => {
+          root.style.setProperty(key, value)
+        })
+      } catch (error) {
+        console.warn('Unable to pre-apply persisted theme', error)
+      }
+    })()
+  </script>
 </head>
 
   <body>

--- a/src/components/Settings/ThemeSelector.vue
+++ b/src/components/Settings/ThemeSelector.vue
@@ -141,7 +141,7 @@ const BUILTIN_THEMES = [
 const availableThemes = ref([...BUILTIN_THEMES])
 const activeBaseTheme = computed({
   get: () => themeStore.activeTheme,
-  set: (value) => themeStore.setTheme(value, { clearOverrides: true })
+  set: (value) => themeStore.setTheme(value, { clearOverrides: false })
 })
 const selectedTheme = ref(BUILTIN_THEMES.find((theme) => theme.name === activeBaseTheme.value) || BUILTIN_THEMES[0])
 const savedThemeId = ref(null)
@@ -258,6 +258,8 @@ const selectTheme = (theme) => {
       clearOverrides: true,
       overrides: theme.css_vars || {},
     })
+    console.log("theme.css_vars for selection:", theme.css_vars)
+
   }
 }
 
@@ -270,6 +272,11 @@ const resetPreview = () => {
     selectTheme(base)
   }
 }
+
+watch(() => themeStore.activeTheme, (val) => {
+  console.log("[ThemeSelector] activeTheme changed ->", val)
+})
+
 
 const saveSelection = async () => {
   if (!selectedTheme.value) return
@@ -340,31 +347,35 @@ const loadThemes = async () => {
 }
 
 const loadUserTheme = async () => {
+  // User not logged in → don't touch the store, just sync UI
   if (!isAuthenticated.value) {
     savedThemeId.value = null
-    const base = BUILTIN_THEMES.find((entry) => entry.name === activeBaseTheme.value) || BUILTIN_THEMES[0]
-    themeStore.setTheme(base.name, { clearOverrides: true })
-    selectTheme(base)
+    const base = BUILTIN_THEMES.find((entry) => entry.name === themeStore.activeTheme) || BUILTIN_THEMES[0]
+    selectedTheme.value = base
     return
   }
+
   try {
     errorMessage.value = ''
     const theme = await fetchUserTheme()
     savedThemeId.value = theme?.id || null
 
     if (theme) {
+      // User has a saved DB theme → apply it
       const normalized = upsertTheme({ ...theme, type: 'database' })
       hydratePreviews()
       selectTheme(normalized)
     } else {
-      const base = BUILTIN_THEMES.find((entry) => entry.name === activeBaseTheme.value) || BUILTIN_THEMES[0]
-      themeStore.setTheme(base.name, { clearOverrides: true })
-      selectTheme(base)
+      // No saved theme in DB → keep whatever is already active in the store
+      const base = BUILTIN_THEMES.find((entry) => entry.name === themeStore.activeTheme) || BUILTIN_THEMES[0]
+      selectedTheme.value = base
+      // IMPORTANT: do NOT call themeStore.setTheme() here
     }
   } catch (error) {
     errorMessage.value = error.message || 'Unable to load saved theme.'
   }
 }
+
 
 const syncActiveTheme = () => {
   if (selectedTheme.value?.type === 'builtin') {

--- a/src/components/Settings/ThemeSelector.vue
+++ b/src/components/Settings/ThemeSelector.vue
@@ -106,13 +106,15 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import { computed, onMounted, reactive, ref, watch } from 'vue'
 import BaseButton from '@/components/ui/input/BaseButton.vue'
-import { applyThemeVars, clearThemeVars, getTheme, setTheme, previewThemeBase, restorePersistentTheme } from '@/utils/theme'
+import { previewThemeBase } from '@/utils/theme'
 import { fetchAllThemes, fetchUserTheme, saveUserTheme } from '@/utils/themeApi'
 import { compareTiers, formatTierLabel } from '@/utils/tierUtils'
 import { useAuth } from '@/composables/useAuth'
+import { useThemeStore } from '@/stores/useThemeStore'
 
+const themeStore = useThemeStore()
 const { tier, isAuthenticated, user } = useAuth()
 
 const BUILTIN_THEMES = [
@@ -137,7 +139,10 @@ const BUILTIN_THEMES = [
 ]
 
 const availableThemes = ref([...BUILTIN_THEMES])
-const activeBaseTheme = ref(getTheme())
+const activeBaseTheme = computed({
+  get: () => themeStore.activeTheme,
+  set: (value) => themeStore.setTheme(value, { clearOverrides: true })
+})
 const selectedTheme = ref(BUILTIN_THEMES.find((theme) => theme.name === activeBaseTheme.value) || BUILTIN_THEMES[0])
 const savedThemeId = ref(null)
 const saving = ref(false)
@@ -245,11 +250,14 @@ const selectTheme = (theme) => {
 
   if (theme.type === 'builtin') {
     activeBaseTheme.value = previewThemeBase(theme.name)
-    clearThemeVars()
+    themeStore.setTheme(activeBaseTheme.value, { clearOverrides: true })
 
   } else {
-    activeBaseTheme.value = setTheme(theme.theme_base || 'dark', { clearOverrides: true })
-    applyThemeVars(theme.css_vars || {})
+    const base = theme.theme_base || 'dark'
+    activeBaseTheme.value = themeStore.setTheme(base, {
+      clearOverrides: true,
+      overrides: theme.css_vars || {},
+    })
   }
 }
 
@@ -334,8 +342,8 @@ const loadThemes = async () => {
 const loadUserTheme = async () => {
   if (!isAuthenticated.value) {
     savedThemeId.value = null
-    clearThemeVars()
     const base = BUILTIN_THEMES.find((entry) => entry.name === activeBaseTheme.value) || BUILTIN_THEMES[0]
+    themeStore.setTheme(base.name, { clearOverrides: true })
     selectTheme(base)
     return
   }
@@ -349,8 +357,8 @@ const loadUserTheme = async () => {
       hydratePreviews()
       selectTheme(normalized)
     } else {
-      clearThemeVars()
       const base = BUILTIN_THEMES.find((entry) => entry.name === activeBaseTheme.value) || BUILTIN_THEMES[0]
+      themeStore.setTheme(base.name, { clearOverrides: true })
       selectTheme(base)
     }
   } catch (error) {
@@ -359,28 +367,16 @@ const loadUserTheme = async () => {
 }
 
 const syncActiveTheme = () => {
-  activeBaseTheme.value = getTheme()
   if (selectedTheme.value?.type === 'builtin') {
-    selectedTheme.value = BUILTIN_THEMES.find((theme) => theme.name === activeBaseTheme.value) || selectedTheme.value
+    selectedTheme.value = BUILTIN_THEMES.find((theme) => theme.name === themeStore.activeTheme) || selectedTheme.value
   }
   hydratePreviews()
-}
-
-let observer
-const handleStorage = (event) => {
-  if (event.key === 'theme') {
-    syncActiveTheme()
-  }
 }
 
 onMounted(async () => {
   syncActiveTheme()
   await loadThemes()
   await loadUserTheme()
-
-  observer = new MutationObserver(syncActiveTheme)
-  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] })
-  window.addEventListener('storage', handleStorage)
 })
 
 watch(
@@ -391,11 +387,12 @@ watch(
   }
 )
 
+watch(
+  () => themeStore.signature,
+  () => {
+    syncActiveTheme()
+  }
+)
 
-onBeforeUnmount(() => {
-  observer?.disconnect()
-  window.removeEventListener('storage', handleStorage)
-  restorePersistentTheme()
-  clearThemeVars()
-})
+
 </script>

--- a/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
@@ -98,23 +98,29 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { computed, ref } from 'vue';
 import { useListenerStore } from '@/stores/useListenerStore';
 import { useActionManagerStore } from '@/stores/useActionManagerStore';
 import { useRoomStore } from '@/stores/useRoomStore';
 import { storeToRefs } from 'pinia';
+import { useKonvaThemeRedraw } from '@/composables/useKonvaTheme';
+import { useThemeStore } from '@/stores/useThemeStore';
 
 
 const { listener } = storeToRefs(useListenerStore())
 const { actionManager } = storeToRefs(useActionManagerStore())
 const { room } = storeToRefs(useRoomStore())
+const themeStore = useThemeStore()
 
-const isDarkMode = ref(document.documentElement.dataset.theme !== 'light')
-let themeObserver = null
+const isDarkMode = computed(() => themeStore.activeTheme !== 'light')
+const { themeVersion } = useKonvaThemeRedraw(() => {
+  const node = listenerGroup.value?.getNode()
+  node?.clearCache?.()
+  node?.getLayer?.()?.batchDraw()
+})
+
 const rootStyles = computed(() => {
-  // re-evaluate when theme changes
-  // eslint-disable-next-line no-unused-expressions
-  isDarkMode.value
+  themeVersion.value
   return typeof window !== 'undefined' ? getComputedStyle(document.documentElement) : null
 })
 const getVar = (name, fallback) => rootStyles.value?.getPropertyValue(name)?.trim() || fallback
@@ -122,18 +128,6 @@ const rgbaFromVar = (name, alpha, fallback) => {
   const rgbValue = rootStyles.value?.getPropertyValue(name)?.trim()
   return rgbValue ? `rgba(${rgbValue}, ${alpha})` : fallback
 }
-
-const syncTheme = () => {
-  isDarkMode.value = document.documentElement.dataset.theme !== 'light'
-}
-
-onMounted(() => {
-  syncTheme()
-  themeObserver = new MutationObserver(syncTheme)
-  themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme', 'class'] })
-})
-
-onBeforeUnmount(() => themeObserver?.disconnect())
 
 const anchorGlowFill = computed(() => isDarkMode.value
   ? rgbaFromVar('--color-accent-strong-rgb', 0.08, 'rgba(var(--color-accent-strong-rgb), 0.08)')

--- a/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ListenerNode.vue
@@ -98,7 +98,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from 'vue';
+import { computed, ref, onBeforeUnmount } from 'vue';
 import { useListenerStore } from '@/stores/useListenerStore';
 import { useActionManagerStore } from '@/stores/useActionManagerStore';
 import { useRoomStore } from '@/stores/useRoomStore';

--- a/src/components/SoundRoom/MainCanvasStage/ScheduledPlayRing.vue
+++ b/src/components/SoundRoom/MainCanvasStage/ScheduledPlayRing.vue
@@ -26,6 +26,7 @@
 
 <script setup>
 import { ref, watch, onMounted, onUnmounted, computed } from 'vue'
+import { useThemeStore } from '@/stores/useThemeStore'
 
 const props = defineProps({
   playing: Boolean,
@@ -55,8 +56,10 @@ const props = defineProps({
   },
 })
 
+const themeStore = useThemeStore()
 // compute default color AFTER setup
 const fallbackColor = computed(() => {
+  themeStore.signature // ensure recompute when theme changes
   if (typeof window === 'undefined') return 'rgb(var(--color-accent-strong-rgb))'
   const styles = getComputedStyle(document.documentElement)
   return (

--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -1,5 +1,6 @@
 <template>
   <v-group
+    ref="sourceGroup"
     :x="source.instance.state.x"
     :y="source.instance.state.y"
     @dragmove="onSourceDragMove"
@@ -115,11 +116,13 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useRoomStore } from '@/stores/useRoomStore'
 import { useActionManagerStore } from '@/stores/useActionManagerStore'
 import { storeToRefs } from 'pinia'
 import ScheduledPlayRing from '@/components/SoundRoom/MainCanvasStage/ScheduledPlayRing.vue'
+import { useKonvaThemeRedraw } from '@/composables/useKonvaTheme'
+import { useThemeStore } from '@/stores/useThemeStore'
 
 // Props and emits
 const props = defineProps({
@@ -131,12 +134,17 @@ const props = defineProps({
 const { room } = storeToRefs(useRoomStore())
 const { actionManager } = storeToRefs(useActionManagerStore())
 const emit = defineEmits(['select'])
+const themeStore = useThemeStore()
 
-const isDarkMode = ref(document.documentElement.dataset.theme !== 'light')
-let themeObserver = null
+const isDarkMode = computed(() => themeStore.activeTheme !== 'light')
+const sourceGroup = ref(null)
+const { themeVersion } = useKonvaThemeRedraw(() => {
+  const node = sourceGroup.value?.getNode()
+  node?.clearCache?.()
+  node?.getLayer?.()?.batchDraw()
+})
 const rootStyles = computed(() => {
-  // eslint-disable-next-line no-unused-expressions
-  isDarkMode.value
+  themeVersion.value
   return typeof window !== 'undefined' ? getComputedStyle(document.documentElement) : null
 })
 const getVar = (name, fallback) => rootStyles.value?.getPropertyValue(name)?.trim() || fallback
@@ -144,18 +152,6 @@ const rgbaFromVar = (name, alpha, fallback) => {
   const rgbValue = rootStyles.value?.getPropertyValue(name)?.trim()
   return rgbValue ? `rgba(${rgbValue}, ${alpha})` : fallback
 }
-
-const syncTheme = () => {
-  isDarkMode.value = document.documentElement.dataset.theme !== 'light'
-}
-
-onMounted(() => {
-  syncTheme()
-  themeObserver = new MutationObserver(syncTheme)
-  themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme', 'class'] })
-})
-
-onBeforeUnmount(() => themeObserver?.disconnect())
 
 const sched = computed(() => props.source.instance.state.schedule)
 const isScheduled = computed(() => sched.value?.enabled)

--- a/src/composables/useKonvaTheme.js
+++ b/src/composables/useKonvaTheme.js
@@ -1,0 +1,19 @@
+import { computed, watch } from 'vue'
+import { useThemeStore } from '@/stores/useThemeStore'
+
+export function useKonvaThemeRedraw(redrawFn) {
+  const themeStore = useThemeStore()
+  const themeVersion = computed(() => themeStore.signature)
+
+  watch(
+    () => themeVersion.value,
+    () => {
+      if (typeof redrawFn === 'function') {
+        redrawFn()
+      }
+    },
+    { flush: 'post' }
+  )
+
+  return { themeStore, themeVersion }
+}

--- a/src/composables/useThemeBootstrap.js
+++ b/src/composables/useThemeBootstrap.js
@@ -1,28 +1,13 @@
 import { onMounted, watch } from 'vue'
-import { fetchUserTheme } from '@/utils/themeApi'
-import { applyThemeVars, clearThemeVars, setTheme } from '@/utils/theme'
 import { useAuth } from '@/composables/useAuth'
+import { useThemeStore } from '@/stores/useThemeStore'
 
 export function useThemeBootstrap() {
   const { user } = useAuth()
+  const themeStore = useThemeStore()
 
   const loadUserTheme = async () => {
-    try {
-      if (!user.value) {
-        clearThemeVars()
-        return
-      }
-
-      const theme = await fetchUserTheme()
-      if (theme?.css_vars) {
-        setTheme(theme.theme_base || 'dark', { clearOverrides: true })
-        applyThemeVars(theme.css_vars)
-      } else {
-        clearThemeVars()
-      }
-    } catch (error) {
-      console.error('Failed to load user theme', error)
-    }
+    await themeStore.loadUserTheme()
   }
 
   onMounted(() => {

--- a/src/main.js
+++ b/src/main.js
@@ -1,33 +1,31 @@
 import { createApp } from 'vue'
 import '@/style.css'
-import { initTheme } from '@/utils/theme.js'
 import App from '@/App.vue'
-import VueKonva from 'vue-konva';
+import VueKonva from 'vue-konva'
 import PortalVue from 'portal-vue'
-import { createPinia } from 'pinia';
+import { createPinia } from 'pinia'
 import router from '@/utils/router.js'
 import '@/composables/useAuth.js' // Ensure auth is initialized before app mounts
-import * as Sentry from "@sentry/vue";
-import '@globalhive/vuejs-tour/dist/style.css';
-initTheme()
+import * as Sentry from '@sentry/vue'
+import '@globalhive/vuejs-tour/dist/style.css'
+import { useThemeStore } from '@/stores/useThemeStore'
 
-const app = createApp(App);
+const app = createApp(App)
+const pinia = createPinia()
+app.use(pinia)
+
+const themeStore = useThemeStore(pinia)
+themeStore.hydrateFromStorage()
+themeStore.watchAuthTheme()
 
 Sentry.init({
   app,
-  dsn: "https://b56e70467391993e18ece8ec50872188@o4510087125008384.ingest.us.sentry.io/4510087127629824",
-
-  // Adds request headers and IP for users, for more info visit:
-  // https://docs.sentry.io/platforms/javascript/guides/vue/configuration/options/#sendDefaultPii
-
-  integrations: [
-  ],
-});
-
+  dsn: 'https://b56e70467391993e18ece8ec50872188@o4510087125008384.ingest.us.sentry.io/4510087127629824',
+  integrations: [],
+})
 
 app
-.use(VueKonva)
-.use(PortalVue)
-.use(router)
-.use(createPinia())
-.mount('#app')
+  .use(VueKonva)
+  .use(PortalVue)
+  .use(router)
+  .mount('#app')

--- a/src/stores/useThemeStore.js
+++ b/src/stores/useThemeStore.js
@@ -1,0 +1,121 @@
+import { computed, ref, watch } from 'vue'
+import { defineStore } from 'pinia'
+import {
+  applyTheme,
+  applyThemeVars,
+  applyThemeVarsFromRemote,
+  readPersistedTheme,
+  resolveInitialTheme,
+} from '@/utils/theme'
+import { fetchUserTheme } from '@/utils/themeApi'
+import { useAuth } from '@/composables/useAuth'
+
+export const useThemeStore = defineStore('theme', () => {
+  const initial = resolveInitialTheme()
+  const activeTheme = ref(initial.theme)
+  const cssVars = ref(readPersistedTheme().cssVars || {})
+  const version = ref(0)
+  const loadingUserTheme = ref(false)
+  const initialized = ref(false)
+
+  const signature = computed(() => `${activeTheme.value}:${JSON.stringify(cssVars.value || {})}`)
+
+  function bumpVersion() {
+    version.value += 1
+  }
+
+  function hydrateFromStorage() {
+    const { theme, cssVars: persistedCssVars } = resolveInitialTheme()
+    activeTheme.value = applyTheme(theme, { persist: false, cssVars: persistedCssVars })
+    cssVars.value = persistedCssVars || {}
+    initialized.value = true
+    bumpVersion()
+  }
+
+  function persistState() {
+    if (typeof localStorage === 'undefined') return
+    try {
+      localStorage.setItem('theme:state', JSON.stringify({ theme: activeTheme.value, cssVars: cssVars.value || {} }))
+      localStorage.setItem('theme', activeTheme.value)
+    } catch (error) {
+      console.warn('Unable to persist theme state', error)
+    }
+  }
+
+  function setTheme(theme, { persist = true, clearOverrides = false, overrides } = {}) {
+    const nextOverrides = overrides ?? (clearOverrides ? {} : cssVars.value)
+    activeTheme.value = applyTheme(theme, {
+      persist,
+      clearOverrides,
+      cssVars: nextOverrides,
+    })
+    cssVars.value = nextOverrides || {}
+    if (persist) persistState()
+    bumpVersion()
+    return activeTheme.value
+  }
+
+  function applyOverrides(vars = {}, { persist = true } = {}) {
+    cssVars.value = vars || {}
+    applyThemeVars(cssVars.value)
+    if (persist) persistState()
+    bumpVersion()
+  }
+
+  function resetToBase(theme) {
+    activeTheme.value = applyTheme(theme || activeTheme.value, { persist: true, clearOverrides: true })
+    cssVars.value = {}
+    persistState()
+    bumpVersion()
+  }
+
+  async function loadUserTheme() {
+    const { user } = useAuth()
+    if (!user.value) {
+      resetToBase(activeTheme.value)
+      return
+    }
+    loadingUserTheme.value = true
+    try {
+      const theme = await fetchUserTheme()
+      if (theme?.css_vars) {
+        activeTheme.value = applyThemeVarsFromRemote(theme.theme_base || activeTheme.value, theme.css_vars)
+        cssVars.value = theme.css_vars
+        persistState()
+      } else {
+        resetToBase(activeTheme.value)
+      }
+      bumpVersion()
+    } catch (error) {
+      console.error('Failed to load user theme', error)
+    } finally {
+      loadingUserTheme.value = false
+    }
+  }
+
+  function watchAuthTheme() {
+    const { user } = useAuth()
+    watch(
+      () => user.value?.id,
+      () => {
+        void loadUserTheme()
+      },
+      { immediate: true }
+    )
+  }
+
+  return {
+    activeTheme,
+    cssVars,
+    version,
+    signature,
+    initialized,
+    loadingUserTheme,
+    hydrateFromStorage,
+    setTheme,
+    applyOverrides,
+    resetToBase,
+    loadUserTheme,
+    watchAuthTheme,
+  }
+})

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,74 +1,70 @@
 const THEME_KEY = 'theme'
-const DEFAULT_THEME = 'dark'
+const THEME_STATE_KEY = 'theme:state'
+export const DEFAULT_THEME = 'dark'
 
 export const SUPPORTED_THEMES = ['dark', 'light']
 
 const tieredOverrides = {
-  active: {}
+  active: {},
 }
 
-function resolveInitialTheme() {
-  if (typeof window === 'undefined') return DEFAULT_THEME
+function normalizeTheme(theme) {
+  return SUPPORTED_THEMES.includes(theme) ? theme : DEFAULT_THEME
+}
 
-  const stored = localStorage.getItem(THEME_KEY)
-  if (SUPPORTED_THEMES.includes(stored)) return stored
+function persistThemeState(theme, cssVars = {}) {
+  if (typeof localStorage === 'undefined') return
+
+  try {
+    localStorage.setItem(
+      THEME_STATE_KEY,
+      JSON.stringify({
+        theme: normalizeTheme(theme),
+        cssVars: cssVars || {},
+      })
+    )
+    localStorage.setItem(THEME_KEY, normalizeTheme(theme))
+  } catch (error) {
+    console.warn('Unable to persist theme', error)
+  }
+}
+
+export function readPersistedTheme() {
+  if (typeof localStorage === 'undefined') return { theme: DEFAULT_THEME, cssVars: {} }
+
+  try {
+    const storedState = localStorage.getItem(THEME_STATE_KEY)
+    if (storedState) {
+      const parsed = JSON.parse(storedState)
+      return {
+        theme: normalizeTheme(parsed.theme) || DEFAULT_THEME,
+        cssVars: parsed.cssVars || {},
+      }
+    }
+
+    const legacy = localStorage.getItem(THEME_KEY)
+    if (legacy) {
+      return { theme: normalizeTheme(legacy), cssVars: {} }
+    }
+  } catch (error) {
+    console.warn('Unable to read persisted theme', error)
+  }
+
+  return { theme: DEFAULT_THEME, cssVars: {} }
+}
+
+export function resolveInitialTheme() {
+  if (typeof window === 'undefined') return { theme: DEFAULT_THEME, cssVars: {} }
+
+  const persisted = readPersistedTheme()
+  if (persisted?.theme) return persisted
 
   const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches
   if (typeof prefersDark === 'boolean') {
-    return prefersDark ? 'dark' : 'light'
+    return { theme: prefersDark ? 'dark' : 'light', cssVars: {} }
   }
 
-  return DEFAULT_THEME
-}
-
-function applyTheme(theme, { persist = true, clearOverrides = false } = {}) {
-  const normalized = SUPPORTED_THEMES.includes(theme) ? theme : DEFAULT_THEME
-  const root = document.documentElement
-  root.dataset.theme = normalized
-  root.classList.toggle('dark', normalized === 'dark')
-  if (clearOverrides) clearThemeVars()
-  if (persist && typeof localStorage !== 'undefined') {
-    localStorage.setItem(THEME_KEY, normalized)
-  }
-  return normalized
-}
-
-export function initTheme() {
-  const initial = resolveInitialTheme()
-  return applyTheme(initial)
-}
-
-export function previewThemeBase(theme) {
-  const normalized = SUPPORTED_THEMES.includes(theme) ? theme : DEFAULT_THEME
-
-  const root = document.documentElement
-  // temporary only — do NOT persist, do NOT clear overrides unless needed
-  root.dataset.theme = normalized
-  root.classList.toggle('dark', normalized === 'dark')
-
-  return normalized
-}
-export function restorePersistentTheme() {
-  const stored = localStorage.getItem(THEME_KEY)
-  const normalized = SUPPORTED_THEMES.includes(stored) ? stored : DEFAULT_THEME
-  applyTheme(normalized, { persist: false })
-}
-
-export function toggleTheme() {
-  const next = document.documentElement.dataset.theme === 'light' ? 'dark' : 'light'
-  return applyTheme(next)
-}
-
-export function setTheme(theme, options = {}) {
-  return applyTheme(theme, options)
-}
-
-export function getTheme() {
-  return document.documentElement.dataset.theme || DEFAULT_THEME
-}
-
-export function getAvailableThemes() {
-  return [...SUPPORTED_THEMES]
+  return { theme: DEFAULT_THEME, cssVars: {} }
 }
 
 export function applyThemeVars(vars = {}) {
@@ -91,6 +87,68 @@ export function clearThemeVars() {
   tieredOverrides.active = {}
 }
 
+export function applyTheme(theme, { persist = true, clearOverrides = false, cssVars } = {}) {
+  const normalized = normalizeTheme(theme)
+  const root = document.documentElement
+  root.dataset.theme = normalized
+  root.classList.toggle('dark', normalized === 'dark')
+
+  if (clearOverrides) {
+    clearThemeVars()
+  }
+
+  if (cssVars) {
+    applyThemeVars(cssVars)
+  }
+
+  if (persist && typeof localStorage !== 'undefined') {
+    persistThemeState(normalized, cssVars ?? tieredOverrides.active)
+  }
+
+  return normalized
+}
+
+export function setTheme(theme, options = {}) {
+  return applyTheme(theme, options)
+}
+
+export function getTheme() {
+  return document.documentElement.dataset.theme || DEFAULT_THEME
+}
+
+export function toggleTheme() {
+  const next = document.documentElement.dataset.theme === 'light' ? 'dark' : 'light'
+  return applyTheme(next)
+}
+
 export function mergeCssVars(baseVars = {}, overrideVars = {}) {
   return { ...baseVars, ...overrideVars }
+}
+
+export function restorePersistentTheme() {
+  const persisted = readPersistedTheme()
+  applyTheme(persisted.theme, { persist: false })
+  applyThemeVars(persisted.cssVars)
+}
+
+export function initThemeFromStorage() {
+  const { theme, cssVars } = resolveInitialTheme()
+  applyTheme(theme, { persist: false })
+  applyThemeVars(cssVars)
+  return theme
+}
+
+export function applyThemeVarsFromRemote(theme, cssVars = {}, { persist = true } = {}) {
+  const normalized = applyTheme(theme, { persist, clearOverrides: true })
+  applyThemeVars(cssVars)
+  if (persist) persistThemeState(normalized, cssVars)
+  return normalized
+}
+
+export function getAvailableThemes() {
+  return [...SUPPORTED_THEMES]
+}
+
+export function previewThemeBase(theme) {
+  return normalizeTheme(theme)
 }


### PR DESCRIPTION
## Summary
- add a Pinia-based theme store that hydrates from storage, persists overrides, and applies CSS variables immediately
- update theme bootstrap and selector flows to rely on the shared store and remove stale DOM observers
- add theme-change redraw hooks for Konva nodes and reactive fallback colors so canvas visuals update with each theme change

## Testing
- npm run build *(fails: @sentry/vite-plugin missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b3c19dae0832fb9a8599ca7160111)