### PR TITLE
Fix context menu lookup for sound source nodes

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -88,6 +88,7 @@ onMounted(() => {
   window.addEventListener('resize', updateCoords)
   const canvasStore = useCanvasStore()
   canvasStore.setStageDivRef(stageDivRef.value)
+  canvasStore.setContextMenuRef(contextMenuRef.value)
   canvasStore.setVStageRef(vStageRef.value)
 })
 onUnmounted(() => {

--- a/src/composables/useContextMenuLogic.js
+++ b/src/composables/useContextMenuLogic.js
@@ -26,7 +26,7 @@ export function useContextMenuLogic(selectedSource) {
     e.evt.preventDefault()
     e.evt.stopPropagation()
     if (e.target.getAttr('name') === SOUND_NODE_PART_NAME) { // if part of a konva SoundSourceNode.vue group
-      canvasStore.stageDivRef.contextMenuRef.show({ x: e.evt.clientX, y: e.evt.clientY }) // show context menu
+      canvasStore.contextMenuRef.value?.show({ x: e.evt.clientX, y: e.evt.clientY }) // show context menu
     }
   }
 

--- a/src/composables/useDragDropAudio.js
+++ b/src/composables/useDragDropAudio.js
@@ -36,7 +36,8 @@ export function useDragDropAudio({ draggedSource }) {
   function handleDrop(e) {
     if (!draggedSource.value) return
     const canvasStore = useCanvasStore()
-    const stageBounds = canvasStore.stageDivRef.getBoundingClientRect()
+    const stageBounds = canvasStore.stageDivRef.value?.getBoundingClientRect()
+    if (!stageBounds) return
     const dropX = e.clientX - stageBounds.left
     const dropY = e.clientY - stageBounds.top
   

--- a/src/stores/useCanvasStore.js
+++ b/src/stores/useCanvasStore.js
@@ -9,6 +9,7 @@ import { ref } from 'vue'
 export const useCanvasStore = defineStore('canvas', () => {
   const stageDivRef = ref(null)
   const vStageRef = ref(null)
+  const contextMenuRef = ref(null)
 
   /**
    * Save a reference to the outer div that hosts the canvas.
@@ -17,6 +18,15 @@ export const useCanvasStore = defineStore('canvas', () => {
    */
   function setStageDivRef(stageInstance) {
     stageDivRef.value = stageInstance
+  }
+
+  /**
+   * Save a reference to the context menu component so composables can trigger it.
+   *
+   * @param {Object} menuRef - Vue ref for the context menu component
+   */
+  function setContextMenuRef(menuRef) {
+    contextMenuRef.value = menuRef
   }
 
   /**
@@ -56,6 +66,8 @@ export const useCanvasStore = defineStore('canvas', () => {
   return {
     stageDivRef,
     setStageDivRef,
+    contextMenuRef,
+    setContextMenuRef,
     vStageRef,
     setVStageRef,
     getThumbnailURI


### PR DESCRIPTION
## Summary
- store the context menu component ref in the canvas store and register it when mounting the canvas
- call the context menu via the stored ref with safety checks to avoid undefined errors
- guard drag-and-drop stage bounds lookup to prevent crashes when the stage ref is unavailable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933e9f9b410832f8ba4107dc92298ce)