### PR TITLE
Respect auto resume playback preference

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -3,11 +3,23 @@
     <div class="max-w-5xl mx-auto px-6 py-10 space-y-10">
       <section class="space-y-4">
         <div class="flex items-center justify-between gap-6 flex-wrap">
-          <div class="space-y-2">
-            <h1 class="text-3xl font-semibold tracking-tight">Settings</h1>
-            <p class="text-sm text-text-muted max-w-xl">
-              Update how you appear in SoundRoom, adjust playback preferences, and keep your account secure.
-            </p>
+          <div class="flex items-start gap-4 flex-wrap">
+            <RouterLink :to="{ name: 'app' }">
+              <BaseButton
+                type="button"
+                variant="naked"
+                class="flex items-center gap-2 text-text-muted hover:text-text-primary"
+              >
+                <span aria-hidden="true">←</span>
+                <span>Back</span>
+              </BaseButton>
+            </RouterLink>
+            <div class="space-y-2">
+              <h1 class="text-3xl font-semibold tracking-tight">Settings</h1>
+              <p class="text-sm text-text-muted max-w-xl">
+                Update how you appear in SoundRoom, adjust playback preferences, and keep your account secure.
+              </p>
+            </div>
           </div>
           <div class="flex items-center gap-3 rounded-full border border-border-subtle px-4 py-2 bg-[color-mix(in_srgb,var(--color-bg-surface)_85%,transparent)]">
             <span class="text-xs uppercase tracking-wide text-text-muted">Plan</span>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -392,23 +392,56 @@ function applyPreferences(source) {
   })
 }
 
