### PR TITLE
Clear audio runtime on room load/delete and stop orphan playback on sign-out

### DIFF
--- a/src/composables/useSaveAndLoadRoom.js
+++ b/src/composables/useSaveAndLoadRoom.js
@@ -50,6 +50,14 @@ export function useSaveAndLoadRoom() {
   const { soundLibrarySources } = storeToRefs(cacheStore);
   const { requireWithinLimit, canAccess } = useEntitlements()
 
+  function clearAudioRuntime() {
+    try {
+      audioEngine.value?.dispose?.()
+    } catch (error) {
+      console.warn('Failed to clear previous audio runtime before room transition:', error)
+    }
+  }
+
   /**
    * Persist the current room to Supabase. Handles insert or update logic
    * depending on whether the room already has an id.
@@ -225,6 +233,7 @@ export function useSaveAndLoadRoom() {
    */
   async function loadRoom(roomId=null) {
     isLoadingRoom.value = true;
+    clearAudioRuntime()
     // get room data from supabase
     const { data, error } = await getRoomDataById(roomId);
     if (!data) {
@@ -349,6 +358,10 @@ export function useSaveAndLoadRoom() {
    * @returns {Promise<boolean>} true if deletion succeeded
    */
   async function deleteRoom(roomId) {
+    if (String(room.value?.id ?? '') === String(roomId ?? '')) {
+      clearAudioRuntime()
+      resetRoomState()
+    }
 
     const { error, statusText } = await supabase
       .from("rooms")
@@ -428,6 +441,7 @@ export function useSaveAndLoadRoom() {
    */
   async function loadRoomLocal() {
     isLoadingRoom.value = true;
+    clearAudioRuntime()
     const stored = localStorage.getItem("tempSoundRoomData");
     if (!stored) {
       console.warn("No room data found in local storage.");

--- a/src/lib/AudioEngine.js
+++ b/src/lib/AudioEngine.js
@@ -505,6 +505,11 @@ export default class AudioEngine {
   dispose() {
     // Tear down all nodes and close the audio context entirely.
     this.pauseAll()
+    this.#scheduler.stop()
+    this.#scheduleWatchers.forEach((unwatchers) => {
+      unwatchers.forEach(stop => stop?.())
+    })
+    this.#scheduleWatchers.clear()
     this.soundSources.value.forEach(s => s.instance.dispose())
     this.soundSources.value.length = 0
  
@@ -539,6 +544,7 @@ export default class AudioEngine {
     }
 
     this.#currentIRName = null
+    this.#uninitializedSoundSources = []
   }
 
   /**

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -241,6 +241,7 @@ import BaseInput from '@/components/ui/input/BaseInput.vue'
 import ThemeSelector from '@/components/Settings/ThemeSelector.vue'
 import { useAuth } from '@/composables/useAuth'
 import { supabase } from '@/utils/supabase'
+import { resetRoomState } from '@/utils/resetRoomState'
 
 const router = useRouter()
 const route = useRoute()
@@ -609,6 +610,7 @@ async function saveProfile() {
 async function signOutCurrentSession() {
   securityMessage.value = ''
   securityError.value = ''
+  resetRoomState()
 
   const { error } = await supabase.auth.signOut()
   if (error) {


### PR DESCRIPTION
### Motivation
- Prevent orphaned audio continuing to play after switching/opening a different room while preserving the editor/draft state when navigating to Settings. 
- The audio runtime (Web Audio context, scheduler timers, and source nodes) was not consistently torn down during room identity transitions, causing playback to survive and become uncontrollable. 
- Make audio-runtime teardown an explicit, audio-only operation so Settings navigation continues to preserve unsaved editor state.

### Description
- Added a `clearAudioRuntime()` helper in `src/composables/useSaveAndLoadRoom.js` and call it at the start of `loadRoom()` and `loadRoomLocal()`, and when deleting the currently-open room to ensure prior-room audio is disposed before loading a new room. 
- Hardened `AudioEngine.dispose()` in `src/lib/AudioEngine.js` to call `#scheduler.stop()`, clear schedule watchers, and reset `#uninitializedSoundSources` before disposing sources and closing the `AudioContext` to avoid orphaned timers/watchers. 
- Ensured sign-out from the Settings page runs a room reset via `resetRoomState()` in `src/views/Settings.vue` so logging out stops audio and clears runtime state consistently without erasing editor drafts on normal Settings navigation. 
- Did not change route-preservation behavior for editor drafts, and kept the change scoped to audio-runtime teardown rather than resetting editor/draft state on simple route changes.

### Testing
- Attempted a production build with `npm run build`, which failed due to a missing build dependency (`@sentry/vite-plugin`) in the environment and therefore a full build/test could not complete. 
- Performed static/logical inspection of affected flows and stores to verify `clearAudioRuntime()` is invoked on room load/local load/delete and that `AudioEngine.dispose()` now stops scheduler timers and clears watchers. 
- No automated unit/integration tests were available/runnable in this environment beyond the attempted build, so please re-run `npm run build` and your CI pipeline in your environment to validate and produce a green build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35954dea8832f91e2c2a2835fa6ed)