### PR TITLE
Improve Sound Library metadata filtering and tag UX

### DIFF
--- a/src/components/ui/modals/SoundLibrary/CategoryList.vue
+++ b/src/components/ui/modals/SoundLibrary/CategoryList.vue
@@ -2,6 +2,13 @@
   <aside class="w-60 bg-surface-base text-text-primary border-r border-border-subtle p-4 space-y-3 overflow-y-auto">
     <h2 class="font-bold text-sm mb-2">Categories</h2>
     <BaseButton
+      :key="'all-sounds'"
+      @click="$emit('update:active', '')"
+      :class="['sound-lib-button', { active: !active }]"
+    >
+      All Sounds
+    </BaseButton>
+    <BaseButton
       v-if="isAuthenticated"
       :key="'your-sounds'"
       @click="handleSelectYourSounds"

--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -4,10 +4,10 @@
       <div class="flex items-start justify-between gap-4">
         <div class="flex-1 min-w-0">
           <h2 class="text-2xl font-bold">SoundLibrary</h2>
-          <div class="mt-3">
+          <div class="mt-3" v-if="activeCategory === ''"">
             <div class="flex items-center gap-2">
               <div class="relative flex-1">
-                <Search class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-muted pointer-events-none" />
+                <Search class="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-muted pointer-events-none" />
                 <input
                   v-model="searchQuery"
                   type="text"
@@ -123,7 +123,8 @@
         <BaseButton id="close-lib-btn" class="text-sm mt-1" @click="$emit('close')">Close</BaseButton>
       </div>
     </div>
-    <div ref="gridScroll" class="mt-5 place-content-start p-6 pt-52 overflow-y-auto h-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+    <div ref="gridScroll" class="mt-5 place-content-start p-6 overflow-y-auto h-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4"
+    :style="{'paddingTop': activeCategory === '' ? '8.75rem' : '6rem'}">
       <SoundGridItem
         v-for="sound in visibleSounds"
         :key="sound.libraryId || sound.id"