-function loadPreferences() {
+function loadPreferencesFromLocal() {
   try {
     const stored = localStorage.getItem(LOCAL_PREF_KEY)
     if (!stored) {
       preferenceInitial.value = { ...preferenceDefaults }
       applyPreferences(preferenceDefaults)
-      return
+      return preferenceDefaults
     }
 
     const parsed = JSON.parse(stored)
     const merged = { ...preferenceDefaults, ...parsed }
     preferenceInitial.value = { ...merged }
     applyPreferences(merged)
+    return merged
   } catch (error) {
     console.warn('Failed to parse stored preferences', error)
     preferenceInitial.value = { ...preferenceDefaults }
     applyPreferences(preferenceDefaults)
+    return preferenceDefaults
+  }
+}
+
+async function loadPreferences() {
+  const localPreferences = loadPreferencesFromLocal()
+
+  if (!user.value?.id) {
+    return
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('users')
+      .select('settings')
+      .eq('id', user.value.id)
+      .maybeSingle()
+
+    if (error) throw error
+
+    const remotePreferences = {
+      ...preferenceDefaults,
+      ...(data?.settings?.preferences ?? {}),
+    }
+
+    preferenceInitial.value = { ...remotePreferences }
+    applyPreferences(remotePreferences)
+    localStorage.setItem(LOCAL_PREF_KEY, JSON.stringify(remotePreferences))
+  } catch (error) {
+    console.warn('Failed to load preferences from Supabase, keeping local copy', error)
+    preferenceInitial.value = { ...localPreferences }
+    applyPreferences(localPreferences)
   }
 }
 

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -115,6 +115,7 @@ import { useAuth } from '@/composables/useAuth'
 import { storeToRefs } from 'pinia'
 import { useRoute } from 'vue-router'
 import { resetRoomState } from "@/utils/resetRoomState";
+import { supabase } from '@/utils/supabase'
 
 // State
 const selectedIndex = ref(null)
@@ -176,7 +177,17 @@ setMaxLibSources(MAX_LIB_SOURCES)
 
 const showWelcomeOverlay = ref(false)
 const showInitOverlay = ref(false)
-const { isAuthenticated } = useAuth()
+const { user, isAuthenticated } = useAuth()
+
+const preferenceDefaults = Object.freeze({
+  autoResumePlayback: false,
+  showInterfaceTips: true
+})
+
+const LOCAL_PREF_KEY = 'soundroom.userPreferences'
+
+const userPreferences = ref({ ...preferenceDefaults })
+const preferencesLoaded = ref(false)
 
 const showAudioResumeOverlay = ref(false)
 
@@ -187,6 +198,52 @@ function resumeAudio() {
   } catch (err) {
     console.warn("Failed to resume audio context:", err)
   }
+}
+
+function applyPreferences(source = {}) {
+  Object.entries(preferenceDefaults).forEach(([key, fallback]) => {
+    userPreferences.value[key] = source[key] ?? fallback
+  })
+}
+
+function loadCachedPreferences() {
+  try {
+    const stored = localStorage.getItem(LOCAL_PREF_KEY)
+    if (!stored) return false
+
+    const parsed = JSON.parse(stored)
+    applyPreferences(parsed)
+    return true
+  } catch (error) {
+    console.warn('Failed to parse cached preferences', error)
+    return false
+  }
+}
+
+async function hydrateUserPreferences() {
+  if (preferencesLoaded.value) return userPreferences.value
+
+  if (!loadCachedPreferences() && user.value?.id) {
+    try {
+      const { data, error } = await supabase
+        .from('users')
+        .select('settings')
+        .eq('id', user.value.id)
+        .maybeSingle()
+
+      if (error) throw error
+
+      const preferences = data?.settings?.preferences ?? {}
+      applyPreferences(preferences)
+      localStorage.setItem(LOCAL_PREF_KEY, JSON.stringify(userPreferences.value))
+    } catch (err) {
+      console.warn('Failed to load preferences from Supabase, using defaults', err)
+      applyPreferences(preferenceDefaults)
+    }
+  }
+
+  preferencesLoaded.value = true
+  return userPreferences.value
 }
 
 onBeforeMount(async () => {
@@ -224,21 +281,26 @@ function waitForWelcome() {
 
 onMounted(async() => {
   watch(
-  () => route.path,
-  (newPath) => {
-    // If we are leaving *any* /app route (including children)
-    if (!newPath.startsWith('/app')) {
-      resetRoomState()
-      audioEngine.value?.dispose()
-      cacheStore.audioCacheManager.clearMemoryCache()
-    }else if (newPath === '/app' && isAuthenticated.value) {
-      loadMostRecentRoom()
-      if (audioEngine.value?.getAudioContext().state === 'suspended') {
-        showAudioResumeOverlay.value = true
+    () => route.path,
+    async (newPath) => {
+      // If we are leaving *any* /app route (including children)
+      if (!newPath.startsWith('/app')) {
+        resetRoomState()
+        audioEngine.value?.dispose()
+        cacheStore.audioCacheManager.clearMemoryCache()
+      } else if (newPath === '/app' && isAuthenticated.value) {
+        const preferences = await hydrateUserPreferences()
+        if (preferences.autoResumePlayback) {
+          loadMostRecentRoom()
+        }
+
+        if (audioEngine.value?.getAudioContext().state === 'suspended') {
+          showAudioResumeOverlay.value = true
+        }
       }
-    }
-      }, { immediate: true }
-    )
+    },
+    { immediate: true }
+  )
   
    // If welcome overlay exists, wait for it
       if (showWelcomeOverlay.value && !welcomeDone.value) {

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -290,9 +290,9 @@ onMounted(async() => {
         cacheStore.audioCacheManager.clearMemoryCache()
       } else if (newPath === '/app' && isAuthenticated.value) {
         const preferences = await hydrateUserPreferences()
-        if (preferences.autoResumePlayback) {
+        if (!preferences.autoResumePlayback) return;
           loadMostRecentRoom()
-        }
+        
 
         if (audioEngine.value?.getAudioContext().state === 'suspended') {
           showAudioResumeOverlay.value = true


### PR DESCRIPTION
## Summary
- cache user preferences locally when entering SoundRoom to avoid repeated database reads
- hydrate preferences from Supabase when needed and fall back to defaults if unavailable
- only auto-load the most recent room when the autoResumePlayback preference is enabled

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d3373ea88832f95f14022ca6ac45d)