### PR TITLE
Refine onboarding status checks in SoundRoom view

### DIFF
--- a/src/views/SoundRoom.vue
+++ b/src/views/SoundRoom.vue
@@ -326,7 +326,28 @@ onMounted(async() => {
       showAudioResumeOverlay.value = false;
     }
 
-  if (localStorage.getItem('soundroom_onboarding_completed') === 'true') return;
+  let onboardingCompleted = localStorage.getItem('soundroom_onboarding_completed') === 'true'
+
+  if (!onboardingCompleted && isAuthenticated.value && user.value?.id) {
+    try {
+      const { data, error } = await supabase
+        .from('users')
+        .select('onboarding_completed')
+        .eq('id', user.value.id)
+        .maybeSingle()
+
+      if (error) throw error
+
+      onboardingCompleted = data?.onboarding_completed === true
+      if (onboardingCompleted) {
+        localStorage.setItem('soundroom_onboarding_completed', 'true')
+      }
+    } catch (err) {
+      console.warn('Failed to fetch onboarding status, falling back to local storage', err)
+    }
+  }
+
+  if (onboardingCompleted) return;
 
   if (route.path == '/app') {
     startTour.value = true


### PR DESCRIPTION
## Summary
- prioritize the local onboarding completion flag when deciding whether to show the tour
- fetch onboarding status from the authenticated user's record only when the local flag is missing
- cache a completed status from the database back into local storage to avoid repeat calls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935475c21d0832fb2f65d8798d71359)