### PR TITLE
Fix context menu reference for sound source nodes

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -88,6 +88,7 @@ onMounted(() => {
   window.addEventListener('resize', updateCoords)
   const canvasStore = useCanvasStore()
   canvasStore.setStageDivRef(stageDivRef.value)
+  canvasStore.setContextMenuRef(contextMenuRef.value)
   canvasStore.setVStageRef(vStageRef.value)
 })
 onUnmounted(() => {

--- a/src/composables/useContextMenuLogic.js
+++ b/src/composables/useContextMenuLogic.js
@@ -25,7 +25,11 @@ export function useContextMenuLogic(selectedSource) {
   function showContextMenu(e) {
     e.evt.preventDefault()
     e.evt.stopPropagation()
-    if (e.target.getAttr('name') === SOUND_NODE_PART_NAME) { // if part of a konva SoundSourceNode.vue group
+    const isSoundNodePart =
+      e.target?.hasName?.(SOUND_NODE_PART_NAME)
+      || Boolean(e.target?.findAncestor?.((node) => node?.hasName?.(SOUND_NODE_PART_NAME)))
+
+    if (isSoundNodePart) { // if part of a konva SoundSourceNode.vue group
       canvasStore.contextMenuRef?.value?.show({ x: e.evt.clientX, y: e.evt.clientY }) // show context menu
     }
   }

--- a/src/composables/useContextMenuLogic.js
+++ b/src/composables/useContextMenuLogic.js
@@ -26,7 +26,7 @@ export function useContextMenuLogic(selectedSource) {
     e.evt.preventDefault()
     e.evt.stopPropagation()
     if (e.target.getAttr('name') === SOUND_NODE_PART_NAME) { // if part of a konva SoundSourceNode.vue group
-      canvasStore.stageDivRef.contextMenuRef.show({ x: e.evt.clientX, y: e.evt.clientY }) // show context menu
+      canvasStore.contextMenuRef?.value?.show({ x: e.evt.clientX, y: e.evt.clientY }) // show context menu
     }
   }
 

--- a/src/stores/useCanvasStore.js
+++ b/src/stores/useCanvasStore.js
@@ -9,6 +9,7 @@ import { ref } from 'vue'
 export const useCanvasStore = defineStore('canvas', () => {
   const stageDivRef = ref(null)
   const vStageRef = ref(null)
+  const contextMenuRef = ref(null)
 
   /**
    * Save a reference to the outer div that hosts the canvas.
@@ -17,6 +18,15 @@ export const useCanvasStore = defineStore('canvas', () => {
    */
   function setStageDivRef(stageInstance) {
     stageDivRef.value = stageInstance
+  }
+
+  /**
+   * Save a reference to the context menu component used by the stage.
+   *
+   * @param {Object} contextMenuInstance - Context menu component instance
+   */
+  function setContextMenuRef(contextMenuInstance) {
+    contextMenuRef.value = contextMenuInstance
   }
 
   /**
@@ -56,6 +66,8 @@ export const useCanvasStore = defineStore('canvas', () => {
   return {
     stageDivRef,
     setStageDivRef,
+    contextMenuRef,
+    setContextMenuRef,
     vStageRef,
     setVStageRef,
     getThumbnailURI


### PR DESCRIPTION
## Summary
- add a context menu reference to the canvas store to avoid undefined access
- register the context menu component when mounting the main canvas stage
- guard context menu display logic when right-clicking sound source nodes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933ed12ad54832fa89ba57a78ce30a5)