### PR TITLE
Improve audio resume overlay logic

### DIFF
--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -189,7 +189,7 @@ const LOCAL_PREF_KEY = 'soundroom.userPreferences'
 const userPreferences = ref({ ...preferenceDefaults })
 const preferencesLoaded = ref(false)
 
-const showAudioResumeOverlay = ref(false)
+const showAudioResumeOverlay = ref(true)
 
 function resumeAudio() {
   try {
@@ -285,10 +285,19 @@ function waitForWelcome() {
   })
 }
 
+watch(showAudioResumeOverlay, (v) => {
+  console.log("AUDIO OVERLAY CHANGED TO:", v)
+}, { immediate: true }
+)
+
+
+
+
 onMounted(async() => {
   watch(
     () => route.path,
     async (newPath) => {
+
       // If we are leaving *any* /app route (including children)
       if (!newPath.startsWith('/app')) {
         resetRoomState()
@@ -308,8 +317,9 @@ onMounted(async() => {
             }
           }
         }
-
         showAudioResumeOverlay.value = audioEngine.value?.getAudioContext().state === 'suspended'
+       
+
       }
     },
     { immediate: true }

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -296,21 +296,20 @@ onMounted(async() => {
         cacheStore.audioCacheManager.clearMemoryCache()
       } else if (newPath === '/app' && isAuthenticated.value) {
         const preferences = await hydrateUserPreferences({ forceLocal: true })
-        if (!preferences.autoResumePlayback) return;
-        await loadMostRecentRoom()
-        
+        if (preferences.autoResumePlayback) {
+          await loadMostRecentRoom()
 
-        if (audioEngine.value?.getAudioContext().state === 'suspended') {
-          try {
-            await audioEngine.value.getAudioContext().resume()
-          } catch (error) {
-            console.warn('Failed to auto-resume audio context', error)
-          }
 
           if (audioEngine.value?.getAudioContext().state === 'suspended') {
-            showAudioResumeOverlay.value = true
+            try {
+              await audioEngine.value.getAudioContext().resume()
+            } catch (error) {
+              console.warn('Failed to auto-resume audio context', error)
+            }
           }
         }
+
+        showAudioResumeOverlay.value = audioEngine.value?.getAudioContext().state === 'suspended'
       }
     },
     { immediate: true }

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -301,7 +301,15 @@ onMounted(async() => {
         
 
         if (audioEngine.value?.getAudioContext().state === 'suspended') {
-          showAudioResumeOverlay.value = true
+          try {
+            await audioEngine.value.getAudioContext().resume()
+          } catch (error) {
+            console.warn('Failed to auto-resume audio context', error)
+          }
+
+          if (audioEngine.value?.getAudioContext().state === 'suspended') {
+            showAudioResumeOverlay.value = true
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
- attempt to auto-resume the audio context when loading the app
- only show the audio resume overlay if the context remains suspended

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d4e1843b0832fb0f16074e6117758)