### PR TITLE
Refactor CORS handling to use dynamic origin resolution and buildCorsHeaders util

### DIFF
--- a/api/_utils/http.js
+++ b/api/_utils/http.js
@@ -1,18 +1,43 @@
-export const ALLOWED_ORIGIN = process.env.NODE_ENV === 'production' ? 'https://soundroom.live' : '*'
-
 export const corsHeaders = {
-  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
+  'Access-Control-Allow-Origin': 'https://soundroom.live',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Content-Type, Stripe-Signature, Authorization',
   'Access-Control-Allow-Credentials': 'true',
+  Vary: 'Origin',
 }
 
-export function jsonResponse(body, init = {}) {
+const STATIC_ALLOWED_ORIGINS = new Set([
+  'https://soundroom.live',
+  'http://localhost:5173',
+])
+
+function isAllowedOrigin(origin = '') {
+  if (!origin) return false
+  if (STATIC_ALLOWED_ORIGINS.has(origin)) return true
+  return /^https:\/\/[a-z0-9-]+\.vercel\.app$/i.test(origin)
+}
+
+export function resolveAllowedOrigin(request) {
+  const origin = request?.headers?.get?.('origin') || ''
+  return isAllowedOrigin(origin) ? origin : 'https://soundroom.live'
+}
+
+export function buildCorsHeaders(request, methods = 'POST, OPTIONS') {
+  return {
+    'Access-Control-Allow-Origin': resolveAllowedOrigin(request),
+    'Access-Control-Allow-Methods': methods,
+    'Access-Control-Allow-Headers': 'Content-Type, Stripe-Signature, Authorization',
+    'Access-Control-Allow-Credentials': 'true',
+    Vary: 'Origin',
+  }
+}
+
+export function jsonResponse(body, init = {}, request = null) {
   return new Response(JSON.stringify(body), {
     ...init,
     headers: {
       'Content-Type': 'application/json',
-      ...corsHeaders,
+      ...buildCorsHeaders(request),
       ...(init.headers || {}),
     },
   })

--- a/api/delete-file.js
+++ b/api/delete-file.js
@@ -2,21 +2,13 @@ import { AwsClient } from 'aws4fetch'
 import { supabaseAdmin } from './_utils/serverClients.js'
 import { authenticateRequest, resolveUserAccessContext } from './_utils/auth.js'
 import { HttpError } from './_utils/errors.js'
+import { buildCorsHeaders } from './_utils/http.js'
 
-const ALLOWED_ORIGIN =
-  process.env.NODE_ENV === 'production' ? 'https://soundroom.live' : '*'
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
-  'Access-Control-Allow-Methods': 'DELETE, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-  'Access-Control-Allow-Credentials': 'true',
-}
-
-export function OPTIONS() {
+export function OPTIONS(request) {
   return new Response(null, {
     status: 204,
-    headers: corsHeaders,
+    headers: buildCorsHeaders(request, 'DELETE, OPTIONS'),
   })
 }
 
@@ -92,20 +84,20 @@ export async function DELETE(request) {
 
     return new Response(JSON.stringify({ success: true }), {
       status: 200,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      headers: { ...buildCorsHeaders(request, 'DELETE, OPTIONS'), 'Content-Type': 'application/json' },
     })
   } catch (error) {
     if (error instanceof HttpError) {
       return new Response(JSON.stringify({ error: error.message }), {
         status: error.status,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        headers: { ...buildCorsHeaders(request, 'DELETE, OPTIONS'), 'Content-Type': 'application/json' },
       })
     }
 
     console.error('💥 DELETE ERROR:', error)
     return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
       status: 500,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      headers: { ...buildCorsHeaders(request, 'DELETE, OPTIONS'), 'Content-Type': 'application/json' },
     })
   }
 }

--- a/api/get-signed-url.js
+++ b/api/get-signed-url.js
@@ -2,22 +2,14 @@ import { AwsClient } from 'aws4fetch'
 import { supabaseAdmin } from './_utils/serverClients.js'
 import { authenticateRequest, resolveUserAccessContext } from './_utils/auth.js'
 import { HttpError } from './_utils/errors.js'
+import { buildCorsHeaders } from './_utils/http.js'
 import { hasPlanAccess, resolveRequiredPlan } from './_utils/entitlements.js'
 
