### PR TITLE
Guard context menu access for sound source nodes

### DIFF
--- a/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
+++ b/src/components/SoundRoom/MainCanvasStage/MainCanvasStage.vue
@@ -88,6 +88,7 @@ onMounted(() => {
   window.addEventListener('resize', updateCoords)
   const canvasStore = useCanvasStore()
   canvasStore.setStageDivRef(stageDivRef.value)
+  canvasStore.setContextMenuRef(contextMenuRef.value) // share context menu instance safely
   canvasStore.setVStageRef(vStageRef.value)
 })
 onUnmounted(() => {

--- a/src/composables/useContextMenuLogic.js
+++ b/src/composables/useContextMenuLogic.js
@@ -40,8 +40,13 @@ export function useContextMenuLogic(selectedSource) {
         selectedSource.value?.instance.playing ? 'Pause' : 'Play'
       ),
       function: () => {
-        const src = selectedSource.value;
-        src.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
+        const src = selectedSource.value
+        if (!src) return // guard against missing source
+
+        const isPlaying = src.instance?.playing // use the instance playing flag for accuracy
+        isPlaying
+          ? audioEngineStore.pauseSoundSource(src)
+          : audioEngineStore.playSoundSource(src)
       },
     },
     {

--- a/src/composables/useContextMenuLogic.js
+++ b/src/composables/useContextMenuLogic.js
@@ -26,7 +26,11 @@ export function useContextMenuLogic(selectedSource) {
     e.evt.preventDefault()
     e.evt.stopPropagation()
     if (e.target.getAttr('name') === SOUND_NODE_PART_NAME) { // if part of a konva SoundSourceNode.vue group
-      canvasStore.stageDivRef.contextMenuRef.show({ x: e.evt.clientX, y: e.evt.clientY }) // show context menu
+      const menuRef = canvasStore.contextMenuRef?.value || canvasStore.contextMenuRef
+
+      if (!menuRef?.show) return // guard against missing context menu instance
+
+      menuRef.show({ x: e.evt.clientX, y: e.evt.clientY }) // show context menu safely
     }
   }
 

--- a/src/stores/useCanvasStore.js
+++ b/src/stores/useCanvasStore.js
@@ -9,6 +9,7 @@ import { ref } from 'vue'
 export const useCanvasStore = defineStore('canvas', () => {
   const stageDivRef = ref(null)
   const vStageRef = ref(null)
+  const contextMenuRef = ref({ show: () => {} }) // default noop to avoid runtime errors
 
   /**
    * Save a reference to the outer div that hosts the canvas.
@@ -17,6 +18,15 @@ export const useCanvasStore = defineStore('canvas', () => {
    */
   function setStageDivRef(stageInstance) {
     stageDivRef.value = stageInstance
+  }
+
+  /**
+   * Save a reference to the context menu component so it can be shown safely.
+   *
+   * @param {Object|null} menuInstance - context menu component instance
+   */
+  function setContextMenuRef(menuInstance) {
+    contextMenuRef.value = menuInstance || { show: () => {} }
   }
 
   /**
@@ -55,7 +65,9 @@ export const useCanvasStore = defineStore('canvas', () => {
 
   return {
     stageDivRef,
+    contextMenuRef,
     setStageDivRef,
+    setContextMenuRef,
     vStageRef,
     setVStageRef,
     getThumbnailURI


### PR DESCRIPTION
## Summary
- store the canvas context menu reference in the canvas store and seed it with a noop default
- guard context menu usage with null-safe checks before attempting to show it
- wire the main canvas stage to register its context menu ref for safe access

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933f0bb59d8832f9644ff2bd6bc6351)