### PR TITLE
Add soft locks for downgraded entitlements

### DIFF
--- a/api/get-upload-url.js
+++ b/api/get-upload-url.js
@@ -1,6 +1,8 @@
 import { getEnv } from "@vercel/functions";
 import { randomBytes, randomUUID } from "node:crypto";
 import { AwsClient } from "aws4fetch";
+import { authenticateRequest, resolveUserAccessContext } from './_utils/auth.js'
+import { HttpError } from './_utils/errors.js'
 
 function createRandomId() {
   if (typeof randomUUID === "function") {
@@ -82,6 +84,12 @@ export function OPTIONS() {
 
 export async function GET(request) {
   try {
+    const { user } = await authenticateRequest(request)
+    const userAccess = await resolveUserAccessContext(user.id)
+    if (!userAccess.entitlements?.canUpload) {
+      throw new HttpError(403, 'Uploads are unavailable on your plan')
+    }
+
     const { accessKeyId, secretAccessKey, bucketName, accountId } = getR2Config();
 
     if (!accessKeyId || !secretAccessKey || !bucketName || !accountId) {
@@ -134,6 +142,19 @@ export async function GET(request) {
       }
     );
   } catch (error) {
+    if (error instanceof HttpError) {
+      return new Response(
+        JSON.stringify({ error: error.message }),
+        {
+          status: error.status,
+          headers: {
+            ...corsHeaders,
+            "Content-Type": "application/json",
+          },
+        }
+      )
+    }
+
     console.error("💥 SIGNING ERROR:", error);
     return new Response(
       JSON.stringify({ error: "Internal Server Error", message: error.message }),

--- a/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
+++ b/src/components/SoundRoom/MainCanvasStage/SoundSourceNode.vue
@@ -6,6 +6,8 @@
     @dragmove="onSourceDragMove"
     :scaleX="selectedScale"
     :scaleY="selectedScale"
+    :opacity="nodeOpacity"
+    :title="isLocked ? lockTooltip : undefined"
   >
     <!-- Outer Cone -->
     <v-wedge
@@ -59,6 +61,16 @@
       @mouseup="onSourceMouseUp"
       @mouseover="setCursor($event, 'pointer')"
       @mouseout="setCursor($event, 'default')"
+    />
+
+    <v-text
+      v-if="isLocked"
+      :text="'🔒'"
+      :fontSize="16"
+      :fill="themeTokens.white"
+      :offsetX="8"
+      :offsetY="10"
+      :listening="false"
     />
 
     <ScheduledPlayRing
@@ -183,6 +195,10 @@ const getFillColor = computed(() => {
   return isScheduled.value ? colors.nodeBlue : colors.nodeRed
 })
 
+const isLocked = computed(() => !!props.source?.locked)
+const nodeOpacity = computed(() => (isLocked.value ? 0.5 : 1))
+const lockTooltip = 'Available on Pro tier.'
+
 const dotStrokeColor = computed(() => {
   if (isDarkMode.value) return props.selected ? themeTokens.value.white : rgbaFromVar('--base-white-rgb', 0.9, 'rgba(var(--base-white-rgb), 0.9)')
   return themeTokens.value.mutedStroke
@@ -274,6 +290,11 @@ let initialSourceAngle = null
 
 // Source dragging
 function onSourceMouseDown(e) {
+  if (isLocked.value) {
+    emit('select', props.index)
+    e.evt?.stopPropagation?.()
+    return
+  }
   emit('select', props.index) // select current SoundSourceNode to display in SelectSourcePanel.vue
   e.evt.stopPropagation()
 
@@ -317,6 +338,10 @@ function onSourceMouseDown(e) {
 }
 
 function onSourceDragMove(e) {
+  if (isLocked.value) {
+    e.target?.draggable(false)
+    return
+  }
   const pos = e.target.position()
   const clampedX = room.value.clamp(pos.x, 0, room.value.width)
   const clampedY = room.value.clamp(pos.y, 0, room.value.height)
@@ -350,6 +375,11 @@ function onSourceMouseUp(e) {
 
 // Rotation interaction
 function onHandleMouseDown(e) {
+  if (isLocked.value) {
+    emit('select', props.index)
+    e.evt?.stopPropagation?.()
+    return
+  }
   emit('select', props.index)
   e.evt.stopPropagation()
 
@@ -376,6 +406,7 @@ function onHandleMouseDown(e) {
 }
 
 function onHandleMouseMove(e) {
+  if (isLocked.value) return
   const stage = e.target.getStage()
   const mousePos = stage.getPointerPosition()
   const dx = mousePos.x - props.source.instance.state.x

--- a/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
+++ b/src/components/SoundRoom/SidebarRight/SelectedSourcePanel.vue
@@ -5,6 +5,14 @@
     </h5>
 
     <div v-if="selectedSource" class="space-y-6 flex flex-col items-center">
+      <div
+        v-if="isLocked"
+        class="flex items-center gap-2 text-xs text-[var(--color-text-muted)]"
+        :title="lockTooltip"
+      >
+        <span aria-hidden="true">🔒</span>
+        <span>Available on Pro tier.</span>
+      </div>
       <!-- Readouts -->
       <div class="space-y-1 text-xs text-[var(--color-text-muted)]">
         <h4>{{ selectedSource.name }}</h4>
@@ -26,6 +34,8 @@
           @drag-start="onStart"
           @change="onChange"
           @drag-end="onEnd"
+          :disabled="isLocked"
+          :class="{ 'opacity-60 cursor-not-allowed': isLocked }"
         />
       </div>
 
@@ -34,8 +44,11 @@
         <button
           @click="playPauseSource"
           class="w-full bg-[var(--color-bg-surface)] text-xs rounded hover:bg-[var(--color-bg-elevated)] border border-[var(--color-border-subtle)] text-[var(--color-text-primary)]"
+          :disabled="isLocked"
+          :title="isLocked ? lockTooltip : undefined"
         >
           {{ playPauseLabel }}
+          <span v-if="isLocked" aria-hidden="true"> 🔒</span>
         </button>
         <button
           @click="deleteSource"
@@ -52,7 +65,7 @@
         <input
           type="checkbox"
           :checked="schedulingEnabled"
-          :disabled="!canUseTimedLoops"
+          :disabled="!canUseTimedLoops || isLocked"
           @change="handleSchedulingToggle"
           class="accent-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
         />
@@ -77,7 +90,8 @@
             :value="schedule.mode"
             @change="handleScheduleModeChange"
             @blur="commitScheduleEdit"
-            class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]">
+            class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+            :disabled="isLocked">
             <option value="interval">Interval</option>
             <option v-if="canUseAdvancedScheduling" value="count">Count</option>
             <option v-if="canUseAdvancedScheduling" value="interval+count">Interval + Count</option>
@@ -100,6 +114,7 @@
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
               class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+              :disabled="isLocked"
             />
           </div>
           <div class="flex flex-col space-y-1">
@@ -117,6 +132,7 @@
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
               class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+              :disabled="isLocked"
             />
             <p v-if="schedule.gapMax < schedule.gapMin" class="text-[var(--color-danger)] text-xs">
               Gap Max cannot be smaller than Gap Min
@@ -141,6 +157,7 @@
               @blur="commitScheduleEdit"
               placeholder="Unlimited"
               class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+              :disabled="isLocked"
             />
           </div>
           <div class="flex flex-col space-y-1">
@@ -157,6 +174,7 @@
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
               class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+              :disabled="isLocked"
             />
           </div>
           <div class="flex flex-col space-y-1">
@@ -172,6 +190,7 @@
               @keyup.enter="commitScheduleEdit"
               @blur="commitScheduleEdit"
               class="px-2 py-1 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)]"
+              :disabled="isLocked"
             />
           </div>
         </div>
@@ -201,6 +220,8 @@ const selectedSource = inject('selectedSource');
 const { actionManager } = storeToRefs(useActionManagerStore());
 const audioEngineStore = useAudioEngineStore();
 const { canAccess, requireEntitlement } = useEntitlements();
+const isLocked = computed(() => !!selectedSource.value?.locked);
+const lockTooltip = 'Available on Pro tier.'
 
 const state = computed(() => selectedSource.value?.instance?.state ?? {});
 const schedule = computed(() => state.value?.schedule ?? {});
@@ -232,13 +253,26 @@ const getScheduleCopy = () => {
   enabled: schedule.value.enabled
 }
 }
-const { onStart, onChange, onEnd } = useVolumeSlider(selectedSource, actionManager);
+const volumeControls = useVolumeSlider(selectedSource, actionManager);
+const onStart = (...args) => {
+  if (isLocked.value) return
+  return volumeControls.onStart(...args)
+}
+const onChange = (...args) => {
+  if (isLocked.value) return
+  return volumeControls.onChange(...args)
+}
+const onEnd = (...args) => {
+  if (isLocked.value) return
+  return volumeControls.onEnd(...args)
+}
 
 const playPauseLabel = computed(() =>
   selectedSource.value.instance.playing ? "Pause" : "Play"
 );
 
 const playPauseSource = () => {
+  if (isLocked.value) return;
   const src = selectedSource.value;
   src.instance.playing ? audioEngineStore.pauseSoundSource(src) : audioEngineStore.playSoundSource(src);
 };
@@ -290,6 +324,7 @@ function commitSchedulePatch(patch) {
 }
 
 function handleSchedulingToggle(event) {
+  if (isLocked.value) return
   const nextEnabled = !!event.target.checked;
   if (nextEnabled && !requireEntitlement('timedLoops')) {
     event.target.checked = !!schedule.value.enabled;
@@ -299,6 +334,7 @@ function handleSchedulingToggle(event) {
 }
 
 function handleScheduleModeChange(event) {
+  if (isLocked.value) return
   const nextMode = event.target.value;
   if (!canUseAdvancedScheduling.value && nextMode !== 'interval') {
     event.target.value = schedule.value.mode ?? 'interval';
@@ -308,6 +344,7 @@ function handleScheduleModeChange(event) {
 }
 
 function commitScheduleEdit() {
+  if (isLocked.value) return
   const changedKeys = Object.keys(scheduleCopy.value).filter(key => {
   const scheduleVal = schedule.value[key]
   const copyVal = scheduleCopy.value[key];

--- a/src/components/ui/modals/RoomManager/RoomCard.vue
+++ b/src/components/ui/modals/RoomManager/RoomCard.vue
@@ -1,19 +1,39 @@
 <template>
-  <div class="room-row p-4 border border-border-subtle rounded-lg shadow-sm hover:bg-[var(--color-bg-elevated)] transition bg-surface-base text-text-primary">
-    <img
-      v-if="room.thumbnail"
-      :src="room.thumbnail"
-      alt="Room preview"
-      class="rounded mb-3 w-full aspect-video object-cover border border-border-subtle"
-    />
-    <EditableRoomName
-      :roomId="room.id"
-      :name="room.name"
-      @updated="name => emit('update-name', name)"
-    />
+  <div
+    class="room-row p-4 border border-border-subtle rounded-lg shadow-sm hover:bg-[var(--color-bg-elevated)] transition bg-surface-base text-text-primary"
+    :class="{ 'opacity-60': locked }"
+    :title="locked ? lockTooltip : undefined"
+  >
+    <div v-if="room.thumbnail" class="relative mb-3">
+      <img
+        :src="room.thumbnail"
+        alt="Room preview"
+        class="rounded w-full aspect-video object-cover border border-border-subtle"
+      />
+      <div
+        v-if="locked"
+        class="absolute inset-0 flex items-center justify-center text-2xl"
+        aria-hidden="true"
+      >
+        🔒
+      </div>
+    </div>
+    <div class="flex items-start justify-between gap-2">
+      <EditableRoomName
+        :roomId="room.id"
+        :name="room.name"
+        @updated="name => emit('update-name', name)"
+      />
+    </div>
     <div class="room-meta text-xs text-text-muted">{{ formatDate(room.updated_at) }}</div>
     <div class="room-actions mt-3 flex gap-2">
-      <BaseButton @click="emit('load', room.id)">Load</BaseButton>
+      <BaseButton
+        @click="emit('load', room.id)"
+        :disabled="locked"
+        :title="locked ? lockTooltip : undefined"
+      >
+        Load
+      </BaseButton>
       <BaseButton @click="emit('delete', room.id)">Delete</BaseButton>
     </div>
   </div>
@@ -25,7 +45,12 @@ import EditableRoomName from '@/components/ui/modals/RoomManager/EditableRoomNam
 import { formatDate } from '@/utils/dateUtils'
 
 const props = defineProps({
-  room: Object
+  room: Object,
+  locked: Boolean,
+  lockTooltip: {
+    type: String,
+    default: ''
+  }
 })
 const emit = defineEmits(['update-name', 'load', 'delete'])
 </script>

--- a/src/components/ui/modals/RoomManager/RoomManager.vue
+++ b/src/components/ui/modals/RoomManager/RoomManager.vue
@@ -46,6 +46,8 @@
             v-for="room in paginatedItems"
             :key="room.id"
             :room="room"
+            :locked="room.locked"
+            :lock-tooltip="lockTooltip"
             @load="handleLoadRoom(room.id)"
             @delete="handleDeleteRoom(room.id)"
             @update-name="name => handleUpdateRoomName(room, name)"
@@ -109,6 +111,8 @@ import { useSaveAndLoadRoom } from '@/composables/useSaveAndLoadRoom'
 import { useRoomStore } from '@/stores/useRoomStore'
 import PulsingOverlay from '@/components/ui/overlays/PulsingOverlay.vue'
 import { resetRoomState } from '@/utils/resetRoomState'
+import { useEntitlements } from '@/composables/useEntitlements'
+import { limit as getPlanLimit } from '@/utils/permissions'
 
 const router = useRouter()
 const buttons = ref([
@@ -123,15 +127,28 @@ const currentPage = ref(0)
 const itemsPerPage = 12 // or 8, 16 depending on grid size
 
 const { loadRoom, deleteRoom, saveRoom, isSavingRoom, isLoadingRoom, updateRoomName } = useSaveAndLoadRoom()
+const { currentPlan } = useEntitlements()
 
 const deleteRoomModalVisible = ref(false)
 const saveRoomCheck = ref(false)
 const rooms = ref([])
 const loading = ref(true)
 let roomId = null
+const maxSavedRooms = computed(() => getPlanLimit(currentPlan.value, 'maxSavedRooms') ?? 1)
+const lockTooltip = 'Your plan allows 1 saved room. Upgrade to access older rooms.'
+
+function shouldLockRoom(index) {
+  if (!Number.isFinite(maxSavedRooms.value)) return false
+  return index >= maxSavedRooms.value
+}
+
+const roomsWithLocks = computed(() => rooms.value.map((room, index) => ({
+  ...room,
+  locked: shouldLockRoom(index)
+})))
 const paginatedItems = computed(() => {
   const start = (currentPage.value) * itemsPerPage
-  return rooms.value.slice(start, start + itemsPerPage)
+  return roomsWithLocks.value.slice(start, start + itemsPerPage)
 })
 
 const totalPages = computed(() =>
@@ -155,6 +172,9 @@ const handleUpdateRoomName = async (room, newName) => {
 }
 
 const handleLoadRoom = async (rId) => {
+  if (roomsWithLocks.value.find(r => r.id === rId)?.locked) {
+    return
+  }
   roomId = rId
   if (!roomStore.isRoomSaveable) {
     

--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -32,8 +32,14 @@
             type="button"
             class="text-sm font-medium text-text-primary hover:underline"
             @click="handleUploadClick"
+            :disabled="!canUpload"
+            :title="!canUpload ? lockTooltip : undefined"
+            :class="{ 'opacity-60 cursor-not-allowed': !canUpload }"
           >
-            {{ uploadCtaLabel }}
+            <span class="inline-flex items-center gap-1">
+              <span>{{ uploadCtaLabel }}</span>
+              <span v-if="!canUpload" aria-hidden="true">🔒</span>
+            </span>
           </button>
         <span v-if="!canUpload" class="text-xs uppercase tracking-wide text-accent">Pro feature</span>
         </div>
@@ -70,6 +76,7 @@ const canUpload = computed(() => canAccess('canUpload'))
 const uploadCtaLabel = computed(() =>
   canUpload.value ? 'Upload your own sound' : 'Upgrade to upload your own sounds'
 )
+const lockTooltip = 'Available on Pro tier.'
 
 function handleUploadClick() {
   if (!requireEntitlement('canUpload')) return

--- a/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
@@ -64,7 +64,7 @@ import { buildStorageKey } from '@/utils/downloadAudio'
 
 
 const { user, isAuthenticated, tier } = useAuth()
-const { requireEntitlement } = useEntitlements()
+const { canAccess, requireEntitlement } = useEntitlements()
 
 const router = useRouter()
 const cacheStore = useAudioCacheStore()
@@ -133,7 +133,8 @@ const rawSounds = ref([])
 const filteredSounds = computed(() => {
   const userTier = tier.value
   const userId = user.value?.id
-  return rawSounds.value.map(sound => annotateSoundAccess(sound, { userTier, userId }))
+  const canUpload = canAccess('canUpload')
+  return rawSounds.value.map(sound => annotateSoundAccess(sound, { userTier, userId, canUpload }))
 })
 watch(
   activeCategory,

--- a/src/composables/useContextMenuLogic.js
+++ b/src/composables/useContextMenuLogic.js
@@ -17,6 +17,7 @@ export function useContextMenuLogic(selectedSource) {
   const audioEngineStore = useAudioEngineStore()
   const { actionManager } = storeToRefs(actionStore)
   const canvasStore = useCanvasStore()
+  const isLocked = computed(() => !!selectedSource.value?.locked)
   /**
    * Display the context menu when the user right-clicks a sound node.
    *
@@ -41,7 +42,7 @@ export function useContextMenuLogic(selectedSource) {
       ),
       function: () => {
         const src = selectedSource.value
-        if (!src) return // guard against missing source
+        if (!src || isLocked.value) return // guard against missing source or locked state
 
         const isPlaying = src.instance?.playing // use the instance playing flag for accuracy
         isPlaying
@@ -52,20 +53,24 @@ export function useContextMenuLogic(selectedSource) {
     {
       label: 'Delete',
       function: () => {
+        if (!selectedSource.value) return
         actionManager.value.doAction('delete_canvas_sound_source', {
           index: selectedSource.value.index,
           src: selectedSource.value,
+          allowLocked: true
         })
       }
     },
     {
       label: 'Duplicate',
       function: () => {
+        if (!selectedSource.value || isLocked.value) return
         const src = {
           // shallow copy of simple fields
           audioPath: selectedSource.value.audioPath,
           name: selectedSource.value.name,
           libraryId: selectedSource.value.libraryId,
+          locked: selectedSource.value.locked,
           // copy reactive state manually
           state: reactive({
             x: selectedSource.value.state.x + 5,

--- a/src/composables/useKeyboardControls.js
+++ b/src/composables/useKeyboardControls.js
@@ -23,6 +23,7 @@ export function useKeyboardControls({selectedSource, selectedIndex}) {
   const rotationKeys = new Set()
   let listenerAngleStart = null
   let sourceAngleStart = null
+  const isSelectedSourceLocked = () => Boolean(selectedSource.value?.locked)
   
 
   actionManager.value.registerActionHandlers(
@@ -84,7 +85,7 @@ export function useKeyboardControls({selectedSource, selectedIndex}) {
       listenerAngleStart = listener.value.angle;
     }
 
-    if ((key == 'z' || key == 'c') && !rotationKeys.has(key)) {
+    if ((key == 'z' || key == 'c') && !rotationKeys.has(key) && !isSelectedSourceLocked()) {
       rotationKeys.add(key)
       sourceAngleStart = selectedSource.value.instance.state.angle;
     }
@@ -119,13 +120,13 @@ export function useKeyboardControls({selectedSource, selectedIndex}) {
         listenerChanged = true
         break
       case 'z':
-        if (selectedSource.value !== null) {
+        if (selectedSource.value !== null && !isSelectedSourceLocked()) {
           selectedSource.value.instance.state.angle -= rotationStep
           selectedSource.value.instance.updateAudio()
         }
         break
       case 'c':
-        if (selectedSource.value !== null) {
+        if (selectedSource.value !== null && !isSelectedSourceLocked()) {
           selectedSource.value.instance.state.angle += rotationStep
           selectedSource.value.instance.updateAudio()
         }

--- a/src/composables/useSaveAndLoadRoom.js
+++ b/src/composables/useSaveAndLoadRoom.js
@@ -48,7 +48,7 @@ export function useSaveAndLoadRoom() {
   const { listener } = storeToRefs(listenerStore);
   const { audioEngine } = storeToRefs(audioEngineStore);
   const { soundLibrarySources } = storeToRefs(cacheStore);
-  const { requireWithinLimit } = useEntitlements()
+  const { requireWithinLimit, canAccess } = useEntitlements()
 
   /**
    * Persist the current room to Supabase. Handles insert or update logic
@@ -243,22 +243,22 @@ export function useSaveAndLoadRoom() {
     roomData.room.id = resolvedRoomId; // Set the room ID from the database
     roomData.room.name = data.name; // Set the room name from the database
     const ids = roomData?.soundLibrarySources?.map(s => s.libraryId) ?? [];
-    const { accessible: dbSounds, lockedIds, missingIds } = await getSoundsFromDB(ids);
-    const { successes: downloaded, failedIds } = await downloadMultipleAudio(dbSounds);
+    const { annotated: dbSounds, accessible: accessibleSounds, lockedIds, missingIds } = await getSoundsFromDB(ids);
+    const { successes: downloaded, failedIds } = await downloadMultipleAudio(accessibleSounds);
 
     const downloadedMap = new Map(downloaded.map(entry => [entry.id, entry.audioPath]));
-    const availableIds = new Set(downloaded.map(entry => entry.id));
+    const availableIds = new Set([...downloaded.map(entry => entry.id), ...lockedIds]);
     const { roomData: cleanedRoom, removed } = filterRoomByAvailableSounds(roomData, availableIds)
     roomData = cleanedRoom
 
     const finalSources = roomData.soundLibrarySources.map(({ libraryId }) => {
-      const audioPath = downloadedMap.get(libraryId);
       const soundMatch = dbSounds.find(d => d.id === libraryId);
+      const audioPath = soundMatch?.locked ? null : downloadedMap.get(libraryId);
 
       const coneInner = roomData.audioEngine.soundSources.find(src => src.libraryId === libraryId)?.state?.coneInner ?? soundMatch?.coneInner ?? 60;
       const coneOuter = roomData.audioEngine.soundSources.find(src => src.libraryId === libraryId)?.state?.coneOuter ?? soundMatch?.coneOuter ?? 180;
 
-      if (!audioPath || !soundMatch) {
+      if ((!audioPath && !soundMatch?.locked) || !soundMatch) {
         console.warn(`Missing data for libraryId ${libraryId}`);
         return null; // or skip it entirely if you'd prefer
       }
@@ -280,14 +280,19 @@ export function useSaveAndLoadRoom() {
         plan_tier: planTier,
         base,
         storageKey,
-        fileId: libraryId ?? storageKey
+        fileId: libraryId ?? storageKey,
+        locked: !!soundMatch.locked,
+        accessReason: soundMatch.accessReason,
+        requiredPlan: soundMatch.requiredPlan,
+        entitlementFeature: soundMatch.entitlementFeature,
+        canUpgrade: soundMatch.canUpgrade
       };
     }).filter(Boolean); // remove nulls if any
     soundLibrarySources.value = finalSources;
 
     const missingUploadCount = missingIds.length + failedIds.length
     if (lockedIds.length > 0) {
-      console.info(`Skipped ${lockedIds.length} locked sound(s) while loading room.`)
+      console.info(`Kept ${lockedIds.length} locked sound(s) visible while loading room.`)
     }
     if (removed > 0 && missingUploadCount === 0 && lockedIds.length === 0) {
       console.info(`Removed ${removed} unavailable sound source(s) while loading room.`)
@@ -308,6 +313,11 @@ export function useSaveAndLoadRoom() {
         src.base = match.base;
         src.storageKey = match.storageKey;
         src.fileId = match.fileId;
+        src.locked = match.locked;
+        src.accessReason = match.accessReason;
+        src.requiredPlan = match.requiredPlan;
+        src.entitlementFeature = match.entitlementFeature;
+        src.canUpgrade = match.canUpgrade;
       }
     });
     
@@ -357,7 +367,7 @@ export function useSaveAndLoadRoom() {
    * @returns {Promise<Array>} list of sound records
    */
   async function getSoundsFromDB(ids) {
-    if (!ids?.length) return { accessible: [], lockedIds: [], missingIds: [] }
+    if (!ids?.length) return { annotated: [], accessible: [], lockedIds: [], missingIds: [] }
 
     const { data, error } = await supabase
       .from("sound_files")
@@ -366,24 +376,25 @@ export function useSaveAndLoadRoom() {
 
     if (error) {
       console.warn("Failed to list files:", error);
-      return { accessible: [], lockedIds: [], missingIds: ids }
+      return { annotated: [], accessible: [], lockedIds: [], missingIds: ids }
     }
 
     const context = {
       userTier: tier.value,
-      userId: user.value?.id
+      userId: user.value?.id,
+      canUpload: canAccess('canUpload')
     }
 
     const annotated = (data ?? []).map(sound => annotateSoundAccess(sound, context))
-    const locked = annotated.filter(sound => sound.locked).map(sound => sound.id)
+    const lockedEntries = annotated.filter(sound => sound.locked)
     const accessible = annotated.filter(sound => !sound.locked)
     const missingIds = ids.filter(id => !annotated.find(sound => sound.id === id))
 
-    if (locked.length > 0) {
-      console.info(`Skipped ${locked.length} sound(s) due to plan entitlements.`)
+    if (lockedEntries.length > 0) {
+      console.info(`Preserved ${lockedEntries.length} locked sound(s) due to plan entitlements.`)
     }
 
-    return { accessible, lockedIds: locked, missingIds }
+    return { annotated, accessible, lockedIds: lockedEntries.map(sound => sound.id), missingIds }
   }
   /**
    * Persist the current room to browser localStorage for offline usage.
@@ -411,17 +422,17 @@ export function useSaveAndLoadRoom() {
     } else {
       let roomData = JSON.parse(stored);
       const ids = roomData.soundLibrarySources.map(s => s.libraryId);
-      const { accessible: dbSounds, lockedIds, missingIds } = await getSoundsFromDB(ids);
-      const { successes: downloaded, failedIds } = await downloadMultipleAudio(dbSounds);
+      const { annotated: dbSounds, accessible: accessibleSounds, lockedIds, missingIds } = await getSoundsFromDB(ids);
+      const { successes: downloaded, failedIds } = await downloadMultipleAudio(accessibleSounds);
 
       const downloadedMap = new Map(downloaded.map(entry => [entry.id, entry.audioPath]));
-      const availableIds = new Set(downloaded.map(entry => entry.id));
+      const availableIds = new Set([...downloaded.map(entry => entry.id), ...lockedIds]);
       const { roomData: cleanedRoom, removed } = filterRoomByAvailableSounds(roomData, availableIds)
       roomData = cleanedRoom
 
       const finalSources = roomData.soundLibrarySources.map(({ libraryId }) => {
-        const audioPath = downloadedMap.get(libraryId);
         const soundMatch = dbSounds.find(d => d.id === libraryId);
+        const audioPath = soundMatch?.locked ? null : downloadedMap.get(libraryId);
         const name = soundMatch?.name;
         const bucket = soundMatch?.bucket;
         const path = soundMatch?.path;
@@ -430,16 +441,33 @@ export function useSaveAndLoadRoom() {
         const storageKey = bucket && path ? buildStorageKey(base, bucket, path) : null;
         const coneInner = roomData.audioEngine.soundSources.find(src => src.libraryId === libraryId)?.state?.coneInner ?? soundMatch?.coneInner ?? 60;
         const coneOuter = roomData.audioEngine.soundSources.find(src => src.libraryId === libraryId)?.state?.coneOuter ?? soundMatch?.coneOuter ?? 180;
-        if (!audioPath || !soundMatch) console.warn(`Missing audioPath for libraryId ${libraryId}`);
-        if (!audioPath || !soundMatch) return null
-        return { libraryId, audioPath, name, path, bucket, coneInner, coneOuter, plan_tier: planTier, base, storageKey, fileId: libraryId ?? storageKey };
+        if ((!audioPath && !soundMatch?.locked) || !soundMatch) console.warn(`Missing audioPath for libraryId ${libraryId}`);
+        if ((!audioPath && !soundMatch?.locked) || !soundMatch) return null
+        return {
+          libraryId,
+          audioPath,
+          name,
+          path,
+          bucket,
+          coneInner,
+          coneOuter,
+          plan_tier: planTier,
+          base,
+          storageKey,
+          fileId: libraryId ?? storageKey,
+          locked: !!soundMatch.locked,
+          accessReason: soundMatch.accessReason,
+          requiredPlan: soundMatch.requiredPlan,
+          entitlementFeature: soundMatch.entitlementFeature,
+          canUpgrade: soundMatch.canUpgrade
+        };
       }).filter(Boolean);
 
       soundLibrarySources.value = finalSources;
 
       const missingUploadCount = missingIds.length + failedIds.length
       if (lockedIds.length > 0) {
-        console.info(`Skipped ${lockedIds.length} locked sound(s) while loading room.`)
+        console.info(`Kept ${lockedIds.length} locked sound(s) visible while loading room.`)
       }
       if (removed > 0 && missingUploadCount === 0 && lockedIds.length === 0) {
         console.info(`Removed ${removed} unavailable sound source(s) while loading room.`)
@@ -459,6 +487,11 @@ export function useSaveAndLoadRoom() {
         src.base = match.base;
         src.storageKey = match.storageKey;
         src.fileId = match.fileId;
+        src.locked = match.locked;
+        src.accessReason = match.accessReason;
+        src.requiredPlan = match.requiredPlan;
+        src.entitlementFeature = match.entitlementFeature;
+        src.canUpgrade = match.canUpgrade;
       }
       });
 

--- a/src/composables/useSaveAndLoadRoom.js
+++ b/src/composables/useSaveAndLoadRoom.js
@@ -244,6 +244,11 @@ export function useSaveAndLoadRoom() {
     roomData.room.name = data.name; // Set the room name from the database
     const ids = roomData?.soundLibrarySources?.map(s => s.libraryId) ?? [];
     const { annotated: dbSounds, accessible: accessibleSounds, lockedIds, missingIds } = await getSoundsFromDB(ids);
+    const accessContext = {
+      userTier: tier.value,
+      userId: user.value?.id,
+      canUpload: canAccess('canUpload')
+    }
     const { successes: downloaded, failedIds } = await downloadMultipleAudio(accessibleSounds);
 
     const downloadedMap = new Map(downloaded.map(entry => [entry.id, entry.audioPath]));
@@ -253,7 +258,8 @@ export function useSaveAndLoadRoom() {
 
     const finalSources = roomData.soundLibrarySources.map(({ libraryId }) => {
       const soundMatch = dbSounds.find(d => d.id === libraryId);
-      const audioPath = soundMatch?.locked ? null : downloadedMap.get(libraryId);
+      const annotatedAccess = soundMatch ? soundMatch : null
+      const audioPath = annotatedAccess?.locked ? null : downloadedMap.get(libraryId);
 
       const coneInner = roomData.audioEngine.soundSources.find(src => src.libraryId === libraryId)?.state?.coneInner ?? soundMatch?.coneInner ?? 60;
       const coneOuter = roomData.audioEngine.soundSources.find(src => src.libraryId === libraryId)?.state?.coneOuter ?? soundMatch?.coneOuter ?? 180;
@@ -269,7 +275,7 @@ export function useSaveAndLoadRoom() {
         ? buildStorageKey(base, soundMatch.bucket, soundMatch.path)
         : null
 
-      return {
+      const nextSource = {
         libraryId,
         audioPath,
         coneInner,
@@ -280,13 +286,12 @@ export function useSaveAndLoadRoom() {
         plan_tier: planTier,
         base,
         storageKey,
-        fileId: libraryId ?? storageKey,
-        locked: !!soundMatch.locked,
-        accessReason: soundMatch.accessReason,
-        requiredPlan: soundMatch.requiredPlan,
-        entitlementFeature: soundMatch.entitlementFeature,
-        canUpgrade: soundMatch.canUpgrade
-      };
+        fileId: libraryId ?? storageKey
+      }
+
+      applyAccessMetadata(nextSource, annotatedAccess, accessContext)
+
+      return nextSource
     }).filter(Boolean); // remove nulls if any
     soundLibrarySources.value = finalSources;
 
@@ -303,7 +308,7 @@ export function useSaveAndLoadRoom() {
 
 
     roomData.audioEngine.soundSources.forEach(src => {
-      const match = finalSources.find(a => a.libraryId === src.libraryId);
+      const match = finalSources.find(a => String(a.libraryId) === String(src.libraryId));
       if (match) {
         src.audioPath = match.audioPath;
         src.name = match.name;
@@ -313,11 +318,9 @@ export function useSaveAndLoadRoom() {
         src.base = match.base;
         src.storageKey = match.storageKey;
         src.fileId = match.fileId;
-        src.locked = match.locked;
-        src.accessReason = match.accessReason;
-        src.requiredPlan = match.requiredPlan;
-        src.entitlementFeature = match.entitlementFeature;
-        src.canUpgrade = match.canUpgrade;
+        applyAccessMetadata(src, match, accessContext)
+      } else {
+        applyAccessMetadata(src, null, accessContext)
       }
     });
     
@@ -396,6 +399,17 @@ export function useSaveAndLoadRoom() {
 
     return { annotated, accessible, lockedIds: lockedEntries.map(sound => sound.id), missingIds }
   }
+
+  function applyAccessMetadata(source, annotatedSound, context) {
+    const access = annotatedSound ? annotatedSound : annotateSoundAccess(source, context)
+
+    source.locked = !!access.locked
+    source.accessReason = access.accessReason
+    source.requiredPlan = access.requiredPlan
+    source.entitlementFeature = access.entitlementFeature
+    source.canUpgrade = access.canUpgrade
+    source.base = source.base ?? access.base ?? source.plan_tier ?? 'users'
+  }
   /**
    * Persist the current room to browser localStorage for offline usage.
    */
@@ -423,6 +437,11 @@ export function useSaveAndLoadRoom() {
       let roomData = JSON.parse(stored);
       const ids = roomData.soundLibrarySources.map(s => s.libraryId);
       const { annotated: dbSounds, accessible: accessibleSounds, lockedIds, missingIds } = await getSoundsFromDB(ids);
+      const accessContext = {
+        userTier: tier.value,
+        userId: user.value?.id,
+        canUpload: canAccess('canUpload')
+      }
       const { successes: downloaded, failedIds } = await downloadMultipleAudio(accessibleSounds);
 
       const downloadedMap = new Map(downloaded.map(entry => [entry.id, entry.audioPath]));
@@ -432,7 +451,8 @@ export function useSaveAndLoadRoom() {
 
       const finalSources = roomData.soundLibrarySources.map(({ libraryId }) => {
         const soundMatch = dbSounds.find(d => d.id === libraryId);
-        const audioPath = soundMatch?.locked ? null : downloadedMap.get(libraryId);
+        const annotatedAccess = soundMatch ? soundMatch : null
+        const audioPath = annotatedAccess?.locked ? null : downloadedMap.get(libraryId);
         const name = soundMatch?.name;
         const bucket = soundMatch?.bucket;
         const path = soundMatch?.path;
@@ -443,7 +463,7 @@ export function useSaveAndLoadRoom() {
         const coneOuter = roomData.audioEngine.soundSources.find(src => src.libraryId === libraryId)?.state?.coneOuter ?? soundMatch?.coneOuter ?? 180;
         if ((!audioPath && !soundMatch?.locked) || !soundMatch) console.warn(`Missing audioPath for libraryId ${libraryId}`);
         if ((!audioPath && !soundMatch?.locked) || !soundMatch) return null
-        return {
+        const nextSource = {
           libraryId,
           audioPath,
           name,
@@ -455,12 +475,11 @@ export function useSaveAndLoadRoom() {
           base,
           storageKey,
           fileId: libraryId ?? storageKey,
-          locked: !!soundMatch.locked,
-          accessReason: soundMatch.accessReason,
-          requiredPlan: soundMatch.requiredPlan,
-          entitlementFeature: soundMatch.entitlementFeature,
-          canUpgrade: soundMatch.canUpgrade
-        };
+        }
+
+        applyAccessMetadata(nextSource, annotatedAccess, accessContext)
+
+        return nextSource;
       }).filter(Boolean);
 
       soundLibrarySources.value = finalSources;
@@ -477,22 +496,20 @@ export function useSaveAndLoadRoom() {
       }
 
       roomData.audioEngine.soundSources.forEach(src => {
-        const match = finalSources.find(a => a.libraryId === src.libraryId);
-      if (match) {
-        src.audioPath = match.audioPath;
-        src.name = match.name;
-        src.bucket = match.bucket;
-        src.path = match.path;
-        src.plan_tier = match.plan_tier;
-        src.base = match.base;
-        src.storageKey = match.storageKey;
-        src.fileId = match.fileId;
-        src.locked = match.locked;
-        src.accessReason = match.accessReason;
-        src.requiredPlan = match.requiredPlan;
-        src.entitlementFeature = match.entitlementFeature;
-        src.canUpgrade = match.canUpgrade;
-      }
+        const match = finalSources.find(a => String(a.libraryId) === String(src.libraryId));
+        if (match) {
+          src.audioPath = match.audioPath;
+          src.name = match.name;
+          src.bucket = match.bucket;
+          src.path = match.path;
+          src.plan_tier = match.plan_tier;
+          src.base = match.base;
+          src.storageKey = match.storageKey;
+          src.fileId = match.fileId;
+          applyAccessMetadata(src, match, accessContext)
+        } else {
+          applyAccessMetadata(src, null, accessContext)
+        }
       });
 
       resetRoomState();

--- a/src/composables/useSoundRoomActions.js
+++ b/src/composables/useSoundRoomActions.js
@@ -60,6 +60,7 @@ function registerCanvasActions() {
    * @param {{x: number, y: number}} coords - new coordinates
    */
   const moveSoundSource = (src, coords) => {
+    if (src?.locked) return
     src.instance.state.x = coords.x
     src.instance.state.y = coords.y
     src.instance.updateAudio()
@@ -71,6 +72,10 @@ function registerCanvasActions() {
    * @param {Object} payload - action payload
    */
   const addSoundSource = async (payload) => {
+    if (payload?.src?.locked && !payload?.allowLocked) {
+      console.info('Sound source is locked for the current plan.')
+      return
+    }
     const libraryId = payload?.src?.libraryId
     if (libraryId && !soundLibrarySources.value.find(s => s.libraryId === libraryId)) {
       const available = await isSoundAvailable(libraryId)
@@ -103,6 +108,7 @@ function registerCanvasActions() {
    */
   const deleteSoundSource = (payload) => {
     payload.src = audioEngine.value.deleteSoundSource(payload)
+    payload.allowLocked = true
     listener.value.updateAudio()
   }
 
@@ -266,12 +272,14 @@ function registerSchedulingActions() {
   const { actionManager } = storeToRefs(useActionManagerStore())
 
   const applyScheduleChanges = (src, params) => {
+    if (src?.locked) return
     for (const key in params) {
       src.instance.state.schedule[key] = params[key];
     }
   };
 
   const updateSchedule = (payload) => {
+    if (payload?.src?.locked) return
     const { src, changedParameters } = payload;
     applyScheduleChanges(src, JSON.parse(JSON.stringify(changedParameters)));
   };

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -580,6 +580,11 @@ export default class AudioEngine {
         base: src.base,
         storageKey: src.storageKey,
         fileId: src.fileId,
+        locked: !!src.locked,
+        accessReason: src.accessReason,
+        requiredPlan: src.requiredPlan,
+        entitlementFeature: src.entitlementFeature,
+        canUpgrade: src.canUpgrade,
         name: src.name,
         audioPath: src.audioPath,
         instance: {
@@ -599,7 +604,7 @@ export default class AudioEngine {
           coneInner: src.state.coneInner,
           coneOuter: src.state.coneOuter,
         },
-        index: src.index,
+          index: src.index,
       })),
       masterVolume: this.masterVolume.value,
       reverb: {
@@ -619,7 +624,7 @@ export default class AudioEngine {
     let engine = null;
 
     if (Array.isArray(json.soundSources)) {
-     const uninitializedSoundSources = json.soundSources.map(src => {
+        const uninitializedSoundSources = json.soundSources.map(src => {
           const base = src.base ?? src.plan_tier ?? 'users'
           const storageKey = src.storageKey ?? (src.bucket && src.path ? buildStorageKey(base, src.bucket, src.path) : null)
           const fileId = src.fileId ?? src.libraryId ?? storageKey
@@ -637,6 +642,11 @@ export default class AudioEngine {
               base,
               storageKey,
               fileId,
+              locked: !!src.locked,
+              accessReason: src.accessReason,
+              requiredPlan: src.requiredPlan,
+              entitlementFeature: src.entitlementFeature,
+              canUpgrade: src.canUpgrade,
             }
           }
         })

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -211,11 +211,12 @@ export default class AudioEngine {
       return
     }
     const src = payload.src
-    
+
     src.index = payload.index ?? this.soundSources.value.length // for proper undo and redo
     const base = src.base ?? src.plan_tier ?? 'users'
     const storageKey = src.storageKey ?? (src.bucket && src.path ? buildStorageKey(base, src.bucket, src.path) : null)
     const fileId = src.fileId ?? src.libraryId ?? storageKey ?? src.audioPath ?? null
+    const isLocked = !!src.locked
 
     const instance = new SoundSource({
       audioContext: this.getAudioContext(),
@@ -236,6 +237,9 @@ export default class AudioEngine {
     this.connectToReverb(instance)
     instance.setRoom(this.#room)
 
+    src.locked = isLocked
+    instance.locked = isLocked
+
     src.instance = instance
     this.soundSources.value.splice(src.index, 0, src)
     // keep the stored indices aligned with the reactive array order
@@ -245,7 +249,14 @@ export default class AudioEngine {
     if (this.#audioContext?.state === 'suspended') {
       this.#audioContext.resume()
     }
-    
+
+    if (isLocked) {
+      const sched = instance.state.schedule
+      sched.paused = true
+      sched.enabled = false
+      return
+    }
+
     // Watch schedule changes to hook into the scheduler
     const sched = instance.state.schedule
     const enabledUnwatch = watch(
@@ -409,6 +420,11 @@ export default class AudioEngine {
       return
     }
 
+    if (src.locked || src.instance.locked) {
+      console.info('Sound source is locked for the current plan.')
+      return
+    }
+
     const schedId = src.instance.state.schedule.id
     if (this.#scheduler.pauseInfo.has(schedId) && this.#scheduler.pauseInfo.get(schedId).isPaused) {
       this.#scheduler.resumeSource(src.instance)
@@ -436,8 +452,9 @@ export default class AudioEngine {
     if (this.#audioContext?.state === 'suspended') {
       this.#audioContext.resume()
     }
-  
+
     this.soundSources.value.forEach(s => {
+      if (s.locked) return
       this.playSoundSource(s) // play each source
     })
     if (this.#scheduler.roomStartTime === null) {

--- a/src/utils/soundEntitlements.js
+++ b/src/utils/soundEntitlements.js
@@ -7,7 +7,8 @@ const PLAN_INDEX = PLANS.reduce((acc, plan, index) => {
 
 const SOUND_TIER_FEATURE = {
   basic: 'curatedPacks',
-  pro: 'allPacks'
+  pro: 'allPacks',
+  users: 'canUpload'
 }
 
 function normalizeSoundTier(rawTier) {
@@ -49,13 +50,16 @@ export function evaluateSoundAccess(sound, context = {}) {
   const ownerId = sound?.owner_id ?? null
   const currentUserId = context.userId ?? null
   const isOwner = Boolean(ownerId && currentUserId && ownerId === currentUserId)
+  const userCanUpload = Boolean(context.canUpload)
 
   let accessible = true
   let reason = null
 
   if (normalizedSoundTier === 'users') {
-    accessible = isOwner
-    reason = accessible ? null : 'ownership'
+    accessible = isOwner && userCanUpload
+    if (!accessible) {
+      reason = isOwner ? 'tier' : 'ownership'
+    }
   } else if (!isOwner) {
     const soundRank = getPlanRank(normalizedSoundTier)
     if (soundRank >= 0) {
@@ -65,7 +69,9 @@ export function evaluateSoundAccess(sound, context = {}) {
     }
   }
 
-  const requiredPlan = !accessible && reason === 'tier' ? normalizedSoundTier : null
+  const requiredPlan = !accessible && reason === 'tier'
+    ? (normalizedSoundTier === 'users' ? 'pro' : normalizedSoundTier)
+    : null
   const entitlementFeature = SOUND_TIER_FEATURE[normalizedSoundTier] ?? null
 
   return {

--- a/src/utils/uploadAudio.js
+++ b/src/utils/uploadAudio.js
@@ -32,7 +32,17 @@ function buildObjectKey(soundId, displayName) {
 async function getSignedUploadUrl(key, userId) {
   const params = new URLSearchParams({ key });
   if (userId) params.set('userId', userId);
-  const res = await fetch(buildApiUrl(`/api/get-upload-url?${params.toString()}`));
+  const accessToken = await getAccessToken();
+
+  if (!accessToken) {
+    throw new Error('You must be signed in to upload audio.');
+  }
+
+  const res = await fetch(buildApiUrl(`/api/get-upload-url?${params.toString()}`), {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
   if (!res.ok) {
     let message = 'Failed to get signed upload URL';
     const rawBody = await res.text().catch(() => '');


### PR DESCRIPTION
## Summary
- enforce sound entitlement evaluation for premium and user-uploaded sources during hydration and library browsing so downgraded plans mark them locked
- harden canvas controls, keyboard rotation, and context menu actions to allow only selection/deletion on locked emitters while preventing playback, duplication, and movement
- guard engine playback and action handlers so locked sources stay muted and unscheduled even when using play-all or schedule updates

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933f68b78f0832f94c6eac1f3b5cf1a)