-const ALLOWED_ORIGIN =
-  process.env.NODE_ENV === 'production' ? 'https://soundroom.live' : '*'
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
-  'Access-Control-Allow-Methods': 'GET, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-  'Access-Control-Allow-Credentials': 'true',
-}
-
-export function OPTIONS() {
+export function OPTIONS(request) {
   return new Response(null, {
     status: 204,
-    headers: corsHeaders,
+    headers: buildCorsHeaders(request, 'GET, OPTIONS'),
   })
 }
 
@@ -108,7 +100,7 @@ export async function GET(request) {
     return new Response(JSON.stringify({ signedUrl: signed.url }), {
       status: 200,
       headers: {
-        ...corsHeaders,
+        ...buildCorsHeaders(request, 'GET, OPTIONS'),
         'Content-Type': 'application/json',
       },
     })
@@ -117,7 +109,7 @@ export async function GET(request) {
       return new Response(JSON.stringify({ error: error.message }), {
         status: error.status,
         headers: {
-          ...corsHeaders,
+          ...buildCorsHeaders(request, 'GET, OPTIONS'),
           'Content-Type': 'application/json',
         },
       })
@@ -127,7 +119,7 @@ export async function GET(request) {
     return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
       status: 500,
       headers: {
-        ...corsHeaders,
+        ...buildCorsHeaders(request, 'GET, OPTIONS'),
         'Content-Type': 'application/json',
       },
     })

--- a/api/get-upload-url.js
+++ b/api/get-upload-url.js
@@ -3,6 +3,7 @@ import { randomBytes, randomUUID } from "node:crypto";
 import { AwsClient } from "aws4fetch";
 import { authenticateRequest, resolveUserAccessContext } from './_utils/auth.js'
 import { HttpError } from './_utils/errors.js'
+import { buildCorsHeaders } from './_utils/http.js'
 
 function createRandomId() {
   if (typeof randomUUID === "function") {
@@ -65,20 +66,11 @@ function getR2Config() {
   return env;
 }
 
-const ALLOWED_ORIGIN =
-  process.env.NODE_ENV === "production" ? "https://soundroom.live" : "*";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": ALLOWED_ORIGIN,
-  "Access-Control-Allow-Methods": "GET, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization",
-  "Access-Control-Allow-Credentials": "true",
-};
-
-export function OPTIONS() {
+export function OPTIONS(request) {
   return new Response(null, {
     status: 204,
-    headers: corsHeaders,
+    headers: buildCorsHeaders(request, 'GET, OPTIONS'),
   });
 }
 
@@ -102,7 +94,7 @@ export async function GET(request) {
         {
           status: 500,
           headers: {
-            ...corsHeaders,
+            ...buildCorsHeaders(request, 'GET, OPTIONS'),
             "Content-Type": "application/json",
           },
         }
@@ -136,7 +128,7 @@ export async function GET(request) {
       {
         status: 200,
         headers: {
-          ...corsHeaders,
+          ...buildCorsHeaders(request, 'GET, OPTIONS'),
           "Content-Type": "application/json",
         },
       }
@@ -148,7 +140,7 @@ export async function GET(request) {
         {
           status: error.status,
           headers: {
-            ...corsHeaders,
+            ...buildCorsHeaders(request, 'GET, OPTIONS'),
             "Content-Type": "application/json",
           },
         }
@@ -161,7 +153,7 @@ export async function GET(request) {
       {
         status: 500,
         headers: {
-          ...corsHeaders,
+          ...buildCorsHeaders(request, 'GET, OPTIONS'),
           "Content-Type": "application/json",
         },
       }


### PR DESCRIPTION
### Motivation
- Centralize and improve CORS handling to allow dynamic origins (including Vercel preview subdomains and localhost) while keeping a secure default.
- Ensure all API routes return the correct `Vary: Origin` header and method-specific CORS headers.
- Make JSON responses use the same origin resolution logic so client requests get appropriate CORS values.

### Description
- Added `STATIC_ALLOWED_ORIGINS`, `isAllowedOrigin`, `resolveAllowedOrigin(request)`, and `buildCorsHeaders(request, methods)` to `api/_utils/http.js`, and replaced the previous static `corsHeaders` and `ALLOWED_ORIGIN` logic.
- Updated `jsonResponse` signature to `jsonResponse(body, init = {}, request = null)` and wired it to use `buildCorsHeaders(request)` for consistent CORS headers and `Vary: Origin`.
- Updated endpoints (`delete-file.js`, `get-signed-url.js`, `get-upload-url.js`) to accept `request` in their `OPTIONS` handlers and to use `buildCorsHeaders(request, ...)` for successful and error responses.

### Testing
- Ran the project's automated test suite and linting checks, and they passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ad522f44832f8fa5ba359f13ba81)