### PR TITLE
Improve onboarding state handling and syncing

### DIFF
--- a/src/components/ui/context/Onboarding.vue
+++ b/src/components/ui/context/Onboarding.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { VTour } from '@globalhive/vuejs-tour';
-import { watch, ref, computed, h } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
+import { watch, ref, onMounted, onUnmounted } from 'vue';
+import { useRoute } from 'vue-router';
 import { useAudioCacheStore } from '@/stores/useAudioCacheStore';
 import { useAudioEngineStore } from '@/stores/useAudioEngineStore';
 import { storeToRefs } from 'pinia';
+import { useAuth } from '@/composables/useAuth';
 
 const { soundLibrarySources } = storeToRefs(useAudioCacheStore())
 const { audioEngine } = storeToRefs(useAudioEngineStore())
@@ -16,6 +17,32 @@ const props = defineProps({
 });
 
 const tourRunning = ref(false);
+const { markOnboardingCompletedInDb } = useAuth();
+const activeBackdropHandler = (event) => {
+  if (!tourRunning.value) return;
+  const backdropTarget = event.target?.closest?.('.vjt-backdrop');
+  if (!backdropTarget) return;
+
+  // FIX: Onboarding Cycle 2 – prevent backdrop clicks from leaking or advancing
+  event.preventDefault();
+  event.stopPropagation();
+  if (typeof event.stopImmediatePropagation === 'function') {
+    event.stopImmediatePropagation();
+  }
+};
+
+onMounted(() => {
+  document.addEventListener('click', activeBackdropHandler, true);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('click', activeBackdropHandler, true);
+
+  // FIX: Onboarding Cycle 1 – reset start flag when tour exits unexpectedly
+  if (localStorage.getItem('soundroom_onboarding_completed') !== 'true') {
+    localStorage.removeItem('soundroom_onboarding_started');
+  }
+});
 
 watch(() => props.startTour, (v) => {
   if (v) {
@@ -116,10 +143,14 @@ const steps = [
       const unwatch = watch(
         () => soundLibrarySources.value.length,
         async (val) => {
-        if (val === 0) return;
+          if (!tourRunning.value) {
+            unwatch();
+            return;
+          }
+          if (val === 0) return;
           unwatch();
           vTour.value.nextStep();
-          
+
         }
       );
     },
@@ -179,10 +210,14 @@ const steps = [
       const unwatch = watch(
         () => audioEngine.value.soundSources.value.length,
         async (val) => {
+          if (!tourRunning.value) {
+            unwatch();
+            return;
+          }
           if (val === 0) return;
           unwatch();
           vTour.value.nextStep();
-          
+
         }
       );
     },
@@ -242,8 +277,19 @@ function waitForDom(selector, attempts = 20) {
 function finishTour() {
   const btn = document.getElementById('add-source-btn');
   if (btn) btn.disabled = false;
-  vTour.value.endTour();
-  localStorage.setItem('soundroom_onboarding_completed', 'true');
+
+  const isFinalStep = (vTour.value?.currentStep ?? 0) >= steps.length - 1;
+  vTour.value?.endTour();
+
+  if (isFinalStep) {
+    localStorage.setItem('soundroom_onboarding_completed', 'true');
+    localStorage.removeItem('soundroom_onboarding_started');
+    markOnboardingCompletedInDb();
+  } else {
+    // FIX: Onboarding Cycle 1 – clear start flag when onboarding ends early
+    localStorage.removeItem('soundroom_onboarding_started');
+  }
+
   tourRunning.value = false;
 }
 

--- a/src/components/ui/context/Onboarding.vue
+++ b/src/components/ui/context/Onboarding.vue
@@ -48,6 +48,11 @@ watch(() => props.startTour, (v) => {
   if (v) {
     tourRunning.value = true;
     vTour.value.startTour();
+  } else if (tourRunning.value) {
+    // FIX: Onboarding Cycle 1 – stop tour when parent disables start flag
+    vTour.value?.endTour();
+    localStorage.removeItem('soundroom_onboarding_started');
+    tourRunning.value = false;
   }
 });
 // Your onboarding steps

--- a/src/composables/useAuth.js
+++ b/src/composables/useAuth.js
@@ -26,6 +26,10 @@ const CACHE_DURATION_MS = 1000 * 60 * 30 // 30 minutes
 
 const hasBillingHistory = ref(false)
 
+// FIX: Onboarding Cycle 3 – track DB onboarding state to sync with local storage
+const onboardingCompleted = ref(false)
+const onboardingStatusLoaded = ref(false)
+
 function writeTierToCache(newTier, billingHistory = hasBillingHistory.value) {
   const normalized = (newTier || 'free').toLowerCase()
   const normalizedBillingHistory = !!billingHistory
@@ -108,23 +112,39 @@ function primeBillingHistory(value) {
 }
 
 async function syncOnboardingStatus(userId) {
-  const localDone = localStorage.getItem('soundroom_onboarding_completed') === 'true'
-  if (!localDone) return
+  onboardingStatusLoaded.value = false
 
-  // Check DB
-  const { data } = await supabase
-    .from('users')
-    .select('onboarding_completed')
-    .eq('id', userId)
-    .maybeSingle()
+  if (!userId) {
+    onboardingCompleted.value = localStorage.getItem('soundroom_onboarding_completed') === 'true'
+    onboardingStatusLoaded.value = true
+    return
+  }
 
-  if (!data || data.onboarding_completed === true) return
+  try {
+    const { data, error } = await supabase
+      .from('users')
+      .select('onboarding_completed')
+      .eq('id', userId)
+      .maybeSingle()
 
-  // Update DB one time
-  await supabase
-    .from('users')
-    .update({ onboarding_completed: true })
-    .eq('id', userId)
+    if (error) throw error
+
+    const dbComplete = data?.onboarding_completed === true
+    onboardingCompleted.value = dbComplete
+
+    if (dbComplete) {
+      localStorage.setItem('soundroom_onboarding_completed', 'true')
+      localStorage.removeItem('soundroom_onboarding_started')
+    } else {
+      // FIX: Onboarding Cycle 3 – DB state overrides stale local flags
+      localStorage.removeItem('soundroom_onboarding_completed')
+      localStorage.removeItem('soundroom_onboarding_started')
+    }
+  } catch (error) {
+    console.warn('Failed to sync onboarding status', error)
+  } finally {
+    onboardingStatusLoaded.value = true
+  }
 }
 
 supabase.auth.getSession().then(async ({ data }) => {
@@ -134,6 +154,10 @@ supabase.auth.getSession().then(async ({ data }) => {
   if (user.value?.id) {
     refreshTier()
     syncOnboardingStatus(user.value.id)   // <-- ADD THIS TOO
+  } else {
+    // FIX: Onboarding Cycle 3 – ensure status is initialized for guests
+    onboardingCompleted.value = localStorage.getItem('soundroom_onboarding_completed') === 'true'
+    onboardingStatusLoaded.value = true
   }
 })
 
@@ -148,8 +172,26 @@ supabase.auth.onAuthStateChange(async (_event, session) => {
     syncOnboardingStatus(user.value.id)   // <-- ADD THIS
   } else {
     tier.value = 'free'
+    onboardingCompleted.value = localStorage.getItem('soundroom_onboarding_completed') === 'true'
+    onboardingStatusLoaded.value = true
   }
 })
+
+// FIX: Onboarding Cycle 3 – explicit DB completion helper for onboarding
+async function markOnboardingCompletedInDb() {
+  if (!user.value?.id) return
+
+  try {
+    await supabase
+      .from('users')
+      .update({ onboarding_completed: true })
+      .eq('id', user.value.id)
+
+    onboardingCompleted.value = true
+  } catch (error) {
+    console.warn('Failed to mark onboarding complete', error)
+  }
+}
 
 refreshTier(true) // Initial tier load
 
@@ -175,11 +217,14 @@ export function useAuth() {
     sessionLoaded: readonly(sessionLoaded),
     isAuthenticated: computed(() => !!user.value),
     tier: readonly(tier),
+    onboardingCompleted: readonly(onboardingCompleted),
+    onboardingStatusLoaded: readonly(onboardingStatusLoaded),
     hasBillingHistory: readonly(hasBillingHistory),
     getTier: getUserTier,
     refreshTier,
     primeTier,
     primeBillingHistory,
+    markOnboardingCompletedInDb,
     clearUser: () => {
       user.value = null
       tier.value = 'free'

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -84,7 +84,7 @@ import { watch } from 'vue';
 defineOptions({
   name: 'SoundRoomRoot',
 })
-import { ref, provide, onBeforeMount, onUnmounted, onMounted } from 'vue'
+import { ref, provide, onBeforeMount, onUnmounted, onMounted, computed } from 'vue'
 
 // Shared constants
 const SOUND_NODE_PART_NAME = 'sound-node-part'
@@ -177,7 +177,7 @@ setMaxLibSources(MAX_LIB_SOURCES)
 
 const showWelcomeOverlay = ref(false)
 const showInitOverlay = ref(false)
-const { user, isAuthenticated } = useAuth()
+const { user, isAuthenticated, onboardingCompleted, onboardingStatusLoaded } = useAuth()
 
 const preferenceDefaults = Object.freeze({
   autoResumePlayback: false,
@@ -273,6 +273,16 @@ onBeforeMount(async () => {
 })
 
 const startTour = ref(false);
+const onboardingStartQueued = ref(false)
+
+// FIX: Onboarding Cycle 1 – ensure start flag is cleared when tour halts prematurely
+function resetOnboardingStartFlag() {
+  localStorage.removeItem('soundroom_onboarding_started')
+}
+
+function onboardingIsCompleted() {
+  return onboardingCompleted.value || localStorage.getItem('soundroom_onboarding_completed') === 'true'
+}
 
 function waitForWelcome() {
   return new Promise((resolve) => {
@@ -296,6 +306,7 @@ onMounted(async() => {
 
       // If we are leaving *any* /app route (including children)
       if (!newPath.startsWith('/app')) {
+        resetOnboardingStartFlag()
         resetRoomState()
         audioEngine.value?.dispose()
         cacheStore.audioCacheManager.clearMemoryCache()
@@ -321,37 +332,66 @@ onMounted(async() => {
     },
     { immediate: true }
   )
-  
-   // If welcome overlay exists, wait for it
-      if (showWelcomeOverlay.value && !welcomeDone.value) {
-        await waitForWelcome()
+
+  // If welcome overlay exists, wait for it
+  if (showWelcomeOverlay.value && !welcomeDone.value) {
+    await waitForWelcome()
+  }
+
+  const onboardingStatusReady = computed(() => onboardingStatusLoaded.value || !isAuthenticated.value)
+
+  const evaluateOnboardingStart = () => {
+    if (!onboardingStatusReady.value) return
+    if (showWelcomeOverlay.value && !welcomeDone.value) return
+
+    if (route.path !== '/app') {
+      startTour.value = false
+      if (!onboardingIsCompleted()) {
+        resetOnboardingStartFlag()
       }
-
-  if (localStorage.getItem('soundroom_onboarding_completed') === 'true') return;
-  if (localStorage.getItem('soundroom_onboarding_started') === 'true') return;
-
-  if (route.path == '/app') {
-        startTour.value = true
-        localStorage.setItem('soundroom_onboarding_started', 'true');
-        return
-      }
-
-  const routeUnwatch = watch(
-    () => route.path,
-    async (newPath) => {
-
-      // Only start on /app
-      if (newPath !== '/app') {
-        startTour.value = false
-        return
-      }
-
-      // Now it's safe to start
-      localStorage.setItem('soundroom_onboarding_started', 'true');
-      startTour.value = true
-      routeUnwatch() // only run once
+      return
     }
+
+    if (onboardingIsCompleted()) {
+      resetOnboardingStartFlag()
+      startTour.value = false
+      return
+    }
+
+    if (showAudioResumeOverlay.value) {
+      onboardingStartQueued.value = true
+      startTour.value = false
+      return
+    }
+
+    onboardingStartQueued.value = false
+
+    if (localStorage.getItem('soundroom_onboarding_started') !== 'true') {
+      localStorage.setItem('soundroom_onboarding_started', 'true')
+    }
+
+    startTour.value = true
+  }
+
+  watch(
+    () => [route.path, onboardingStatusReady.value],
+    () => evaluateOnboardingStart(),
+    { immediate: true }
   )
+
+  watch(showAudioResumeOverlay, (visible) => {
+    if (!visible && onboardingStartQueued.value) {
+      evaluateOnboardingStart()
+    }
+  })
+
+  watch(onboardingCompleted, (val) => {
+    if (val) {
+      localStorage.setItem('soundroom_onboarding_completed', 'true')
+      resetOnboardingStartFlag()
+      startTour.value = false
+    }
+  })
 })
 
 

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -306,6 +306,8 @@ onMounted(async() => {
 
       // If we are leaving *any* /app route (including children)
       if (!newPath.startsWith('/app')) {
+        // FIX: Onboarding Cycle 1 – halt onboarding when leaving the app
+        startTour.value = false
         resetOnboardingStartFlag()
         resetRoomState()
         audioEngine.value?.dispose()

--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -346,7 +346,7 @@ onMounted(async() => {
     if (!onboardingStatusReady.value) return
     if (showWelcomeOverlay.value && !welcomeDone.value) return
 
-    if (route.path !== '/app') {
+    if (!route.path.startsWith('/app')) {
       startTour.value = false
       if (!onboardingIsCompleted()) {
         resetOnboardingStartFlag()


### PR DESCRIPTION
## Summary
- clear onboarding start flags on early exits and block backdrop clicks from advancing the tour
- sync onboarding completion from the database into local storage and expose helpers for completion updates
- defer onboarding start until audio resume overlays clear and watch state to prevent stray step advancement

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693527c098d4832fb039b9f6a4c20f47)