### PR TITLE
Fix audio resume overlay when playback auto starts

### DIFF
--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -126,7 +126,7 @@ const listenerStore = useListenerStore()
 const engineStore = useAudioEngineStore()
 const cacheStore = useAudioCacheStore()
 const { listener } = storeToRefs(listenerStore)
-const { audioEngine } = storeToRefs(engineStore)
+const { audioEngine, isPlaying } = storeToRefs(engineStore)
 
 const MAX_LIB_SOURCES = 20
 const MAX_CANVAS_SOURCES = 30
@@ -190,6 +190,22 @@ const userPreferences = ref({ ...preferenceDefaults })
 const preferencesLoaded = ref(false)
 
 const showAudioResumeOverlay = ref(false)
+
+let removeAudioContextStateListener
+
+function attachAudioContextStateListener() {
+  const context = audioEngine.value?.getAudioContext()
+  if (!context) return
+
+  const handleStateChange = () => {
+    if (context.state === 'running') {
+      showAudioResumeOverlay.value = false
+    }
+  }
+
+  context.addEventListener('statechange', handleStateChange)
+  removeAudioContextStateListener = () => context.removeEventListener('statechange', handleStateChange)
+}
 
 function resumeAudio() {
   try {
@@ -266,6 +282,7 @@ onBeforeMount(async () => {
   }
   
   engineStore.setupAudioContext()
+  attachAudioContextStateListener()
   engineStore.loadIR('cathedral', '/impulses/1st_baptist_nashville_far_wide.wav') // Load the default impulse response
   roomStore.setExistingRoomNames() // Initialize with empty names
   roomStore.room.name.value = 'Untitled Room' // Default room name
@@ -297,11 +314,13 @@ onMounted(async() => {
       } else if (newPath === '/app' && isAuthenticated.value) {
         const preferences = await hydrateUserPreferences({ forceLocal: true })
         if (!preferences.autoResumePlayback) return;
-        loadMostRecentRoom()
-        
+        await loadMostRecentRoom()
 
-        if (audioEngine.value?.getAudioContext().state === 'suspended') {
+        const audioContext = audioEngine.value?.getAudioContext()
+        if (audioContext?.state === 'suspended' && !isPlaying.value) {
           showAudioResumeOverlay.value = true
+        } else {
+          showAudioResumeOverlay.value = false
         }
       }
     },
@@ -346,6 +365,7 @@ onUnmounted(() => {
   resetRoomState()
   unregisterSoundRoomActions()
   audioEngine.value.dispose()
+  removeAudioContextStateListener?.()
   // Revoke object URLs to avoid memory leaks
   cacheStore.audioCacheManager.clearMemoryCache()
   // Uncomment to also wipe IndexedDB cache if long-term storage isn't desired

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -126,7 +126,7 @@ const listenerStore = useListenerStore()
 const engineStore = useAudioEngineStore()
 const cacheStore = useAudioCacheStore()
 const { listener } = storeToRefs(listenerStore)
-const { audioEngine, isPlaying } = storeToRefs(engineStore)
+const { audioEngine } = storeToRefs(engineStore)
 
 const MAX_LIB_SOURCES = 20
 const MAX_CANVAS_SOURCES = 30
@@ -317,11 +317,7 @@ onMounted(async() => {
         await loadMostRecentRoom()
 
         const audioContext = audioEngine.value?.getAudioContext()
-        if (audioContext?.state === 'suspended' && !isPlaying.value) {
-          showAudioResumeOverlay.value = true
-        } else {
-          showAudioResumeOverlay.value = false
-        }
+        showAudioResumeOverlay.value = audioContext?.state === 'suspended'
       }
     },
     { immediate: true }


### PR DESCRIPTION
## Summary
- attach an audio context state listener to clear the resume overlay once playback is running
- await loading the most recent room before deciding whether to show the resume prompt and skip it when audio is already active

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d39ea161c832f94d41d26c5b6839a)