@@ -199,8 +200,8 @@ const props = defineProps({
 
 const emit = defineEmits(['close', 'toggleSound', 'updateCurrent', 'upload', 'delete', 'locked', 'update:activeCategory'])
 
-const INITIAL_VISIBLE_LIMIT = 50
-const VISIBLE_STEP = 50
+const INITIAL_VISIBLE_LIMIT = 10
+const VISIBLE_STEP = 10
 const TAG_SUGGESTION_LIMIT = 10
 
 const categoryOptions = [
@@ -308,6 +309,7 @@ const hasActiveFilters = computed(() => {
 watch([searchQuery, activeCategory, selectedTags], () => {
   visibleLimit.value = INITIAL_VISIBLE_LIMIT
   showAllTags.value = false
+  activeCategory.value !== '' ? clearSearch() : null;
 }, { deep: true })
 
 function setCategory(categoryId) {

--- a/src/components/ui/modals/SoundLibrary/SoundGrid.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundGrid.vue
@@ -11,15 +11,15 @@
                 <input
                   v-model="searchQuery"
                   type="text"
-                  placeholder="Search sounds"
+                  placeholder="Search sounds, tags, categories"
                   class="w-full rounded-full border border-border-subtle bg-surface-base py-2 pl-9 pr-9 text-sm text-text-primary placeholder:text-text-muted outline-none focus:border-border-strong"
                 >
                 <button
-                  v-if="hasActiveFilters"
+                  v-if="searchQuery.trim()"
                   type="button"
                   class="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1 text-text-muted hover:text-text-primary"
-                  aria-label="Clear search and category filter"
-                  @click="clearFilters"
+                  aria-label="Clear search"
+                  @click="clearSearch"
                 >
                   <X class="h-4 w-4" />
                 </button>
@@ -27,33 +27,103 @@
               <button
                 type="button"
                 class="inline-flex items-center justify-center rounded-full border border-border-subtle bg-surface-base p-2 text-text-muted hover:text-text-primary"
-                :class="{ 'text-text-primary border-border-strong': isCategoryFilterOpen }"
-                aria-label="Toggle category filters"
-                @click="isCategoryFilterOpen = !isCategoryFilterOpen"
+                :class="{ 'text-text-primary border-border-strong': showTagFilters }"
+                aria-label="Toggle filters"
+                @click="showTagFilters = !showTagFilters"
               >
                 <SlidersHorizontal class="h-4 w-4" />
               </button>
-            </div>
-            <div v-if="isCategoryFilterOpen" class="mt-2 flex flex-wrap gap-2">
               <button
-                v-for="category in categories"
-                :key="category"
+                v-if="hasActiveFilters"
                 type="button"
-                class="rounded-full border border-border-subtle px-3 py-1 text-xs text-text-muted hover:text-text-primary"
-                :class="{
-                  'bg-[color-mix(in_srgb,var(--color-accent)_20%,transparent)] text-text-primary border-border-strong': selectedCategory === category
-                }"
-                @click="toggleCategory(category)"
+                class="rounded-full border border-border-subtle bg-surface-base px-3 py-2 text-xs text-text-muted hover:text-text-primary"
+                @click="clearAllFilters"
               >
-                {{ category }}
+                Clear all
               </button>
+            </div>
+
+            <div v-if="showTagFilters" class="mt-3 space-y-3">
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="text-xs uppercase tracking-wide text-text-muted">Category</span>
+                <button
+                  type="button"
+                  class="rounded-full border border-border-subtle px-3 py-1 text-xs"
+                  :class="!activeCategory ? 'text-text-primary border-border-strong' : 'text-text-muted hover:text-text-primary'"
+                  @click="setCategory('')"
+                >
+                  All
+                </button>
+                <button
+                  v-for="category in categoryOptions"
+                  :key="category.id"
+                  type="button"
+                  class="rounded-full border border-border-subtle px-3 py-1 text-xs"
+                  :class="activeCategory === category.id ? 'bg-[color-mix(in_srgb,var(--color-accent)_20%,transparent)] text-text-primary border-border-strong' : 'text-text-muted hover:text-text-primary'"
+                  @click="setCategory(category.id)"
+                >
+                  {{ category.label }}
+                </button>
+                <button
+                  v-if="activeCategory"
+                  type="button"
+                  class="text-xs text-text-muted hover:text-text-primary underline"
+                  @click="setCategory('')"
+                >
+                  Clear category
+                </button>
+              </div>
+
+              <div class="space-y-2">
+                <div v-if="selectedTags.length" class="flex flex-wrap items-center gap-2">
+                  <span class="text-xs uppercase tracking-wide text-text-muted">Selected</span>
+                  <button
+                    v-for="tag in selectedTags"
+                    :key="`selected-${tag}`"
+                    type="button"
+                    class="rounded-full border border-border-strong bg-[color-mix(in_srgb,var(--color-accent)_20%,transparent)] px-3 py-1 text-xs text-text-primary"
+                    @click="toggleTag(tag)"
+                  >
+                    {{ tag }}
+                  </button>
+                  <button
+                    type="button"
+                    class="text-xs text-text-muted hover:text-text-primary underline"
+                    @click="clearTags"
+                  >
+                    Clear tags
+                  </button>
+                </div>
+
+                <div class="flex flex-wrap items-center gap-2">
+                  <span class="text-xs uppercase tracking-wide text-text-muted">Suggested tags</span>
+                  <button
+                    v-for="tag in visibleTagSuggestions"
+                    :key="tag"
+                    type="button"
+                    class="rounded-full border border-border-subtle px-3 py-1 text-xs text-text-muted hover:text-text-primary"
+                    :class="selectedTags.includes(tag) ? 'bg-[color-mix(in_srgb,var(--color-accent)_20%,transparent)] text-text-primary border-border-strong' : ''"
+                    @click="toggleTag(tag)"
+                  >
+                    {{ tag }}
+                  </button>
+                  <button
+                    v-if="contextTagSuggestions.length > TAG_SUGGESTION_LIMIT"
+                    type="button"
+                    class="text-xs text-text-muted hover:text-text-primary underline"
+                    @click="showAllTags = !showAllTags"
+                  >
+                    {{ showAllTags ? 'Less tags' : `More tags (${contextTagSuggestions.length - TAG_SUGGESTION_LIMIT})` }}
+                  </button>
+                </div>
+              </div>
             </div>
           </div>
         </div>
         <BaseButton id="close-lib-btn" class="text-sm mt-1" @click="$emit('close')">Close</BaseButton>
       </div>
     </div>
-    <div ref="gridScroll" class="mt-5 place-content-start p-6 pt-44 overflow-y-auto h-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+    <div ref="gridScroll" class="mt-5 place-content-start p-6 pt-52 overflow-y-auto h-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
       <SoundGridItem
         v-for="sound in visibleSounds"
         :key="sound.libraryId || sound.id"
@@ -65,6 +135,15 @@
         @delete="$emit('delete', $event)"
         @locked="$emit('locked', $event)"
       />
+
+      <template v-if="!visibleSounds.length && !waiting">
+        <div class="col-span-full text-center text-text-muted mt-20">
+          <div class="text-lg font-semibold mb-2">No sounds match these filters.</div>
+          <button type="button" class="text-sm underline hover:text-text-primary" @click="clearAllFilters">
+            Clear filters
+          </button>
+        </div>
+      </template>
 
       <div v-if="showLoadMore" class="col-span-full flex justify-center pt-2">
         <BaseButton class="text-xs px-3 py-1" @click="loadMoreSounds">
@@ -118,57 +197,144 @@ const props = defineProps({
   activeCategory: String
 })
 
+const emit = defineEmits(['close', 'toggleSound', 'updateCurrent', 'upload', 'delete', 'locked', 'update:activeCategory'])
+
 const INITIAL_VISIBLE_LIMIT = 50
 const VISIBLE_STEP = 50
+const TAG_SUGGESTION_LIMIT = 10
 
-const categories = ['Nature', 'Human', 'Musical', 'Work/Focus', 'Atmospheric', 'Misc']
+const categoryOptions = [
+  { id: 'nature', label: 'Nature' },
+  { id: 'human', label: 'Human' },
+  { id: 'musical', label: 'Musical' },
+  { id: 'tools', label: 'Work/Focus' },
+  { id: 'atmospheric', label: 'Atmospheric' },
+  { id: 'misc', label: 'Misc' }
+]
+
 const searchQuery = ref('')
-const isCategoryFilterOpen = ref(false)
-const selectedCategory = ref('')
+const showTagFilters = ref(false)
+const selectedTags = ref([])
+const showAllTags = ref(false)
 const visibleLimit = ref(INITIAL_VISIBLE_LIMIT)
 
-const filteredSounds = computed(() => {
-  const normalizedSearch = searchQuery.value.trim().toLowerCase()
+const activeCategory = computed(() => props.activeCategory || '')
 
+const normalizedSounds = computed(() => {
   const soundList = Array.isArray(props.sounds) ? props.sounds : []
+  return soundList.map((sound) => {
+    const tags = Array.isArray(sound.tags)
+      ? sound.tags.map((tag) => String(tag).trim()).filter(Boolean)
+      : typeof sound.tags === 'string'
+        ? sound.tags.split(',').map((tag) => tag.trim()).filter(Boolean)
+        : []
 
-  if (!normalizedSearch && !selectedCategory.value) {
-    return soundList
+    return {
+      ...sound,
+      tags
+    }
+  })
+})
+
+const searchMatchedSounds = computed(() => {
+  const query = searchQuery.value.trim().toLowerCase()
+  if (!query) return normalizedSounds.value
+
+  return normalizedSounds.value.filter((sound) => {
+    const tagsText = sound.tags.join(' ').toLowerCase()
+    const categoryText = String(sound.category || sound.bucket || '').toLowerCase()
+    const descriptionText = String(sound.description || '').toLowerCase()
+    const nameText = String(sound.name || '').toLowerCase()
+
+    return (
+      nameText.includes(query) ||
+      tagsText.includes(query) ||
+      categoryText.includes(query) ||
+      descriptionText.includes(query)
+    )
+  })
+})
+
+const categoryFilteredSounds = computed(() => {
+  if (!activeCategory.value || activeCategory.value === 'your-sounds') {
+    return searchMatchedSounds.value
   }
 
-  return soundList.filter((sound) => {
-    const matchesCategory = !selectedCategory.value || sound.category === selectedCategory.value
-
-    if (!normalizedSearch) {
-      return matchesCategory
-    }
-
-    const tags = Array.isArray(sound.tags) ? sound.tags.join(' ').toLowerCase() : ''
-    const matchesSearch =
-      sound.name?.toLowerCase().includes(normalizedSearch) ||
-      sound.category?.toLowerCase().includes(normalizedSearch) ||
-      tags.includes(normalizedSearch)
-
-    return matchesCategory && matchesSearch
+  return searchMatchedSounds.value.filter((sound) => {
+    const soundCategory = String(sound.category || sound.bucket || '').toLowerCase()
+    return soundCategory === activeCategory.value
   })
+})
+
+const contextTagSuggestions = computed(() => {
+  const counts = new Map()
+  for (const sound of categoryFilteredSounds.value) {
+    for (const tag of sound.tags) {
+      counts.set(tag, (counts.get(tag) || 0) + 1)
+    }
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([tag]) => tag)
+})
+
+const filteredSounds = computed(() => {
+  if (!selectedTags.value.length) {
+    return categoryFilteredSounds.value
+  }
+
+  return categoryFilteredSounds.value.filter((sound) =>
+    selectedTags.value.every((tag) => sound.tags.includes(tag))
+  )
 })
 
 const visibleSounds = computed(() => filteredSounds.value.slice(0, visibleLimit.value))
 const remainingSoundsCount = computed(() => Math.max(filteredSounds.value.length - visibleSounds.value.length, 0))
 const showLoadMore = computed(() => remainingSoundsCount.value > 0)
-const hasActiveFilters = computed(() => Boolean(searchQuery.value.trim()) || Boolean(selectedCategory.value))
 
-watch([searchQuery, selectedCategory, () => props.activeCategory], () => {
-  visibleLimit.value = INITIAL_VISIBLE_LIMIT
+const visibleTagSuggestions = computed(() => {
+  const suggestions = contextTagSuggestions.value.filter((tag) => !selectedTags.value.includes(tag))
+  if (showAllTags.value) {
+    return suggestions
+  }
+  return suggestions.slice(0, TAG_SUGGESTION_LIMIT)
 })
 
-function toggleCategory(category) {
-  selectedCategory.value = selectedCategory.value === category ? '' : category
+const hasActiveFilters = computed(() => {
+  return Boolean(searchQuery.value.trim()) || Boolean(activeCategory.value) || selectedTags.value.length > 0
+})
+
+watch([searchQuery, activeCategory, selectedTags], () => {
+  visibleLimit.value = INITIAL_VISIBLE_LIMIT
+  showAllTags.value = false
+}, { deep: true })
+
+function setCategory(categoryId) {
+  emit('update:activeCategory', categoryId)
 }
 
-function clearFilters() {
+function toggleTag(tag) {
+  if (!tag) return
+  if (selectedTags.value.includes(tag)) {
+    selectedTags.value = selectedTags.value.filter((t) => t !== tag)
+    return
+  }
+  selectedTags.value = [...selectedTags.value, tag]
+}
+
+function clearSearch() {
   searchQuery.value = ''
-  selectedCategory.value = ''
+}
+
+function clearTags() {
+  selectedTags.value = []
+}
+
+function clearAllFilters() {
+  clearSearch()
+  clearTags()
+  setCategory('')
 }
 
 function loadMoreSounds() {
@@ -177,7 +343,6 @@ function loadMoreSounds() {
 
 const { isAuthenticated } = useAuth()
 const { canAccess, requireEntitlement } = useEntitlements()
-const emit = defineEmits(['close', 'toggleSound', 'updateCurrent', 'upload', 'delete', 'locked'])
 
 const gridScroll = ref(null)
 function scrollTop() {

--- a/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
@@ -213,7 +213,7 @@ async function ensureCategorySoundsLoaded() {
   const categoryIds = categories.map(({ id }) => id)
   const { data, error } = await supabase
     .from('sound_files')
-    .select('id, name, bucket, tags, description, path, preview_url, duration_seconds, preview_duration_seconds, owner_id, plan_tier, required_plan, base')
+    .select('id, name, bucket, tags, path, preview_url, duration_seconds, size, mime_type, owner_id, plan_tier, created_at, cone_inner, cone_outer')
     .in('bucket', categoryIds)
 
   if (error) {
@@ -259,7 +259,7 @@ async function listUserSounds() {
 
   const { data, error } = await supabase
     .from('sound_files')
-    .select('id, name, bucket, tags, description, path, preview_url, duration_seconds, preview_duration_seconds, owner_id, plan_tier, required_plan, base')
+    .select('id, name, bucket, tags, path, preview_url, duration_seconds, size, mime_type, owner_id, plan_tier, created_at, cone_inner, cone_outer')
     .eq('owner_id', userId)
   if (error) {
     console.error('Failed to list user sounds:', error)

--- a/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
@@ -23,6 +23,7 @@
         @upload="showUploadPanel = true"
         @delete="promptDeleteSound"
         @locked="handleLockedSound"
+        @update:activeCategory="val => activeCategory = val"
       />
      
     </div>
@@ -127,7 +128,7 @@ function handleLockedSound(sound) {
   })
 }
 
-const activeCategory = ref(categories?.[0]?.id || '')
+const activeCategory = ref('')
 const gridRef = ref(null) // ref to SoundGrid component
 const rawSounds = ref([])
 const categorySoundCache = ref([])
@@ -153,7 +154,9 @@ watch(
     }
 
     await ensureCategorySoundsLoaded()
-    const cachedCategorySounds = categorySoundCache.value.filter((sound) => sound.bucket === newCategory)
+    const cachedCategorySounds = newCategory
+      ? categorySoundCache.value.filter((sound) => sound.bucket === newCategory)
+      : categorySoundCache.value
     rawSounds.value = mapLibraryRows(cachedCategorySounds)
   },
   { immediate: true }
@@ -210,7 +213,7 @@ async function ensureCategorySoundsLoaded() {
   const categoryIds = categories.map(({ id }) => id)
   const { data, error } = await supabase
     .from('sound_files')
-    .select()
+    .select('id, name, bucket, category, tags, description, path, preview_url, duration_seconds, preview_duration_seconds, owner_id, plan_tier, required_plan, base')
     .in('bucket', categoryIds)
 
   if (error) {
@@ -223,9 +226,25 @@ async function ensureCategorySoundsLoaded() {
   hasFetchedCategorySounds.value = true
 }
 
+function normalizeTags(rawTags) {
+  if (Array.isArray(rawTags)) {
+    return rawTags.map((tag) => String(tag).trim()).filter(Boolean)
+  }
+
+  if (typeof rawTags === 'string') {
+    return rawTags
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean)
+  }
+
+  return []
+}
+
 function mapLibraryRows(rows = []) {
-  return rows.map(({ id, ...rest }) => ({
+  return rows.map(({ id, tags, ...rest }) => ({
     libraryId: id,
+    tags: normalizeTags(tags),
     ...rest
   }))
 }
@@ -240,7 +259,7 @@ async function listUserSounds() {
 
   const { data, error } = await supabase
     .from('sound_files')
-    .select()
+    .select('id, name, bucket, category, tags, description, path, preview_url, duration_seconds, preview_duration_seconds, owner_id, plan_tier, required_plan, base')
     .eq('owner_id', userId)
   if (error) {
     console.error('Failed to list user sounds:', error)

--- a/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundLibrary.vue
@@ -213,7 +213,7 @@ async function ensureCategorySoundsLoaded() {
   const categoryIds = categories.map(({ id }) => id)
   const { data, error } = await supabase
     .from('sound_files')
-    .select('id, name, bucket, category, tags, description, path, preview_url, duration_seconds, preview_duration_seconds, owner_id, plan_tier, required_plan, base')
+    .select('id, name, bucket, tags, description, path, preview_url, duration_seconds, preview_duration_seconds, owner_id, plan_tier, required_plan, base')
     .in('bucket', categoryIds)
 
   if (error) {
@@ -259,7 +259,7 @@ async function listUserSounds() {
 
   const { data, error } = await supabase
     .from('sound_files')
-    .select('id, name, bucket, category, tags, description, path, preview_url, duration_seconds, preview_duration_seconds, owner_id, plan_tier, required_plan, base')
+    .select('id, name, bucket, tags, description, path, preview_url, duration_seconds, preview_duration_seconds, owner_id, plan_tier, required_plan, base')
     .eq('owner_id', userId)
   if (error) {
     console.error('Failed to list user sounds:', error)

--- a/src/components/ui/modals/SoundLibrary/SoundPreviewCircle.vue
+++ b/src/components/ui/modals/SoundLibrary/SoundPreviewCircle.vue
@@ -25,7 +25,7 @@
     </svg>
 
     <!-- Icon -->
-    <div class="z-10 flex items-center justify-center">
+    <div class="flex items-center justify-center">
       <svg v-if="!isPlaying" class="w-4 h-4 text-current" fill="currentColor" viewBox="0 0 16 16">
         <path d="M4.5 3.5v9l7-4.5-7-4.5z" />
       </svg>


### PR DESCRIPTION
### Motivation
- Search was unintentionally scoped to the currently selected category and tags were not treated as independent filters, preventing useful cross-category searches. 
- Tags needed to come from stored sound metadata and be used client-side so filtering is fast and does not refetch on every interaction. 
- The UI needed a compact, contextual tag UX (suggestions + selected row) instead of rendering a giant wall of tags.

### Description
- Updated category loading so `activeCategory` defaults to empty (global) and added an `All Sounds` option to make category filtering optional, with cached category metadata used as the global dataset.  
- Made Supabase queries explicit to include `tags` and `description` (lightweight metadata) and normalized DB `tags` into a `string[]` with `normalizeTags` so every `sound.tags` is an array.  
- Refactored `SoundGrid.vue` filtering pipeline to compute `normalizedSounds` → `searchMatchedSounds` → `categoryFilteredSounds` → `filteredSounds` (applies selected tags with AND/`every` logic) → `visibleSounds`, preserving the `visibleLimit` and `load more` behavior and resetting `visibleLimit` on filter changes.  
- Implemented compact tag UI in `SoundGrid.vue` with a `Selected` row, contextual `Suggested tags` (derived from the current search/category context), a capped initial suggestion list (`TAG_SUGGESTION_LIMIT = 10`) with a `More tags` toggle, and clear controls for search/category/tags/all; added an empty-state that offers `Clear filters`.

### Testing
- Attempted `npm run build` to validate the changes, but the build failed in this environment due to a missing Vite plugin dependency (`@sentry/vite-plugin`), so a full production build could not be completed.  
- No additional automated tests were present or run; behavior is implemented with computed pipelines and watch handlers so runtime QA (dev server/manual) is recommended to verify UX and that no playback/room behavior is impacted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0fcb44f80832f9f7ebff5288ba4fc)