### PR TITLE
Ensure theme resets when downgrading to free

### DIFF
--- a/src/stores/useThemeStore.js
+++ b/src/stores/useThemeStore.js
@@ -4,6 +4,7 @@ import {
   applyTheme,
   applyThemeVars,
   applyThemeVarsFromRemote,
+  DEFAULT_THEME,
   readPersistedTheme,
   resolveInitialTheme,
 } from '@/utils/theme'
@@ -94,13 +95,27 @@ export const useThemeStore = defineStore('theme', () => {
   }
 
   function watchAuthTheme() {
-    const { user } = useAuth()
+    const { user, tier } = useAuth()
     watch(
       () => user.value?.id,
       () => {
         void loadUserTheme()
       },
       { immediate: true }
+    )
+
+    watch(
+      () => tier.value,
+      (nextTier, previousTier) => {
+        if (nextTier !== 'free' || previousTier === 'free') return
+
+        // Downgrade to free: drop premium overrides and return to default base theme
+        const hasOverrides = Object.keys(cssVars.value || {}).length > 0
+        if (!hasOverrides && activeTheme.value === DEFAULT_THEME) return
+
+        setTheme(DEFAULT_THEME || 'light', { clearOverrides: true })
+      },
+      { immediate: false }
     )
   }
 


### PR DESCRIPTION
## Summary
- add theme store watcher for tier changes to clear premium overrides on downgrade
- reset active theme to the default when plan tier becomes free

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933f36daa44832f9e58131c08bce0be)