### PR TITLE
Fix context menu for sound source nodes

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -6,6 +6,7 @@
     @dragmove="onSourceDragMove"
     :scaleX="selectedScale"
     :scaleY="selectedScale"
+    @contextmenu="onContextMenu"
   >
     <!-- Outer Cone -->
     <v-wedge
@@ -133,7 +134,7 @@ const props = defineProps({
 
 const { room } = storeToRefs(useRoomStore())
 const { actionManager } = storeToRefs(useActionManagerStore())
-const emit = defineEmits(['select'])
+const emit = defineEmits(['select', 'contextmenu'])
 const themeStore = useThemeStore()
 
 const isDarkMode = computed(() => themeStore.activeTheme !== 'light')
@@ -400,6 +401,10 @@ function onHandleMouseUp() {
   }
 
   initialSourceAngle = null
+}
+
+function onContextMenu(e) {
+  emit('contextmenu', e)
 }
 
 </script>


### PR DESCRIPTION
## Summary
- forward context menu events from sound source nodes to display the custom menu

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933ee983324832fa33453e77435676e)